### PR TITLE
Gulp help

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Gulp can watch your source files so they are processed on every change:
 
 ```sh
   ~$ cd DRUPAL/profiles/ding2/themes/ddbasic
-  ~$ gulp
+  ~$ gulp watch
 ```
 
 Note that developers changing the source JavaScript and SCSS files are also responsible for changing the processed files in their commits.

--- a/themes/ddbasic/gulpfile.js
+++ b/themes/ddbasic/gulpfile.js
@@ -1,4 +1,4 @@
-var gulp = require('gulp');
+var gulp = require('gulp-help')(require('gulp'));
 
 // Plugins.
 var gutil = require('gulp-util');
@@ -11,15 +11,13 @@ var sass = require('gulp-sass');
 var jsPath = './scripts/ddbasic.!(*.min).js';
 var sassPath = './sass/**/*.scss';
 
-// Run Javascript through JSHint.
-gulp.task('jshint', function() {
+gulp.task('jshint', 'Run Javascript through JSHint', function() {
   return gulp.src(jsPath)
     .pipe(jshint())
     .pipe(jshint.reporter('jshint-stylish'));
 });
 
-// Minify JavaScript using Uglify.
-gulp.task('uglify', function() {
+gulp.task('uglify', 'Minify JavaScript using Uglify', function() {
   gulp.src(jsPath)
     .pipe(uglify({
       // Preserve the $ variable name.
@@ -33,8 +31,7 @@ gulp.task('uglify', function() {
     .pipe(gulp.dest('./scripts'));
 });
 
-// Process SCSS using libsass
-gulp.task('sass', function () {
+gulp.task('sass', 'Process SCSS using libsass', function () {
   gulp.src(sassPath)
     .pipe(sass({
       outputStyle: 'compressed',
@@ -47,7 +44,7 @@ gulp.task('sass', function () {
     .pipe(gulp.dest('./css'));
 });
 
-gulp.task('watch', function() {
+gulp.task('watch', 'Watch and process JS and SCSS files', function() {
   gulp.watch(jsPath, ['jshint', 'uglify']);
   gulp.watch(sassPath, ['sass']);
 });

--- a/themes/ddbasic/gulpfile.js
+++ b/themes/ddbasic/gulpfile.js
@@ -11,42 +11,50 @@ var sass = require('gulp-sass');
 var jsPath = './scripts/ddbasic.!(*.min).js';
 var sassPath = './sass/**/*.scss';
 
-gulp.task('jshint', 'Run Javascript through JSHint', function() {
-  return gulp.src(jsPath)
-    .pipe(jshint())
-    .pipe(jshint.reporter('jshint-stylish'));
-});
+gulp.task('jshint', 'Run Javascript through JSHint',
+  function() {
+    return gulp.src(jsPath)
+      .pipe(jshint())
+      .pipe(jshint.reporter('jshint-stylish'));
+  }
+);
 
-gulp.task('uglify', 'Minify JavaScript using Uglify', function() {
-  gulp.src(jsPath)
-    .pipe(uglify({
-      // Preserve the $ variable name.
-      mangle: { except: ['$'] }
-    }).on('error', gutil.log))
-    // Use gulp-rename to change the name of processed files.
-    // We keep them in the same folder as the originals.
-    .pipe(rename(function (path) {
-      path.extname = '.min.js'
-    }))
-    .pipe(gulp.dest('./scripts'));
-});
+gulp.task('uglify', 'Minify JavaScript using Uglify',
+  function() {
+    gulp.src(jsPath)
+      .pipe(uglify({
+        // Preserve the $ variable name.
+        mangle: { except: ['$'] }
+      }).on('error', gutil.log))
+      // Use gulp-rename to change the name of processed files.
+      // We keep them in the same folder as the originals.
+      .pipe(rename(function (path) {
+        path.extname = '.min.js'
+      }))
+      .pipe(gulp.dest('./scripts'));
+  }
+);
 
-gulp.task('sass', 'Process SCSS using libsass', function () {
-  gulp.src(sassPath)
-    .pipe(sass({
-      outputStyle: 'compressed',
-      includePaths: [
-        'node_modules/compass-mixins/lib',
-        // Zen grids is downloaded as a library using drush make.
-        '../../libraries/zen-grids/stylesheets'
-      ]
-    }).on('error', sass.logError))
-    .pipe(gulp.dest('./css'));
-});
+gulp.task('sass', 'Process SCSS using libsass',
+  function () {
+    gulp.src(sassPath)
+      .pipe(sass({
+        outputStyle: 'compressed',
+        includePaths: [
+          'node_modules/compass-mixins/lib',
+          // Zen grids is downloaded as a library using drush make.
+          '../../libraries/zen-grids/stylesheets'
+        ]
+      }).on('error', sass.logError))
+      .pipe(gulp.dest('./css'));
+  }
+);
 
-gulp.task('watch', 'Watch and process JS and SCSS files', function() {
-  gulp.watch(jsPath, ['jshint', 'uglify']);
-  gulp.watch(sassPath, ['sass']);
-});
+gulp.task('watch', 'Watch and process JS and SCSS files', ['uglify', 'sass'],
+  function() {
+    gulp.watch(jsPath, ['jshint', 'uglify']);
+    gulp.watch(sassPath, ['sass']);
+  }
+);
 
-gulp.task('default', ['uglify', 'sass', 'watch']);
+gulp.task('default', ['help']);

--- a/themes/ddbasic/package.json
+++ b/themes/ddbasic/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "compass-mixins": "^0.12.7",
     "gulp": "^3.9.0",
+    "gulp-help": "^1.6.1",
     "gulp-jshint": "^1.11.2",
     "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.4",


### PR DESCRIPTION
This change adds [`gulp-help`](https://www.npmjs.com/package/gulp-help) to make using gulp a little bit more developer friendly. This shows a list of available tasks.

I suggest that `help` becomes the default task instead of `watch`.

![1 bash 2015-10-29 10-50-17](https://cloud.githubusercontent.com/assets/73966/10815228/02ac6e8e-7e2b-11e5-84cb-f976e6ade213.png)
