### PR TITLE
Issue #1321 by holt83: Fix "Connection reset by peer" and missing leading slash from ban URL

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -319,6 +319,10 @@ projects[variable][version] = "2.5"
 projects[varnish][subdir] = "contrib"
 projects[varnish][version] = "1.0-beta3"
 projects[varnish][patch][0] = "http://drupal.org/files/issues/notification_level_settings-2169271-3.patch"
+; Fixes "Connection reset by peer" on large purge list by batching paths, https://www.drupal.org/node/1481136
+projects[varnish][patch][] = "https://www.drupal.org/files/issues/varnish_purge_limit-1481136-11_1.patch"
+; Fixes missing leading slash from ban URLs, https://www.drupal.org/node/2340829
+projects[varnish][patch][] = "https://www.drupal.org/files/issues/varnish-leave_base_path_in_urls-2340829-26.patch"
 
 projects[virtual_field][subdir] = "contrib"
 projects[virtual_field][version] = "1.2"


### PR DESCRIPTION
Adds 2 patches to Varnish module:

http://platform.dandigbib.org/issues/1321