### PR TITLE
1235: Fix undefined Drupal.settings.ting_search_carousel error

### DIFF
--- a/modules/ting_search_carousel/js/ting_search_carousel.js
+++ b/modules/ting_search_carousel/js/ting_search_carousel.js
@@ -363,6 +363,10 @@
    */
   Drupal.behaviors.ting_search_carousel = {
     attach: function (context, settings) {
+      // template_preprocess_ting_search_carousel() is not called by p2/ting_carousel
+      if (settings.ting_search_carousel === undefined) {
+        return;
+      }
       $.each(settings.ting_search_carousel.carousels, function (id, carousel_settings) {
         Drupal.TingSearchCarousel.init(id, carousel_settings);
       });


### PR DESCRIPTION
Drupal.settings.ting_search_carousel is defined in
template_preprocess_ting_search_carousel(), but it is not called
by p2/ting_carousel
