### PR TITLE
1749: Make provider file paths relative to provider dir

### DIFF
--- a/modules/alma/alma.module
+++ b/modules/alma/alma.module
@@ -54,35 +54,33 @@ function alma_get_interest_periods() {
  * Implements hook_ding_provider().
  */
 function alma_ding_provider() {
-  $path = drupal_get_path('module', 'alma');
-
   return array(
     'title' => 'Alma provider',
     'settings' => 'alma_settings_form',
     'provides' => array(
       'availability' => array(
         'prefix' => 'availability',
-        'file' => $path . '/includes/alma.availability.inc',
+        'file' => 'includes/alma.availability.inc',
       ),
       'debt' => array(
         'prefix' => 'debt',
-        'file' => $path . '/includes/alma.debt.inc',
+        'file' => 'includes/alma.debt.inc',
       ),
       'loan' => array(
         'prefix' => 'loan',
-        'file' => $path . '/includes/alma.loan.inc',
+        'file' => 'includes/alma.loan.inc',
       ),
       'reservation' => array(
         'prefix' => 'reservation',
-        'file' => $path . '/includes/alma.reservation.inc',
+        'file' => 'includes/alma.reservation.inc',
       ),
       'user' => array(
         'prefix' => 'user',
-        'file' => $path . '/includes/alma.user.inc',
+        'file' => 'includes/alma.user.inc',
       ),
       'wayf' => array(
         'prefix' => 'wayf',
-        'file' => $path . '/includes/alma.wayf.inc',
+        'file' => 'includes/alma.wayf.inc',
       ),
     ),
   );

--- a/modules/ding_provider/connie/connie.module
+++ b/modules/ding_provider/connie/connie.module
@@ -27,19 +27,19 @@ function connie_ding_provider() {
       ),
       'user' => array(
         'prefix' => 'user',
-        'file' => drupal_get_path('module', 'connie') . '/connie.user.inc',
+        'file' => 'connie.user.inc',
       ),
       'reservation' => array(
         'prefix' => 'reservation',
-        'file' => drupal_get_path('module', 'connie') . '/connie.reservation.inc',
+        'file' => 'connie.reservation.inc',
       ),
       'loan' => array(
         'prefix' => 'loan',
-        'file' => drupal_get_path('module', 'connie') . '/connie.loan.inc',
+        'file' => 'connie.loan.inc',
       ),
       'branch' => array(
         'prefix' => 'branch',
-        'file' => drupal_get_path('module', 'connie') . '/connie.branch.inc',
+        'file' => 'connie.branch.inc',
       ),
     ),
   );

--- a/modules/ding_provider/ding_provider.api.php
+++ b/modules/ding_provider/ding_provider.api.php
@@ -23,6 +23,7 @@
  *   - "settings": Form id for a form of settings common to all providers
  *      of this module. Optional.
  *   - "file": File to include for the global settings form. Optional.
+ *      The path should be relative to the provider module root directory.
  *   - "provides": An array of providers. The key is the name and the value
  *      is an array with the following attributes:
  *      - "prefix": An optional prefix for the methods in this provider.
@@ -31,6 +32,7 @@
  *         ding_provider will attempt to call the
  *         <module name>_user_is_logged_in function.
  *      - "file": File to be included before calling this function. Optional.
+ *         The path should be relative to the provider module root directory.
  *
  * @see connie.module
  */
@@ -41,7 +43,7 @@ function hook_ding_provider() {
     'provides' => array(
       'availability' => array(
         'prefix' => 'availability',
-        'file' => drupal_get_path('module', 'my_module') . '/mymodule.availability.inc',
+        'file' => 'mymodule.availability.inc',
       ),
     ),
   );

--- a/modules/ding_provider/ding_provider.module
+++ b/modules/ding_provider/ding_provider.module
@@ -43,7 +43,10 @@ function ding_provider_menu() {
         'type' => MENU_LOCAL_TASK,
       );
       if ($provider['global settings file']) {
-        $items['admin/config/ding/provider/' . $provider['module']]['file'] = $provider['global settings file'];
+        $items['admin/config/ding/provider/' . $provider['module']] += array(
+          'file path' => drupal_get_path('module', $provider['module']),
+          'file' => $provider['global settings file'],
+        );
       }
     }
   }
