### PR TITLE
Issue 773 by Pjohans: Disable custom alias settings

### DIFF
--- a/modules/ding_library/ding_library.js
+++ b/modules/ding_library/ding_library.js
@@ -1,0 +1,13 @@
+(function ($) {
+    Drupal.behaviors.pathAutoDisable = {
+        attach: function (context) {
+            // fake a disabled checkbox
+            var check = $('#edit-path-pathauto');
+            check.attr('checked', 'checked');
+            check.css('opacity','0.5');
+            check.change(function(context){
+                check.attr('checked', 'checked');
+            })
+        }
+    }
+})(jQuery);

--- a/modules/ding_library/ding_library.js
+++ b/modules/ding_library/ding_library.js
@@ -1,13 +1,14 @@
 (function ($) {
-    Drupal.behaviors.pathAutoDisable = {
-        attach: function (context) {
-            // fake a disabled checkbox
-            var check = $('#edit-path-pathauto');
-            check.attr('checked', 'checked');
-            check.css('opacity','0.5');
-            check.change(function(context){
-                check.attr('checked', 'checked');
-            })
-        }
+  "use strict";
+  Drupal.behaviors.pathAutoDisable = {
+    attach: function () {
+      // fake a disabled checkbox
+      var check = $('#edit-path-pathauto');
+      check.attr('checked', 'checked');
+      check.css('opacity', '0.5');
+      check.change(function () {
+        check.attr('checked', 'checked');
+      });
     }
+  };
 })(jQuery);

--- a/modules/ding_library/ding_library.module
+++ b/modules/ding_library/ding_library.module
@@ -207,8 +207,7 @@ function ding_library_form_ding_library_node_form_alter(&$form, &$form_state) {
 function ding_library_disable_custom_alias($form, &$form_state) {
   if (isset($form['path']['pathauto'])) {
     $form['path']['pathauto']['#description'] = t('Custom alias has been disabled');
-    $form['path']['pathauto']['#attached']['js'][] =
-      drupal_get_path('module', 'ding_library') . '/ding_library.js';
+    $form['path']['pathauto']['#attached']['js'][] = drupal_get_path('module', 'ding_library') . '/ding_library.js';
 
     unset($form['path']['alias']);
   }

--- a/modules/ding_library/ding_library.module
+++ b/modules/ding_library/ding_library.module
@@ -191,7 +191,7 @@ function ding_library_ctools_plugin_directory($owner, $plugin_type) {
  * Implements hook_form_FORM_ID_alter().
  */
 function ding_library_form_ding_library_node_form_alter(&$form, &$form_state) {
-  $form['#after_build'][] = 'ding_library_remove_path_auto';
+  $form['#after_build'][] = 'ding_library_disable_custom_alias';
 
   if (isset($form['field_ding_library_slug'][$form['#node']->language])) {
     $form['field_ding_library_slug'][$form['#node']->language][0]['#element_validate'][] = 'ding_library_slug_validate';
@@ -202,10 +202,16 @@ function ding_library_form_ding_library_node_form_alter(&$form, &$form_state) {
 }
 
 /**
- * After build method. Take out path auto option for ding libraries
+ * After build method. Add javascript to simulate disabled checkbox
  */
-function ding_library_remove_path_auto($form, &$form_state) {
-  $form['path']['#access'] = FALSE;
+function ding_library_disable_custom_alias($form, &$form_state) {
+  if (isset($form['path']['pathauto'])) {
+    $form['path']['pathauto']['#description'] = t('Custom alias has been disabled');
+    $form['path']['pathauto']['#attached']['js'][] =
+      drupal_get_path('module', 'ding_library') . '/ding_library.js';
+
+    unset($form['path']['alias']);
+  }
   return $form;
 }
 


### PR DESCRIPTION
This is a bit hacky. I tried to disable the custom alias checkbox, but that caused path auto functionality to fail (path became node/id instead of bibliotek/name). This solution simulates a disabled checkbox with a javascript.