### PR TITLE
Exclude generated Features code from Scrutinizer

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -28,11 +28,15 @@ filter:
         - '*.panelizer.inc'
         - '*.strongarm.inc'
         - '*.views_default.inc'
+        # Generated webservice client code for FBS
         - modules/fbs/prancer/*
+        # Third party dependencies for FBS
         - modules/fbs/vendor/*
+        # Third party JavaScript libraries
         - themes/ddbasic/scripts/equalize.min.js
         - themes/ddbasic/scripts/html5shiv.js
         - themes/ddbasic/scripts/jquery.*
         - themes/ddbasic/scripts/respond.*
         - themes/ddbasic/scripts/scalefix.js
+        # Minified JavaScript files
         - themes/ddbasic/scripts/*.min.js

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -18,6 +18,16 @@ build_failure_conditions:
 
 filter:
     excluded_paths:
+        # Generated Features code
+        - '*.features.*'
+        - '*.feeds_importer_default.inc'
+        - '*.field_group.inc'
+        - '*.layouts.inc'
+        - '*.pages_default.inc'
+        - '*.panels_default.inc'
+        - '*.panelizer.inc'
+        - '*.strongarm.inc'
+        - '*.views_default.inc'
         - modules/fbs/prancer/*
         - modules/fbs/vendor/*
         - themes/ddbasic/scripts/equalize.min.js


### PR DESCRIPTION
Generated code does not comply with our coding standards and causes the
build to fail. It is not feasible for us to fix this so we exclude it
instead.