### PR TITLE
Issue #1610 by xendk: Make CTools argument return the proper object type

### DIFF
--- a/modules/ting/plugins/arguments/ting_object_id.inc
+++ b/modules/ting/plugins/arguments/ting_object_id.inc
@@ -27,8 +27,8 @@ function ting_tasks_ting_object_id_context($arg = NULL, $conf = NULL, $empty = F
     return FALSE;
   }
   module_load_include('client.inc', 'ting');
-  $object = ting_get_object($arg);
-  if (!($object instanceOf TingClientObject)) {
+  $object = ding_entity_load($arg, 'ting_object');
+  if (!$object) {
     return FALSE;
   }
 


### PR DESCRIPTION
The CTools argument handler returns a TingClientObject rather than the
expected TingEntity.

This makes it rather useless as contexts expect the latter.