### PR TITLE
1894: Revert upgrading Workflow module to 2.7

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -386,7 +386,10 @@ projects[workbench][subdir] = "contrib"
 projects[workbench][version] = "1.2"
 
 projects[workflow][subdir] = "contrib"
-projects[workflow][version] = "2.7"
+projects[workflow][version] = "2.5"
+projects[workflow][patch][] = "http://www.drupal.org/files/issues/features_import-2484297-10.patch"
+; Prevent fatal errors on cron when using Scheduler, https://www.drupal.org/node/2499193.
+projects[workflow][patch][] = "https://www.drupal.org/files/issues/workflow-php_fatal_error_call-2499193-7-2.5.patch"
 
 ; This revision support the CKEditor 4.x, and can be used until a new version is tagged.
 projects[wysiwyg][type] = "module"


### PR DESCRIPTION
This also means we have to reapply patches.

Upgrading Workflow has introduced a range of other problems.

Creating a News node spawns errors:

- Workflow 1 cannot be loaded. Contact your system administrator. 

Workflow 1 cannot be loaded. Contact your system administrator.
Error: content 42 has no workflow attached. The data is not saved.
PDOException: SQLSTATE23000: Integrity constraint violation: 1048 Column 'field_bpi_workflow_value' cannot be null: INSERT INTO {field_data_field_bpi_workflow} (entity_type, entity_id, revision_id, bundle, delta, language, field_bpi_workflow_value) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5, :db_insert_placeholder_6); Array ( [:db_insert_placeholder_0] => node [:db_insert_placeholder_1] => 42 [:db_insert_placeholder_2] => 122 [:db_insert_placeholder_3] => ding_news [:db_insert_placeholder_4] => 0 [:db_insert_placeholder_5] => und [:db_insert_placeholder_6] => ) i field_sql_storage_field_storage_write() (linje 514 af /var/aegir/platforms/ddb300rc2/modules/field/modules/field_sql_storage/field_sql_storage.module).