### PR TITLE
1527: Redirect to registration page for unknown WAYF logins

### DIFF
--- a/modules/ding_gatewayf/ding_gatewayf.install
+++ b/modules/ding_gatewayf/ding_gatewayf.install
@@ -11,3 +11,23 @@ function uninstall() {
   // Remove configuration settings.
   variable_del('ding_gatewayf');
 }
+
+/**
+ * Add new translation string and Danish translation of it.
+ */
+function ding_gatewayf_update_7101(&$sandbox) {
+  require_once DRUPAL_ROOT . '/includes/locale.inc';
+
+  $report = &drupal_static(__FUNCTION__, array(
+    'additions' => 0,
+    'updates' => 0,
+    'deletes' => 0,
+    'skips' => 0,
+  ));
+
+  $source = 'You do not have an user account at the public library. If you wish you can create an user account below. You are still logged in at WAYF, so you can !logout to logout of WAYF.';
+  $translation = "<p>Du er ikke låner ved biblioteket. Hvis du ønsker at oprette dig som låner kan du gøre det nedenfor.</p>\n<p>Du er stadig logget ind ved NemID, så du kan !logout for at logge ud.</p>";
+
+  _locale_import_one_string_db($report, 'da', '', $source, $translation, 'default', 'Import via helper ' . __FUNCTION__ . '().', LOCALE_IMPORT_KEEP);
+  cache_clear_all('locale:', 'cache', TRUE);
+}

--- a/modules/ding_gatewayf/ding_gatewayf.module
+++ b/modules/ding_gatewayf/ding_gatewayf.module
@@ -305,13 +305,22 @@ function _ding_gatewayf_provider_login(array $attributes) {
           if (_ding_gatewayf_registration_is_registration_request()) {
             $_SESSION[DING_GATEWAYF_ATTRIBUTES] = $attributes;
           }
-          else {
+          elseif (current_path() !== DING_GATEWAYF_REGISTRATION_ACCEPTANCE_URL) {
             // Display message that the user don't have an account an then can
-            // create on or logout.
-            drupal_set_message(t('You do not have an user account at the public library. If you wish to create an user account !user_url . You are still logged in at WAYF, so you can !logout to logout of WAYF.', array(
+            // create one or logout.
+            drupal_set_message(t('You do not have an user account at the public library. If you wish you can create an user account below. You are still logged in at WAYF, so you can !logout to logout of WAYF.', array(
               '!logout' => l(t('click here'), DING_GATEWAYF_LOGOUT_URL),
-              '!user_url' => l(t('click here'), DING_GATEWAYF_REGISTRATION_INFORMATION_URL),
             )), 'warning');
+
+            // Remove the redirect.
+            unset($_REQUEST['destination']);
+            unset($_GET['destination']);
+
+            // Redirect to the registration page. We avoid redirecting to the
+            // front page because messages will be lost on sites that strip
+            // sessions cookies from the front page (see #1527).
+            _ding_gatewayf_redirect_user(DING_GATEWAYF_REGISTRATION_INFORMATION_URL);
+            return;
           }
         }
         else {

--- a/translations/da.po
+++ b/translations/da.po
@@ -47949,8 +47949,8 @@ msgid "Create user"
 msgstr "Opret bruger"
 
 #: /gatewayf/callback?destination=ding_frontpage?eduPersonTargetedID=WAYF-DK-e767c06edaad0f8d23e785bbc470e7f37ad03e8d&mail=&logintype=nemlogin
-msgid "You do not have an user account at the public library. If you wish to create an user account !user_url . You are still logged in at WAYF, so you can !logout to logout of WAYF."
-msgstr "<p>Du er ikke låner ved biblioteket. Hvis du ønsker at oprette dig som låner kan du !user_url.</p>\r p>Du er stadig logget ind ved NemID, så du kan !logout for at logge ud.</p>"
+msgid "You do not have an user account at the public library. If you wish you can create an user account below. You are still logged in at WAYF, so you can !logout to logout of WAYF."
+msgstr "<p>Du er ikke låner ved biblioteket. Hvis du ønsker at oprette dig som låner kan du gøre det nedenfor.</p>\r<p>Du er stadig logget ind ved NemID, så du kan !logout for at logge ud.</p>"
 
 #: /search/ting/+.net
 msgid "Best match on title"


### PR DESCRIPTION
http://platform.dandigbib.org/issues/1527

Redirect unknown users logging in via WAYF to the registration page.

We avoid redirecting to the front page (as it used to be) because messages will are lost on sites that strip sessions cookies from the front page.