### PR TITLE
Issue #1731 by holt83: Track user selected facets in Webtrends OSS

### DIFF
--- a/modules/ding_webtrends/ding_webtrends.module
+++ b/modules/ding_webtrends/ding_webtrends.module
@@ -92,7 +92,7 @@ EOT;
     $meta_tag['#tag'] = 'meta';
     $meta_tag['#attributes'] = array(
       'name' => 'WT.oss',
-      'content' => $search_info['search_key'],
+      'content' => $search_info['type'] . ':' . $search_info['search_key'],
     );
     drupal_add_html_head($meta_tag, 'search_query_meta_tag');
     $meta_tag['#attributes'] = array(
@@ -111,18 +111,36 @@ function ding_webtrends_panels_pane_content_alter($content, $pane, $args, $conte
     $search_result = drupal_static('ting_search_results', FALSE);
     $search_key = $search_result->search_key;
     $count = $search_result->numTotalObjects;
-    ding_webtrends_set_search_info($search_key, $count);
+    ding_webtrends_set_search_info($search_key, $count, 'ting_search');
   }
 }
 
-function ding_webtrends_set_search_info($search_key, $count) {
+/**
+ * Implemenents hook_views_post_execute().
+ */
+function ding_webtrends_views_post_execute(&$view) {
+  if ($view->name == 'ding_multiple_search') {
+    $count = $view->total_rows;
+    $search_key = array_shift($view->args);
+    ding_webtrends_set_search_info($search_key, $count, 'node');
+  }
+}
+
+/**
+ * Set info about a search has been performed for later use in page building.
+ */
+function ding_webtrends_set_search_info($search_key, $count, $type) {
   $search_info = &drupal_static(__FUNCTION__);
   $search_info = array(
     'search_key' => $search_key,
     'count' => $count,
+    'type' => $type,
   );
 }
 
+/**
+ * Helper function to get info about a performed search.
+ */
 function ding_webtrends_get_search_info() {
   return drupal_static('ding_webtrends_set_search_info', FALSE);
 }

--- a/modules/ding_webtrends/ding_webtrends.module
+++ b/modules/ding_webtrends/ding_webtrends.module
@@ -67,16 +67,7 @@ window.webtrendsAsyncInit=function(){
             facebook:{src:"//s.webtrends.com/js/webtrends.fb.js"},
             yt:{src:"//s.webtrends.com/js/webtrends.yt.js"}
         }
-        });
-
-        // @TODO: Prepare for search-data
-        var count = jQuery('.js-count');
-        if(count.length > 0) {
-          dcs.WT.oss = jQuery('.form-type-textfield input').val();  // search query
-          dcs.WT.oss_r = count.attr('data-js-count'); // search hits
-        }
-        
-        dcs.track();
+        }).track();
 };
 EOT;
 
@@ -96,4 +87,42 @@ EOT;
     '#markup' => $html,
   );
 
+  // Check to see if a search needs to be tracked.
+  if ($search_info = ding_webtrends_get_search_info()) {
+    $meta_tag['#tag'] = 'meta';
+    $meta_tag['#attributes'] = array(
+      'name' => 'WT.oss',
+      'content' => $search_info['search_key'],
+    );
+    drupal_add_html_head($meta_tag, 'search_query_meta_tag');
+    $meta_tag['#attributes'] = array(
+      'name' => 'WT.oss_r',
+      'content' => $search_info['count'],
+    );
+    drupal_add_html_head($meta_tag, 'search_count_meta_tag');
+  }
+}
+
+/**
+ * Implements hook_panels_pane_content_alter().
+ */
+function ding_webtrends_panels_pane_content_alter($content, $pane, $args, $contexts) {
+  if ($pane->type == 'search_result' && $pane->configuration['type'] == 'ting_search') {
+    $search_result = drupal_static('ting_search_results', FALSE);
+    $search_key = $search_result->search_key;
+    $count = $search_result->numTotalObjects;
+    ding_webtrends_set_search_info($search_key, $count);
+  }
+}
+
+function ding_webtrends_set_search_info($search_key, $count) {
+  $search_info = &drupal_static(__FUNCTION__);
+  $search_info = array(
+    'search_key' => $search_key,
+    'count' => $count,
+  );
+}
+
+function ding_webtrends_get_search_info() {
+  return drupal_static('ding_webtrends_set_search_info', FALSE);
 }

--- a/modules/ding_webtrends/ding_webtrends.module
+++ b/modules/ding_webtrends/ding_webtrends.module
@@ -108,10 +108,11 @@ EOT;
  */
 function ding_webtrends_panels_pane_content_alter($content, $pane, $args, $contexts) {
   if ($pane->type == 'search_result' && $pane->configuration['type'] == 'ting_search') {
-    $search_result = drupal_static('ting_search_results', FALSE);
-    $search_key = $search_result->search_key;
-    $count = $search_result->numTotalObjects;
-    ding_webtrends_set_search_info($search_key, $count, 'ting_search');
+    if ($search_result = drupal_static('ting_search_results', FALSE)) {
+      $search_key = $search_result->search_key;
+      $count = $search_result->numTotalObjects;
+      ding_webtrends_set_search_info($search_key, $count, 'ting_search');
+    }
   }
 }
 

--- a/modules/ding_webtrends/ding_webtrends.module
+++ b/modules/ding_webtrends/ding_webtrends.module
@@ -111,6 +111,25 @@ function ding_webtrends_panels_pane_content_alter($content, $pane, $args, $conte
     if ($search_result = drupal_static('ting_search_results', FALSE)) {
       $search_key = $search_result->search_key;
       $count = $search_result->numTotalObjects;
+
+      // Look for facets in the query parameters, which are selected by the user
+      // in the UI. Ting search only saves the search key without the appended
+      // facets, so at this point this is the only way to get this information.
+      // We append them exactly like Ting search does, to reflect the actual
+      // query send to the data well.
+      if (isset($_GET['facets']) && is_array($_GET['facets'])) {
+        $facets = array();
+        foreach ($_GET['facets'] as $facet) {
+          $facet = explode(':', $facet, 2);
+          if (count($facet) > 1) {
+            $facets[] = $facet[0] . '="' . rawurldecode($facet[1]) . '"';
+          }
+        }
+        if ($facets) {
+          $search_key .= ' AND ' . implode(' AND ', $facets);
+        }
+      }
+
       ding_webtrends_set_search_info($search_key, $count, 'ting_search');
     }
   }


### PR DESCRIPTION
Enables tracking of user selected facets in Webtrends onsite search statistics. Without this it is not possible to differentiate searches with or without facets in these stats.

These need special handling since they are implemented as query parameters and therefore not part of the search key in the URL.

Note that this PR is based on additions from https://github.com/ding2/ding2/pull/252 and therefor include those commits.

http://platform.dandigbib.org/issues/1731
