### PR TITLE
976: Revert changes as it is superseded by 1606

### DIFF
--- a/modules/alma/alma.features.field_base.inc
+++ b/modules/alma/alma.features.field_base.inc
@@ -155,7 +155,6 @@ function alma_field_default_field_bases() {
         90 => '3 months',
         180 => '6 months',
         360 => '12 months',
-        720 => '24 months',
       ),
       'allowed_values_function' => '',
       'profile2_private' => 0,

--- a/modules/openruth/openruth.features.field_base.inc
+++ b/modules/openruth/openruth.features.field_base.inc
@@ -114,7 +114,6 @@ function openruth_field_default_field_bases() {
         90 => '3 months',
         180 => '6 months',
         360 => '12 months',
-        720 => '24 months',
       ),
       'allowed_values_function' => '',
       'profile2_private' => 0,

--- a/translations/da.po
+++ b/translations/da.po
@@ -46316,10 +46316,6 @@ msgstr "3 måneder"
 msgid "12 months"
 msgstr "12 måneder"
 
-#: /install.php?profile=ding2&locale=en
-msgid "24 months"
-msgstr "24 måneder"
-
 #: profiles/ding2/modules/ding_availability/js/ding_availability_labels.js
 msgid "Can be obtained"
 msgstr "Kan fremskaffes"

--- a/translations/fields_da.po
+++ b/translations/fields_da.po
@@ -735,11 +735,6 @@ msgctxt "field_alma_interest_period:#allowed_values:360"
 msgid "12 months"
 msgstr "12 måneder"
 
-#: field:field_alma_interest_period:#allowed_values:720
-msgctxt "field_alma_interest_period:#allowed_values:720"
-msgid "24 months"
-msgstr "24 måneder"
-
 #: field:field_alma_city:provider_alma:label
 msgctxt "field_alma_city:provider_alma:label"
 msgid "City"
@@ -904,11 +899,6 @@ msgstr "6 måneder"
 msgctxt "field_openruth_interest_period:#allowed_values:360"
 msgid "12 months"
 msgstr "12 måneder"
-
-#: field:field_openruth_interest_period:#allowed_values:720
-msgctxt "field_openruth_interest_period:#allowed_values:720"
-msgid "24 months"
-msgstr "24 måneder"
 
 #: field:field_ding_news_comment_body:comment_node_ding_news:label
 msgctxt "field_ding_news_comment_body:comment_node_ding_news:label"


### PR DESCRIPTION
This reverts commit 4677481355b031677e66bd40e467e1adfc21151d.
"Issue #976 by Inlead: Add support for 24 months interest period."