### PR TITLE
1916: Fix bookmark import when there is no flag module

### DIFF
--- a/modules/p2/ding_list/ding_list.module
+++ b/modules/p2/ding_list/ding_list.module
@@ -396,6 +396,13 @@ function ding_list_user_login(&$edit, $account) {
 function ding_list_import_bookmarks($account) {
   // Using simplevar module here, because compatibility with lazy_vars is
   // broken, will be fixed later.
+  // If there is no flag content to import then back out.
+  // This happens on new sites where the flag module has never been installed.
+  if (!db_table_exists('flag_content')) {
+    simplevar_set('ding_list_import_bookmarks', $account->uid, TRUE);
+    return;
+  }
+
   // Bail out if the bookmarks is already imported.
   if (simplevar_get('ding_list_import_bookmarks', $account->uid, FALSE) === TRUE) {
     return;

--- a/modules/p2/ding_list/ding_list.module
+++ b/modules/p2/ding_list/ding_list.module
@@ -409,6 +409,8 @@ function ding_list_import_bookmarks($account) {
   }
 
   // Fetch all the content_ids from the flag_content table.
+  // We use raw queries here as the flag module has been disabled and its API is
+  // not available.
   $query = db_select('flag_content', 'fc');
   $query->join('flags', 'f', 'f.fid = fc.fid');
   $cids = $query


### PR DESCRIPTION
Without this change the installation process will fail. There is no flag_content table as the flag module is not enabled.