### PR TITLE
420: Catch no provider exception during login

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -586,7 +586,8 @@ function ding_user_user_login_validate($form, &$form_state) {
     // Trying to login the user using the provider.
     try {
       $auth_res = ding_provider_invoke('user', 'authenticate', $form_state['values']['name'], $form_state['values']['pass'], $form_state['values']);
-    } catch(DingProviderNoProvider $exception) {
+    }
+    catch(DingProviderNoProvider $exception) {
       drupal_set_message($exception->getMessage(), 'warning');
       return;
     }

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -584,7 +584,12 @@ function ding_user_user_login_validate($form, &$form_state) {
   }
   try {
     // Trying to login the user using the provider.
-    $auth_res = ding_provider_invoke('user', 'authenticate', $form_state['values']['name'], $form_state['values']['pass'], $form_state['values']);
+    try {
+      $auth_res = ding_provider_invoke('user', 'authenticate', $form_state['values']['name'], $form_state['values']['pass'], $form_state['values']);
+    } catch(DingProviderNoProvider $exception) {
+      drupal_set_message($exception->getMessage(), 'warning');
+      return;
+    }
     if (!is_array($auth_res) || !isset($auth_res['success'])) {
       watchdog('ding_user', 'Provider returned invalid result: @res', array('@res' => print_r($auth_res, TRUE)), WATCHDOG_DEBUG);
       return;


### PR DESCRIPTION
This happens when disabling all providers, which is a trick used when switching to the new FBS system.