### PR TITLE
Fix Drush installation on Circle CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -18,7 +18,7 @@ dependencies:
     # Clean up existing global composer installation. It contains dependencies
     # which do not match the PHP version we use. This prevents installation of
     # other packages.
-    - rm -rf ~/.composer
+    - rm -rf ~/.composer/vendor
     # Install drush globally using composer.
     # Use prefer-source to get around GitHub API rate limits.
     - composer global require drush/drush:6.* --prefer-source --no-interaction


### PR DESCRIPTION
We only need to delete the vendor folder to remove preexisting
dependencies. Deleting the entire folder causes Composer to install in
~/.config/composer and ~/.config/composer/vendor/bin is outside the
project path.

This causes subsequent calls to drush to fail.