### PR TITLE
Issue #430: Fixed roles match filter in search API

### DIFF
--- a/modules/ding_frontend/ding_frontend.features.inc
+++ b/modules/ding_frontend/ding_frontend.features.inc
@@ -970,7 +970,7 @@ function ding_frontend_default_search_api_index() {
         "ding_frontend_role_filter" : {
           "status" : 1,
           "weight" : "-10",
-          "settings" : { "default" : "0", "roles" : { "9" : "9" } }
+          "settings" : { "default" : "0", "match_type": "partial", "roles" : { "9" : "9" } }
         },
         "search_api_alter_language_control" : {
           "status" : 0,

--- a/modules/ding_frontend/includes/callback_user_role_filter.inc
+++ b/modules/ding_frontend/includes/callback_user_role_filter.inc
@@ -18,7 +18,18 @@ class DingFrontendUserRoleFilter extends SearchApiAbstractAlterCallback {
     foreach ($items as $id => $item) {
       if ($item->item_type == 'user') {
         $account = $item->user;
-        $role_match = (count(array_diff_key($account->roles, $roles)) !== count($account->roles));
+        switch ($this->options['match_type']) {
+          case 'partial':
+            $keys = array_keys($account->roles);
+            $t = array_intersect_key($roles, $account->roles);
+            $role_match = (count(array_intersect_key($roles, $account->roles)) === count($roles));
+            break;
+
+          default:
+            $role_match = (count(array_diff_key($account->roles, $roles)) !== count($account->roles));
+            break;
+        }
+
         if ($role_match === $default) {
           unset($items[$id]);
         }
@@ -41,6 +52,15 @@ class DingFrontendUserRoleFilter extends SearchApiAbstractAlterCallback {
         '#options' => array(
           1 => t('All but those from one of the selected roles'),
           0 => t('Only those from the selected roles'),
+        ),
+      ),
+      'match_type' => array(
+        '#type' => 'radios',
+        '#title' => t('Which users should be indexed?'),
+        '#default_value' => isset($this->options['match_type']) ? $this->options['match_type'] : 'partial',
+        '#options' => array(
+          'all' => t('Should match roles (user only has selected roles)'),
+          'partial' => t('Should have roles (may have other roles as well)'),
         ),
       ),
       'roles' => array(


### PR DESCRIPTION
Allow users to have more than the required roles.

Eg. staff may also have editor an still be indexed.

See http://platform.dandigbib.org/issues/430