### PR TITLE
2118: Fixed bpi module to use xautoload for bpi-client dependencies

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -449,11 +449,13 @@ libraries[chosen][download][url] = "https://github.com/harvesthq/chosen/releases
 libraries[chosen][destination] = "libraries"
 
 libraries[guzzle][download][type] = "git"
-libraries[guzzle][download][url] = "git@github.com:guzzle/guzzle.git"
+libraries[guzzle][download][url] = "https://github.com/guzzle/guzzle.git"
+libraries[guzzle][download][tag] = "6.2.2"
 libraries[guzzle][destination] = "libraries"
 
 libraries[http-message][download][type] = "git"
-libraries[http-message][download][url] = "git@github.com:php-fig/http-message.git"
+libraries[http-message][download][url] = "https://github.com/php-fig/http-message.git"
+libraries[http-message][download][tag] = "1.0.1"
 libraries[http-message][destination] = "libraries"
 
 libraries[leaflet][download][type] = "get"
@@ -468,11 +470,13 @@ libraries[profiler][download][branch] = "7.x-2.0-beta1"
 libraries[profiler][patch][0] = "http://drupal.org/files/profiler-reverse.patch"
 
 libraries[promises][download][type] = "git"
-libraries[promises][download][url] = "git@github.com:guzzle/promises.git"
+libraries[promises][download][url] = "https://github.com/guzzle/promises.git"
+libraries[promises][download][tag] = "1.2.0"
 libraries[promises][destination] = "libraries"
 
 libraries[psr7][download][type] = "git"
-libraries[psr7][download][url] = "git@github.com:guzzle/psr7.git"
+libraries[psr7][download][url] = "https://github.com/guzzle/psr7.git"
+libraries[psr7][download][tag] = "1.3.1"
 libraries[psr7][destination] = "libraries"
 
 libraries[ting-client][download][type] = "git"

--- a/modules/bpi/bpi.info
+++ b/modules/bpi/bpi.info
@@ -11,6 +11,7 @@ dependencies[] = media
 dependencies[] = wysiwyg
 dependencies[] = bpi_features
 dependencies[] = libraries
+dependencies[] = xautoload
 files[] = lib/bpi-client/Bpi/Sdk/Bpi.php
 files[] = bpi.admin.inc
 files[] = bpi.delete.inc

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -812,19 +812,66 @@ function bpi_validate_material($id) {
  * For defining external libraries.
  */
 function bpi_libraries_info() {
-  $libraries['chosen'] = array(
-    'name' => 'Chosen',
-    'vendor url' => 'https://github.com/harvesthq/chosen',
-    'download url' => 'https://github.com/harvesthq/chosen/releases',
-    'version arguments' => array(
-      'file' => 'chosen.jquery.min.js',
-      'pattern' => '@(?:Chosen v|Version\s+)([0-9a-zA-Z\.-]+)@',
+  return array(
+    'chosen' => array(
+      'name' => 'Chosen',
+      'vendor url' => 'https://github.com/harvesthq/chosen',
+      'download url' => 'https://github.com/harvesthq/chosen/releases',
+      'version arguments' => array(
+        'file' => 'chosen.jquery.min.js',
+        'pattern' => '@(?:Chosen v|Version\s+)([0-9a-zA-Z\.-]+)@',
+      ),
+      'files' => array(
+        'css' => array('chosen.min.css'),
+        'js' => array('chosen.jquery.min.js'),
+      ),
     ),
-    'files' => array(
-      'css' => array('chosen.min.css'),
-      'js' => array('chosen.jquery.min.js'),
+    'guzzle' => array(
+      'name' => 'Guzzle',
+      'vendor url' => 'https://github.com/guzzle/guzzle',
+      'download url' => 'https://github.com/guzzle/guzzle',
+      'version' => '6.2',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
+    'promises' => array(
+      'name' => 'Guzzle promises library',
+      'vendor url' => 'https://github.com/guzzle/promises',
+      'download url' => 'https://github.com/guzzle/promises',
+      'version' => '1.2',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
+    'http-message' => array(
+      'name' => 'Common interface for HTTP messages',
+      'vendor url' => 'https://github.com/php-fig/http-message',
+      'download url' => 'https://github.com/php-fig/http-message',
+      'version' => '1.0',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
+    'psr7' => array(
+      'name' => 'PSR-7 message implementation',
+      'vendor url' => 'https://github.com/guzzle/psr7',
+      'download url' => 'https://github.com/guzzle/psr7',
+      'version' => '1.3',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
     ),
   );
+}
 
-  return $libraries;
+/**
+ * Implements hook_xautoload().
+ */
+function bpi_xautoload($adapter) {
+  // PSR-4 paths for bpi-client.
+  $adapter->absolute()->addPsr4(
+    'Bpi\Sdk\\',
+    drupal_get_path('module', 'bpi') . '/lib/bpi-client/Bpi/Sdk/'
+  );
 }


### PR DESCRIPTION
This fixes http://platform.dandigbib.org/issues/2118 by making the bpi module load dependencies for the bpi-client library.

Depends on PR to the bpi-client library: https://github.com/ding2/bpi-client/pull/12