### PR TITLE
2074: Added extra values to bpi data

### DIFF
--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -126,6 +126,8 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
   $bpi_content['agency_id'] = variable_get('bpi_agency_id', '');
   $bpi_content['local_id'] = $node->nid;
   $bpi_content['bpi_id'] = isset($node->bpi_id) ? $node->bpi_id : NULL;
+  $bpi_content['url'] = url('node/' . $node->nid, array('absolute' => TRUE, 'alias' => TRUE));
+  $bpi_content['data'] = '';
 
   $user = user_load($node->uid);
   $bpi_content['firstname'] = $user->name;


### PR DESCRIPTION
In the near future a couple of new fields, url and data, will be added to the BPI web service. In order to not break running sites when these are added (the bpi client makes all fields required), we add the fields now and they will simply be ignored by the web service until it's updated.

http://platform.dandigbib.org/issues/2074