### PR TITLE
Core: Use default method for fetching Drupal Core

### DIFF
--- a/drupal.make
+++ b/drupal.make
@@ -2,12 +2,7 @@ core = 7.x
 api = 2
 
 ; Core
-; As d.o is having issues with the update XML file, we are using this form for downloading core.
-; See this: https://drupal.org/node/2126123
-projects[drupal][type] = core
 projects[drupal][version] = 7.44
-projects[drupal][download][type] = get
-projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.44.tar.gz
 projects[drupal][patch][] = http://drupal.org/files/issues/menu-get-item-rebuild-1232346-45.patch
 projects[drupal][patch][] = http://drupal.org/files/ssl-socket-transports-1879970-13.patch
 projects[drupal][patch][] = http://www.drupal.org/files/issues/autocomplete-1232416-205-7x.patch


### PR DESCRIPTION
The XML issue has been resolved for a while now so the workaround is no
longer needed.