### PR TITLE
#659: Fixes for Gatewayf

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -334,3 +334,10 @@ function ding2_update_7015() {
 function ding2_update_7016() {
   ding2_translation_update();
 }
+
+/**
+ * Update our own translations.
+ */
+function ding2_update_7017() {
+  ding2_translation_update();
+}

--- a/modules/alma/includes/alma.wayf.inc
+++ b/modules/alma/includes/alma.wayf.inc
@@ -22,7 +22,7 @@ function alma_wayf_login_credentials($attributes) {
   }
   else {
     // Set message that hash value was not found.
-    watchdog('alma', 'The WAYF hash value has not been set in setting.php as $conf[\'wayf_hash\'] and WAYF login will fail.', WATCHDOG_ERROR);
+    watchdog('alma', 'The WAYF hash value has not been set in setting.php as $conf[\'wayf_hash\'] and WAYF login will fail.', array(), WATCHDOG_ERROR);
   }
 
   return $credentials;

--- a/modules/alma/lib/AlmaClient/AlmaClient.class.php
+++ b/modules/alma/lib/AlmaClient/AlmaClient.class.php
@@ -1015,7 +1015,10 @@ class AlmaClient {
       'email' => $mail,
       'branch' => $branch,
       'addr1' => '+++',
-      'verified' => TRUE,
+      // Verified has to be set to the string value true
+      // for this to work. Booleans are converted to integers
+      // and they are no good.
+      'verified' => 'true',
       'locale' => 'da_DK'
     );
 

--- a/modules/alma/lib/AlmaClient/AlmaClient.class.php
+++ b/modules/alma/lib/AlmaClient/AlmaClient.class.php
@@ -128,6 +128,9 @@ class AlmaClient {
       'pinCodeChange',
       'address',
       'emailAddress',
+      'securityNumber',
+      'pin',
+      'email',
     );
 
     $log_params = array();

--- a/modules/ding_gatewayf/ding_gatewayf.module
+++ b/modules/ding_gatewayf/ding_gatewayf.module
@@ -169,14 +169,15 @@ function ding_gatewayf_login() {
 function ding_gatewayf_logout() {
   $config = _ding_gatewayf_load_configuration();
 
-  // Ensure gatewayf attributes store in the session is removed.
-  unset($_SESSION[DING_GATEWAYF_ATTRIBUTES]);
+  // Remove indication of WAYF login.
+  unset($_SESSION[DING_GATEWAYF_IS_LOGGED_IN]);
 
-  // Get the sites base url, which is used to redirect the user after logout.
-  global $base_url;
+  // Get the logout url for the site, which is used to redirect the user after
+  // logout. This ensures that the logout process is completed.
+  $logout_url = url('user/logout', array('absolute' => TRUE));
 
   // Redirect to the gateway.
-  header('Location:' . $config['service']['endpoint'] . '?returnUrl=' . $base_url . '&op=logout');
+  header('Location:' . $config['service']['endpoint'] . '?op=logout&returnUrl=' . $logout_url);
 
   drupal_exit();
 }

--- a/modules/ding_gatewayf/ding_gatewayf.module
+++ b/modules/ding_gatewayf/ding_gatewayf.module
@@ -195,7 +195,7 @@ function ding_gatewayf_logout() {
 /**
  * Handle callback from the gatewayf service.
  *
- * This handles all callbacks from the service both after login and logout.
+ * This handles all callbacks from the service after login.
  */
 function ding_gatewayf_callback() {
   // Check error callback.
@@ -210,45 +210,33 @@ function ding_gatewayf_callback() {
     $_REQUEST['destination'] = substr($_REQUEST['destination'], 0, strpos($_REQUEST['destination'], '?'));
   }
 
-  // Check if the is an login or logout request.
-  if (!_ding_gatewayf_is_logged_in_with_gatewayf()) {
-    $attributes = $_POST;
+  $attributes = $_POST;
 
-    // Check if the login was successful and the users information was returned.
-    if (!empty($attributes['schacPersonalUniqueID'])) {
-      $config = _ding_gatewayf_load_configuration();
+  // Check if the login was successful and the users information was returned.
+  if (!empty($attributes['schacPersonalUniqueID'])) {
+    $config = _ding_gatewayf_load_configuration();
 
-      if ($config['development']['log_auth_data']) {
-        watchdog('ding_gatewayf', 'Authentication data: %data', array('%data' => var_export($_POST, TRUE)), WATCHDOG_DEBUG);
-      }
-
-      // Set flag in session that we are logged in via gateway. It's not
-      // prefixed with gatewayf, but just wayf so it can be used by all wayf
-      // modules to indicate that the user was logged in via wayf. This could
-      // then be used to change behaviour in forgotten pin-code in the user
-      // profile (not requiring old password when logged in with wayf).
-      $_SESSION[DING_GATEWAYF_IS_LOGGED_IN] = TRUE;
-
-      // Log into the library system and Drupal.
-      _ding_gatewayf_provider_login($attributes);
+    if ($config['development']['log_auth_data']) {
+      watchdog('ding_gatewayf', 'Authentication data: %data', array('%data' => var_export($_POST, TRUE)), WATCHDOG_DEBUG);
     }
-    else {
-      watchdog('ding_gatewayf', 'The gateway returned no error and no schacPersonalUniqueID', array(), WATCHDOG_ERROR);
 
-      // Set message to the user.
-      drupal_set_message(t('The login with nem-login failed please try again later.'), 'error');
+    // Set flag in session that we are logged in via gateway. It's not
+    // prefixed with gatewayf, but just wayf so it can be used by all wayf
+    // modules to indicate that the user was logged in via wayf. This could
+    // then be used to change behaviour in forgotten pin-code in the user
+    // profile (not requiring old password when logged in with wayf).
+    $_SESSION[DING_GATEWAYF_IS_LOGGED_IN] = TRUE;
 
-      _ding_gatewayf_redirect_user('<front>');
-    }
+    // Log into the library system and Drupal.
+    _ding_gatewayf_provider_login($attributes);
   }
   else {
-    // Log the user out of drupal an clear session.
-    unset($_SESSION[DING_GATEWAYF_IS_LOGGED_IN]);
+    watchdog('ding_gatewayf', 'The gateway returned no error and no schacPersonalUniqueID', array(), WATCHDOG_ERROR);
 
-    // The gatewayf logout service does not return any information about the
-    // success of the logout request, so the only thing we can do is redirect to
-    // drupal logout.
-    _ding_gatewayf_redirect_user('user/logout');
+    // Set message to the user.
+    drupal_set_message(t('The login with nem-login failed please try again later.'), 'error');
+
+    _ding_gatewayf_redirect_user('<front>');
   }
 }
 

--- a/modules/ding_gatewayf/ding_gatewayf.module
+++ b/modules/ding_gatewayf/ding_gatewayf.module
@@ -304,7 +304,7 @@ function _ding_gatewayf_provider_login(array $attributes) {
           // this is the only way to get the information from login callback to
           // the acceptance form.
           if (_ding_gatewayf_registration_is_registration_request()) {
-            $_SESSION[DING_GATEWAYF_ATTRIBUTES] = $required_attr;
+            $_SESSION[DING_GATEWAYF_ATTRIBUTES] = $attributes;
           }
           else {
             // Display message that the user don't have an account an then can

--- a/modules/ding_gatewayf/ding_gatewayf.module
+++ b/modules/ding_gatewayf/ding_gatewayf.module
@@ -174,7 +174,7 @@ function ding_gatewayf_logout() {
     unset($_SESSION[DING_GATEWAYF_IS_LOGGED_IN]);
   }
 
-  drupal_set_message('You are now logged out of WAYF');
+  drupal_set_message(t('You are now logged out of WAYF.'));
 
   // Get the logout url for the site, which is used to redirect the user after
   // logout. This needs to handle two cases:

--- a/modules/ding_gatewayf/ding_gatewayf.module
+++ b/modules/ding_gatewayf/ding_gatewayf.module
@@ -50,7 +50,7 @@ function ding_gatewayf_menu() {
   // Redirect the user to gatewayf for logout.
   $items[DING_GATEWAYF_LOGOUT_URL] = array(
     'page callback' => 'ding_gatewayf_logout',
-    'access callback' => 'ding_gatewayf_logout_access_check',
+    'access callback' => TRUE,
     'type' => MENU_CALLBACK,
   );
 
@@ -170,14 +170,24 @@ function ding_gatewayf_logout() {
   $config = _ding_gatewayf_load_configuration();
 
   // Remove indication of WAYF login.
-  unset($_SESSION[DING_GATEWAYF_IS_LOGGED_IN]);
+  if (!empty($_SESSION[DING_GATEWAYF_IS_LOGGED_IN])) {
+    unset($_SESSION[DING_GATEWAYF_IS_LOGGED_IN]);
+  }
+
+  drupal_set_message('You are now logged out of WAYF');
 
   // Get the logout url for the site, which is used to redirect the user after
-  // logout. This ensures that the logout process is completed.
-  $logout_url = url('user/logout', array('absolute' => TRUE));
+  // logout. This needs to handle two cases:
+  // - If the Drupal user is logged in then return to the Drupal logout path
+  //   This ensures that the logout process is completed even if this function
+  //   is not the last to complete
+  // - If no Drupal user is logged in and we still want to log the user out
+  //   then we just return to the frontpage.
+  $return_path = (!user_is_anonymous()) ? 'user/logout' : '<front>';
+  $return_url = url($return_path, array('absolute' => TRUE));
 
-  // Redirect to the gateway.
-  header('Location:' . $config['service']['endpoint'] . '?op=logout&returnUrl=' . $logout_url);
+  // Redirect to the gateway to perform the actual logout.
+  header('Location:' . $config['service']['endpoint'] . '?op=logout&returnUrl=' . $return_url);
 
   drupal_exit();
 }

--- a/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
+++ b/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
@@ -307,6 +307,7 @@ function ding_gatewayf_registration_acceptance_form() {
     '#description' => t('Pin code with an max length of %length', array('%length' => ding_user_get_pincode_length())),
     '#maxlength' => ding_user_get_pincode_length(),
     '#required' => TRUE,
+    '#element_validate' => array('ding_user_element_validate_pincode'),
     '#attributes' => array(
       'autocomplete' => 'off',
     ),

--- a/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
+++ b/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
@@ -336,7 +336,14 @@ function ding_gatewayf_registration_acceptance_form_submit($form, $form_state) {
 
   // This value was not store in the form to ensure that the user can reload the
   // form.
-  $required_attributes = $_SESSION[DING_GATEWAYF_ATTRIBUTES];
+  $required_attributes = array(
+    'schacPersonalUniqueID' => array(
+      'field' => 'CPR',
+      'authname' => TRUE,
+    ),
+  );
+  $wayf_attributes = $_SESSION[DING_GATEWAYF_ATTRIBUTES];
+  $required_attributes = _ding_gatewayf_get_required_attributes($wayf_attributes, $required_attributes);
   unset($_SESSION[DING_GATEWAYF_ATTRIBUTES]);
 
   // Check that the logged in user is over the age limit.
@@ -355,7 +362,7 @@ function ding_gatewayf_registration_acceptance_form_submit($form, $form_state) {
     ding_provider_invoke('user', 'create', $required_attributes['schacPersonalUniqueID'], $values['pin'], $values['name'], $values['mail'], $values['branch']);
 
     $_REQUEST['destination'] = DING_GATEWAYF_REGISTRATION_SUCCESS_URL;
-    _ding_gatewayf_provider_login($required_attributes);
+    _ding_gatewayf_provider_login($wayf_attributes);
 
     // Clean out message from the login form. Provider do not always allow login
     // at once, so the login attempt above may fail. But we have tried.
@@ -366,7 +373,7 @@ function ding_gatewayf_registration_acceptance_form_submit($form, $form_state) {
     //         exists is provider "named", hence for now we capture all
     //         exceptions. This should be fixed with FBS.
     drupal_set_message(t('You already have an user account at the library. So we have just logged you in.'));
-    _ding_gatewayf_provider_login($required_attributes);
+    _ding_gatewayf_provider_login($wayf_attributes);
   }
 }
 

--- a/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
+++ b/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
@@ -158,8 +158,8 @@ function ding_gatewayf_registration_form_ding_gatewayf_admin_settings_form_alter
   $form['ding_gatewayf_registration']['information']['content'] = array(
     '#type' => 'text_format',
     '#title' => t('Content'),
-    '#default_value' => $defaults['information']['content'],
-    '#format' => 'ding_wysiwyg',
+    '#default_value' => $defaults['information']['content']['value'],
+    '#format' => $defaults['information']['content']['format'],
   );
 
   $form['ding_gatewayf_registration']['information']['link'] = array(
@@ -182,8 +182,8 @@ function ding_gatewayf_registration_form_ding_gatewayf_admin_settings_form_alter
     '#type' => 'text_format',
     '#title' => t('Acceptance text'),
     '#description' => t('Description displayed next to the user acceptance check box.'),
-    '#default_value' => $defaults['acceptance']['description'],
-    '#format' => 'ding_wysiwyg',
+    '#default_value' => $defaults['acceptance']['description']['value'],
+    '#format' => $defaults['acceptance']['description']['format'],
   );
 
   // Define after create info page.
@@ -205,8 +205,8 @@ function ding_gatewayf_registration_form_ding_gatewayf_admin_settings_form_alter
   $form['ding_gatewayf_registration']['success']['content'] = array(
     '#type' => 'text_format',
     '#title' => t('Content'),
-    '#default_value' => $defaults['success']['content'],
-    '#format' => 'ding_wysiwyg',
+    '#default_value' => $defaults['success']['content']['value'],
+    '#format' => $defaults['success']['content']['format'],
   );
 }
 
@@ -225,7 +225,7 @@ function ding_gatewayf_registration_information() {
   return array(
     '#theme' => 'ding_gatewayf_registration_information',
     '#title' => $config['information']['title'],
-    '#content' => $config['information']['content'],
+    '#content' => $config['information']['content']['value'],
     '#link' => array(
       '#theme' => 'link',
       '#text' => $config['information']['link'],
@@ -265,7 +265,7 @@ function ding_gatewayf_registration_acceptance_form() {
   $form['accept'] = array(
     '#type' => 'checkbox',
     '#title' => t('I accept the user agreements'),
-    '#description' => $config['acceptance']['description'],
+    '#description' => $config['acceptance']['description']['value'],
     '#required' => TRUE,
   );
 
@@ -382,7 +382,7 @@ function ding_gatewayf_registration_success() {
   return array(
     '#theme' => 'ding_gatewayf_registration_success_page',
     '#title' => $config['success']['title'],
-    '#content' => $config['success']['content'],
+    '#content' => $config['success']['content']['value'],
   );
 }
 
@@ -462,15 +462,24 @@ function _ding_gatewayf_registration_load_config() {
     'age_limit' => 18,
     'information' => array(
       'title' => t('Self registration'),
-      'content' => t("Please read the library's regulations for usage before you use self registration."),
+      'content' => array(
+        'value' => t("Please read the library's regulations for usage before you use self registration."),
+        'format' => 'ding_wysiwyg',
+      ),
       'link' => t('Start self registration'),
     ),
     'acceptance' => array(
-      'description' => t("I accept the library's regulations and rules."),
+      'description' => array(
+        'value' => t("I accept the library's regulations and rules."),
+        'format' => 'ding_wysiwyg',
+      ),
     ),
     'success' => array(
       'title' => t('Success'),
-      'content' => t('You have been registered at the library as an user.'),
+      'content' => array(
+        'value' => t('You have been registered at the library as an user.'),
+        'format' => 'ding_wysiwyg',
+      ),
     ),
   );
 }

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -250,6 +250,15 @@ function ding_user_get_pincode_length() {
 }
 
 /**
+ * Form element validation handler for pincode elements.
+ */
+function ding_user_element_validate_pincode($element, &$form_state, $form) {
+  if (!preg_match('/^\d{' . ding_user_get_pincode_length() . '}$/', $element['#value'])) {
+    form_error($element, t('The pincode must consist of exactly %number digits.', array('%number' => ding_user_get_pincode_length())));
+  }
+}
+
+/**
  * Implements hook_form_FORM_ID_alter().
  *
  * Add pin-code fields to the provider profile(s), so the users can change their

--- a/translations/da.po
+++ b/translations/da.po
@@ -48358,5 +48358,5 @@ msgstr "Dit fulde navn"
 msgid "Select an interest period."
 msgstr "Vælg en interesseperiode"
 
-msgid "You are now logged out of WAYF"
-msgstr "Du er nu logget ud af NemID"
+msgid "You are now logged out of WAYF."
+msgstr "Du er nu logget ud af NemID."

--- a/translations/da.po
+++ b/translations/da.po
@@ -48348,7 +48348,7 @@ msgstr "NemID logo"
 
 #: /gatewayf/callback?destination=ding_frontpage?eduPersonTargetedID=WAYF-DK-e767c06edaad0f8d23e785bbc470e7f37ad03e8d&mail=&logintype=nemlogin
 msgid "click here"
-msgstr "Klik her"
+msgstr "klikke her"
 
 #: /gatewayf/registration/acceptance
 msgid "Your full name."

--- a/translations/da.po
+++ b/translations/da.po
@@ -48360,3 +48360,6 @@ msgstr "Vælg en interesseperiode"
 
 msgid "You are now logged out of WAYF."
 msgstr "Du er nu logget ud af NemID."
+
+msgid "The pincode must consist of exactly %number digits."
+msgstr "Pinkoden skal bestå af %number cifre."


### PR DESCRIPTION
This pull request fixes a range of issues with the Gatewayf Implementation:

- The verified flag should be set to "true" instead of TRUE which is converted to 1.
- Retrieval of texts should conform to the value format of `text_format` field types
- Prevent watchdog from crashing when hash is not set
- Fix juggling of WAYF attributes during registration
- Prevent CPR, PIN and email address from being logged during self registration