### PR TITLE
Issue #1342 by holt83: Fix naming of Ting oEmbed module

### DIFF
--- a/modules/ting_oembed/ting_oembed.info
+++ b/modules/ting_oembed/ting_oembed.info
@@ -1,5 +1,5 @@
-name = Add oEmbed support to Ting objects
-description = Use oEmbed module to add oEmbed support for displaying Ting objects
+name = Ting oEmbed
+description = Adds oEmbed support for displaying Ting objects
 package = Ding!
 core = 7.x
 version = 7.x-1.x


### PR DESCRIPTION
The naming of the oEmbed module in the .info file, makes it hard to find in module lists:

http://platform.dandigbib.org/issues/1342
