### PR TITLE
Issue #1540 by xendk: Don't log username of failed logins.

### DIFF
--- a/modules/ding_user/ding_user.install
+++ b/modules/ding_user/ding_user.install
@@ -102,3 +102,15 @@ function ding_user_update_7006(&$sandbox) {
     }
   }
 }
+
+/**
+ * Remove logged login attempt failures.
+ */
+function ding_user_update_7007(&$sandbox) {
+  if (module_exists('dblog')) {
+    db_delete('watchdog')
+      ->condition('type', 'user')
+      ->condition('message', 'Login attempt failed for%', 'LIKE')
+      ->execute();
+  }
+}

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -578,7 +578,12 @@ function ding_user_user_login_validate($form, &$form_state) {
       // If we reach this code the login have failed and we always want to
       // display this message.
       form_set_error('name', t('Sorry, unrecognized username or password. Please contact your local library to request a new password. Contact information can be found on the <a href="@url">library</a> page.', array('@url' => url('biblioteker'))));
-      watchdog('user', 'Login attempt failed for %user.', array('%user' => $form_state['values']['name']));
+      // Obfuscate the user name. We just set the form value to the obfuscated
+      // version as user.module will log the failure with the name from the
+      // form. If the provider defines its own authnames, this wont match the
+      // username that the user would have, but we can't expect the provider
+      // to supply it for invalid logins.
+      form_set_value($form['name'], ding_user_default_authname($form_state['values']['name']), $form_state);
     }
   }
   catch (DingProviderException $exception) {


### PR DESCRIPTION
As a bonus, it deletes previous logged failed attempts.