### PR TITLE
Core: Patch oEmbed to prevent fatal errors

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -235,6 +235,8 @@ projects[oembed][subdir] = "contrib"
 projects[oembed][version] = "1.0-rc2"
 ; Remove hook_system_info_alter() to allow installing modules depending on oembed, after oembed is installed.
 projects[oembed][patch][] = "http://www.drupal.org/files/issues/oembed-remove_hook_sytem_info_alter-2502817-1.patch"
+; Fix fatal error on install: Unsupported operand types
+projects[oembed][patch][] = "https://www.drupal.org/files/oembed-2021015-1.patch"
 
 projects[og][subdir] = "contrib"
 projects[og][version] = "2.7"


### PR DESCRIPTION
The following error occurs: 
“Fatal error: Unsupported operand types in /oembed.module on line 129”

Patch oEmbed module to prevent this. Patch has already been committed
but no release has been made yet.

See https://www.drupal.org/node/2021015.