### PR TITLE
Issue #808 - Added update function to enable global redirect

### DIFF
--- a/ding2.info
+++ b/ding2.info
@@ -23,6 +23,7 @@ dependencies[] = module_filter
 dependencies[] = menu_position
 dependencies[] = cookiecontrol
 dependencies[] = view_unpublished
+dependencies[] = redirect
 
 ; Ding modules.
 dependencies[] = ding_base

--- a/ding2.install
+++ b/ding2.install
@@ -264,3 +264,10 @@ function ding2_update_7007() {
 function ding2_update_7008() {
   module_enable(array('view_unpublished'), TRUE);
 }
+
+/**
+ * Enable redirect module.
+ */
+function ding2_update_7009() {
+  module_enable(array('redirect'));
+}


### PR DESCRIPTION
Ensured that redirect module is enabled by default.

See http://platform.dandigbib.org/issues/808