### PR TITLE
Issue 1631: Always return an entity from ding_user_provider_profile

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -368,7 +368,8 @@ function ding_user_profile_update_submit(&$form, &$form_state) {
  */
 function ding_user_provider_profile($account) {
   $profile_type = ding_user_get_provider_profile_type();
-  return profile2_load_by_user($account, $profile_type->type);
+  $profile2 = profile2_load_by_user($account, $profile_type->type);
+  return is_array($profile2) ? reset($profile2) : $profile2;
 }
 
 /**

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -369,7 +369,7 @@ function ding_user_profile_update_submit(&$form, &$form_state) {
 function ding_user_provider_profile($account) {
   $profile_type = ding_user_get_provider_profile_type();
   $profile2 = profile2_load_by_user($account, $profile_type->type);
-  return is_array($profile2) ? reset($profile2) : $profile2;
+  return is_array($profile2) ? NULL : $profile2;
 }
 
 /**


### PR DESCRIPTION
This issue is caused by ask_vopros.module::ask_vopros_preprocess_html() calling field_get_items() with an array of profile2 instead of an entity (because the dummy_provider does not implement a profile).  
I have chosen to fix it in ding_user, since the profile2_load_by_user() returns an array if given  profile_type does not match and another profile is found - in this case ding_staff, and it is the responsibility of ding_user to return the profile.