### PR TITLE
Fail Scrutinizer build for new issues

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -12,6 +12,10 @@ tools:
   js_hint:
     use_native_config: true
 
+build_failure_conditions:
+  # No new issues allowed.
+  - 'issues.new.exists'
+
 filter:
     excluded_paths:
         - modules/fbs/prancer/*


### PR DESCRIPTION
Currently is it easy to miss if a pull request introduces new issues. This change makes the Scrunitizer build fail which should be more visible. It is still possible to merge the pull request regardless of build failures.

![ding2 2015-12-11 11-57-28](https://cloud.githubusercontent.com/assets/73966/11742582/5ff3c180-a001-11e5-93e0-6518cabd68a1.png)
