### PR TITLE
Fix drush install on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,9 +12,13 @@ dependencies:
     - echo "memory_limit = 512M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
     # Disable mail sending. Sendmail is not working on Circle.
     - echo "sendmail_path = /bin/true" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
+    # Clean up existing global composer installation. It contains dependencies
+    # which do not match the PHP version we use. This prevents installation of
+    # other packages.
+    - rm -rf ~/.composer
     # Install drush globally using composer.
-    # Prefer source to get around GitHub API rate limits.
-    - composer global require drush/drush:6.*  --prefer-source --no-interaction
+    # Use prefer-source to get around GitHub API rate limits.
+    - composer global require drush/drush:6.* --prefer-source --no-interaction
 
 test:
   override:


### PR DESCRIPTION
The Circle image comes preinstalled with a range of dependencies. `zendframework/zend-stdlib` requires PHP 5.5 and we use 5.4 on Circle. This makes the build fail when we try to install drush.