### PR TITLE
Issue #1609 by xendk: Properly return false with zero cache lifetime

### DIFF
--- a/modules/ting/ting.client.inc
+++ b/modules/ting/ting.client.inc
@@ -485,8 +485,8 @@ function ting_cache_get($id, $type = TING_CACHE_TING_OBJECT, $with_relations = F
       // about this object and no where found.
       return $data;
     }
-    return FALSE;
   }
+  return FALSE;
 }
 
 /**


### PR DESCRIPTION
If setting ting_cache_liftetime to zero for development, everything
breaks. Ting object pages are rendered, but the data is missing.

Somewhere someone is checking that ting_cache_get() returns '=== FALSE',
or something like that, and it happens to not return anything if the
lifetime is 0.

Simple fix.