### PR TITLE
Support continuous integration using Circle CI

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "build"]
-	path = build
-	url = git@github.com:reload/phing-drupal-template.git

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Ding2 is a continuation of [ding.TING](http://ting.dk/content/om-dingting)
 [Drupal](http://drupal.org/project/drupal) distribution for libraries as part
 of the [TING concept](http://ting.dk).
 
+[![Circle CI](https://circleci.com/gh/ding2/ding2.svg?style=svg)](https://circleci.com/gh/ding2/ding2)
+
 # Installation
 This README assumes that you have install a configured your server with a
 working Apache/Nginx, APC, Memcached, PHP 5.4 and Varnish 3.x (optional). The

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
 
 dependencies:
   post:
+    # Increase memory limit to 512M. This is required by ding2.
+    - echo "memory_limit = 512M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
     # Install drush globally using composer.
     # Prefer source to get around GitHub API rate limits.
     - composer global require drush/drush:6.*  --prefer-source --no-interaction

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,15 @@
+machine:
+  php:
+    # We support PHP 5.4 so choose the latest version supported by Circle.
+    version: 5.4.37
+
+dependencies:
+  post:
+    # Install drush globally using composer.
+    # Prefer source to get around GitHub API rate limits.
+    - composer global require drush/drush:6.*  --prefer-source --no-interaction
+
+test:
+  override:
+    # Build profile using drush make
+    - drush make ding2.make --no-core --contrib-destination=. -y

--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ machine:
     version: 5.4.37
   environment:
     # This is where we build our complete Drupal site
-    DING_BUILD_PATH: /tmp/drupal
+    DRUPAL_SITE_PATH: /tmp/drupal
 
 dependencies:
   post:
@@ -16,15 +16,18 @@ test:
   override:
     # Build profile using drush make
     - drush make ding2.make --no-core --contrib-destination=. -y
-  post:
-    # Built an entire Drupal site with core, contrib and custom code and make
-    # it available as an artifact.
+    # Built an entire Drupal site with core, contrib and custom code
     # First we build Drupal core only. Instead of using the profile specified in
     # the make  file we use the one we have just build.
     # This way we do not have to update drupal.make for each build.
-    - drush make drupal.make --projects=drupal -y $DING_BUILD_PATH
+    - drush make drupal.make --projects=drupal -y $DRUPAL_SITE_PATH
     # Copy the current profile which has just been built into Drupal core
-    - mkdir $DING_BUILD_PATH/profiles/ding2
-    - cp -R ./* $DING_BUILD_PATH/profiles/ding2/
+    - mkdir $DRUPAL_SITE_PATH/profiles/ding2
+    - cp -R ./* $DRUPAL_SITE_PATH/profiles/ding2/
+    # Install the site using the ding2 profile
+    - (cd $DRUPAL_SITE_PATH && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test --locale=da -y)
+  post:
+    # Clean up after site install
+    - rm -rf $DRUPAL_SITE_PATH/sites/default
     # Wrap the site into an archieve and expose it as an artifact.
-    - tar -zcvf $CIRCLE_ARTIFACTS/ding2-$CIRCLE_SHA1.tar.gz -C $DING_BUILD_PATH .
+    - tar -zcvf $CIRCLE_ARTIFACTS/ding2-$CIRCLE_SHA1.tar.gz -C $DRUPAL_SITE_PATH .

--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,9 @@ machine:
   php:
     # We support PHP 5.4 so choose the latest version supported by Circle.
     version: 5.4.37
+  environment:
+    # This is where we build our complete Drupal site
+    DING_BUILD_PATH: /tmp/drupal
 
 dependencies:
   post:
@@ -13,3 +16,15 @@ test:
   override:
     # Build profile using drush make
     - drush make ding2.make --no-core --contrib-destination=. -y
+  post:
+    # Built an entire Drupal site with core, contrib and custom code and make
+    # it available as an artifact.
+    # First we build Drupal core only. Instead of using the profile specified in
+    # the make  file we use the one we have just build.
+    # This way we do not have to update drupal.make for each build.
+    - drush make drupal.make --projects=drupal -y $DING_BUILD_PATH
+    # Copy the current profile which has just been built into Drupal core
+    - mkdir $DING_BUILD_PATH/profiles/ding2
+    - cp -R ./* $DING_BUILD_PATH/profiles/ding2/
+    # Wrap the site into an archieve and expose it as an artifact.
+    - tar -zcvf $CIRCLE_ARTIFACTS/ding2-$CIRCLE_SHA1.tar.gz -C $DING_BUILD_PATH .

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,8 @@ dependencies:
   post:
     # Increase memory limit to 512M. This is required by ding2.
     - echo "memory_limit = 512M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
+    # Disable mail sending. Sendmail is not working on Circle.
+    - echo "sendmail_path = /bin/true" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
     # Install drush globally using composer.
     # Prefer source to get around GitHub API rate limits.
     - composer global require drush/drush:6.*  --prefer-source --no-interaction

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,8 @@ test:
     # Install the site using the ding2 profile
     - (cd $DRUPAL_SITE_PATH && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test -y)
   post:
-    # Clean up after site install
-    - rm -rf $DRUPAL_SITE_PATH/sites/default
+    # Clean up after site install.
+    # sudo is required here. The files are not writeable.
+    - sudo rm -rf $DRUPAL_SITE_PATH/sites/default/settings.php $DRUPAL_SITE_PATH/sites/default/files
     # Wrap the site into an archieve and expose it as an artifact.
     - tar -zcvf $CIRCLE_ARTIFACTS/ding2-$CIRCLE_SHA1.tar.gz -C $DRUPAL_SITE_PATH .

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ test:
     - mkdir $DRUPAL_SITE_PATH/profiles/ding2
     - cp -R ./* $DRUPAL_SITE_PATH/profiles/ding2/
     # Install the site using the ding2 profile
-    - (cd $DRUPAL_SITE_PATH && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test --locale=da -y)
+    - (cd $DRUPAL_SITE_PATH && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test -y)
   post:
     # Clean up after site install
     - rm -rf $DRUPAL_SITE_PATH/sites/default

--- a/circle.yml
+++ b/circle.yml
@@ -20,6 +20,13 @@ test:
   override:
     # Build profile using drush make
     - drush make ding2.make --no-core --contrib-destination=. -y
+    # Install theme dependencies
+    - (cd themes/ddbasic && npm install)
+    # Process theme files.
+    # If there are any changes then fail the build. The result of processing
+    # should be committed along with the source changes.
+    - (cd themes/ddbasic && node_modules/.bin/gulp uglify sass)
+    - git diff --exit-code
     # Built an entire Drupal site with core, contrib and custom code
     # First we build Drupal core only. Instead of using the profile specified in
     # the make  file we use the one we have just build.


### PR DESCRIPTION
This change adds support for continuous integration using Circle CI.

This includes:

- Running drush make
- Re(building) theme assets to check for uncommitted changes
- Doing a site install
- Creating an artifact containing the code base after each build 