### PR TITLE
659: Update translations

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -341,3 +341,10 @@ function ding2_update_7016() {
 function ding2_update_7017() {
   ding2_translation_update();
 }
+
+/**
+ * Update our own translations.
+ */
+function ding2_update_7018() {
+  ding2_translation_update();
+}

--- a/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
+++ b/modules/ding_gatewayf/modules/ding_gatewayf_registration/ding_gatewayf_registration.module
@@ -134,7 +134,7 @@ function ding_gatewayf_registration_form_ding_gatewayf_admin_settings_form_alter
   $form['ding_gatewayf_registration']['age_limit'] = array(
     '#type' => 'textfield',
     '#title' => t('Age limit'),
-    '#description' => t('The age limit will be used to ensure that no user is created without begin above the limit. If left empty no age limit is enforced.'),
+    '#description' => t('The age limit will be used to ensure that no user is created without being above the limit. If left empty no age limit is enforced.'),
     '#default_value' => $defaults['age_limit'],
     '#element_validate' => array('element_validate_integer_positive'),
   );

--- a/translations/da.po
+++ b/translations/da.po
@@ -48252,7 +48252,7 @@ msgstr "Opret bruger"
 
 #: /gatewayf/callback?destination=ding_frontpage?eduPersonTargetedID=WAYF-DK-e767c06edaad0f8d23e785bbc470e7f37ad03e8d&mail=&logintype=nemlogin
 msgid "You do not have an user account at the public library. If you wish to create an user account !user_url . You are still logged in at WAYF, so you can !logout to logout of WAYF."
-msgstr "<p>Du er ikke låner ved ved biblioteket. Hvis du ønsker at oprette dig som låner kan du !user_url.</p>\r\n <p>Du er stadig logget ind ved NemID, så du kan !logout for at logge ud.</p>"
+msgstr "<p>Du er ikke låner ved biblioteket. Hvis du ønsker at oprette dig som låner kan du !user_url.</p>\r\n <p>Du er stadig logget ind ved NemID, så du kan !logout for at logge ud.</p>"
 
 #: /search/ting/+.net
 msgid "Best match on title"
@@ -48363,3 +48363,6 @@ msgstr "Du er nu logget ud af NemID."
 
 msgid "The pincode must consist of exactly %number digits."
 msgstr "Pinkoden skal bestå af %number cifre."
+
+msgid "You are not allowed to automatically be created because of the age limit (!limit years). Please go to your local library to registry."
+msgstr "Du kan ikke oprette dig som bruger via NemID på grund af aldersbegrænsningen (!limit år). Du kan blive oprettet som bruger ved personlig henvendelse på biblioteket."


### PR DESCRIPTION
- Add missing translation string
- Fix typo in source string
- Remove double word (ved) in translation

Fixes http://platform.dandigbib.org/issues/659#note-65.