@@ -532,7 +535,7 @@ function _ding_provider_function($type, $hook, $quiet = FALSE) {
     $function = $provider['module'] . '_' . (isset($provider['prefix']) ? $provider['prefix'] . '_' : '') . $hook;
 
     if (isset($provider['file'])) {
-      require_once DRUPAL_ROOT . '/' . $provider['file'];
+      require_once drupal_get_path('module', $provider['module']) . '/' . $provider['file'];
     }
 
     if (function_exists($function)) {

--- a/modules/ding_wayf/tests/wyrna/wyrna.module
+++ b/modules/ding_wayf/tests/wyrna/wyrna.module
@@ -15,7 +15,7 @@ function wyrna_ding_provider() {
     'provides' => array(
       'wayf' => array(
         'prefix' => 'wayf',
-        'file' => drupal_get_path('module', 'wyrna') . '/wyrna.wayf.inc',
+        'file' => 'wyrna.wayf.inc',
       ),
     ),
   );

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -26,35 +26,33 @@ function fbs_init() {
  * Implements hook_ding_provider().
  */
 function fbs_ding_provider() {
-  $path = drupal_get_path('module', 'fbs');
-
   return array(
     'title' => 'FBS provider',
     'settings' => 'fbs_settings_form',
     'provides' => array(
       'availability' => array(
         'prefix' => 'availability',
-        'file' => $path . '/includes/fbs.availability.inc',
+        'file' => 'includes/fbs.availability.inc',
       ),
       'debt' => array(
         'prefix' => 'debt',
-        'file' => $path . '/includes/fbs.debt.inc',
+        'file' => 'includes/fbs.debt.inc',
       ),
       'loan' => array(
         'prefix' => 'loan',
-        'file' => $path . '/includes/fbs.loan.inc',
+        'file' => 'includes/fbs.loan.inc',
       ),
       'reservation' => array(
         'prefix' => 'reservation',
-        'file' => $path . '/includes/fbs.reservation.inc',
+        'file' => 'includes/fbs.reservation.inc',
       ),
       'user' => array(
         'prefix' => 'user',
-        'file' => $path . '/includes/fbs.user.inc',
+        'file' => 'includes/fbs.user.inc',
       ),
       'wayf' => array(
         'prefix' => 'wayf',
-        'file' => $path . '/includes/fbs.wayf.inc',
+        'file' => 'includes/fbs.wayf.inc',
       ),
     ),
   );

--- a/modules/openruth/openruth.module
+++ b/modules/openruth/openruth.module
@@ -16,27 +16,27 @@ function openruth_ding_provider() {
     'provides' => array(
       'availability' => array(
         'prefix' => 'availability',
-        'file' => drupal_get_path('module', 'openruth') . '/includes/openruth.availability.inc',
+        'file' => 'includes/openruth.availability.inc',
       ),
       'user' => array(
         'prefix' => 'user',
-        'file' => drupal_get_path('module', 'openruth') . '/includes/openruth.user.inc',
+        'file' => 'includes/openruth.user.inc',
       ),
       'reservation' => array(
         'prefix' => 'reservation',
-        'file' => drupal_get_path('module', 'openruth') . '/includes/openruth.reservation.inc',
+        'file' => 'includes/openruth.reservation.inc',
       ),
       'loan' => array(
         'prefix' => 'loan',
-        'file' => drupal_get_path('module', 'openruth') . '/includes/openruth.loan.inc',
+        'file' => 'includes/openruth.loan.inc',
       ),
       'debt' => array(
         'prefix' => 'debt',
-        'file' => drupal_get_path('module', 'openruth') . '/includes/openruth.debt.inc',
+        'file' => 'includes/openruth.debt.inc',
       ),
       'wayf' => array(
         'prefix' => 'wayf',
-        'file' => drupal_get_path('module', 'openruth') . '/includes/openruth.wayf.inc',
+        'file' => 'includes/openruth.wayf.inc',
       ),
     ),
   );


### PR DESCRIPTION
The current implementation is inconsistent:

1. The “file” option under “provides” are relative to the Drupal root dir
2. The root “file” option is relative to the ding_provider root dir

Part 2 results in developers with settings functions outside the .module
file have to jump through hoop to load the correct file.

Making all files paths relative to the Drupal root would require the 
smallest number of changes but that is not possible due to the way
the hook_menu() “file path” option works.

Instead we make all file paths relative to the provider root directory.
This is also the simplest going forward as all providers follow this
pattern anyway.

This change:
- Updates “file path” op ion  in the the ding_provider hook_menu
implementation for loading settings forms to be relative to the 
provider module root dir.
- Updates provider function invocation to load files relatative to the
provider module root dir
- Update all existing providers (alma, connie, fbs, openruth, wyrna) to
set file paths relative to the individual provider module root 
directories.