### PR TITLE
Issue 484: Fix cookie control module for site names with UTF8 chars.

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -164,6 +164,8 @@ projects[cookiecontrol][subdir] = "contrib"
 projects[cookiecontrol][version] = "1.6"
 # https://drupal.org/node/2174955, fix translatable link.
 projects[cookiecontrol][patch][0] = "http://drupal.org/files/issues/translatable_link_title-2174955-1.patch"
+# https://www.drupal.org/node/2318997, fix cookie name with UTF-8 characters.
+projects[cookiecontrol][patch][1] = "https://www.drupal.org/files/issues/cookie-control-utf_8_characters_in-2318997-5.patch"
 
 # Using dev release, as the "stable" version is making errors in the install profile.
 projects[uuid][subdir] = "contrib"


### PR DESCRIPTION
Cookies with such characters are not supported in IE and other browsers.

Issue http://platform.dandigbib.org/issues/484