### PR TITLE
1671: Fix migration of addi variables

### DIFF
--- a/modules/ting_covers_addi/ting_covers_addi.install
+++ b/modules/ting_covers_addi/ting_covers_addi.install
@@ -22,7 +22,7 @@ function ting_covers_addi_install() {
     $value = variable_get($variable, NULL);
     if ($value) {
       // The 'addi' part is part of the existing name.
-      variable_set('ting_covers_' . $migrate_variables, $value);
+      variable_set('ting_covers_' . $variable, $value);
     }
   }
 }


### PR DESCRIPTION
Addi variables are not migrated properly. This results in the following error:

PHP Fatal error:  SOAP-ERROR: Parsing WSDL: Couldn't load from '/moreinfo.wsdl' : failed to load external entity "/moreinfo.wsdl"

The error is caused by a faulty migration of the addi variables.