### PR TITLE
1990: Fixed query used to fetch facets

### DIFF
--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -840,9 +840,10 @@ function bpi_get_facets() {
   }
 
   if ($reload) {
-    $response = bpi_search_content();
-    if (!empty($response)) {
-      $facets = $response->getFacets();
+    $bpi = bpi_client_instance();
+    $result = $bpi->searchNodes();
+    if (!empty($result)) {
+      $facets = $result->getFacets();
       $_SESSION[BPI_ALL_FACETS_KEY] = bpi_facets_to_array($facets);
     }
     else {


### PR DESCRIPTION
This fixes http://platform.dandigbib.org/issues/1990.

Before this fix, the _second page_ of nodes from BPI was used to build the facets filters, but if this list of nodes was empty (when BPI ws contains very few nodes) the filters were not built.
