### PR TITLE
1744 by Inlead: Refactor ting_search_carousel

### DIFF
--- a/modules/ting_search_carousel/ting_search_carousel.admin.inc
+++ b/modules/ting_search_carousel/ting_search_carousel.admin.inc
@@ -66,7 +66,7 @@ function ting_search_carousel_settings_admin_form($form, &$form_state) {
  */
 function ting_search_carousel_admin_form(array $form, array &$form_state) {
   $clicked_btn = '';
-  $remove_btn = null;
+  $remove_btn = NULL;
   $num_searches = (!empty($form_state['values']['num_searches']))
     ? $form_state['values']['num_searches']
     : 0;
@@ -157,12 +157,14 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
 /**
  * Callback function for ajax add more searches.
  *
- * @see ting_search_carousel_admin_form
+ * @param array $form
+ *   Form.
+ * @param array $form_state
+ *   Form state.
  *
- * @param $form
- * @param $form_state
+ * @see ting_search_carousel_admin_form
  */
-function ting_search_carousel_add_more_add_one($form, &$form_state) {
+function ting_search_carousel_add_more_add_one(array $form, array &$form_state) {
   $form_state['values']['num_searches']++;
   $form_state['rebuild'] = TRUE;
 }
@@ -170,14 +172,17 @@ function ting_search_carousel_add_more_add_one($form, &$form_state) {
 /**
  * Callback for searches form.
  *
+ * @param array $form
+ *   Form.
+ * @param array $form_state
+ *   Form state.
+ *
  * @see ting_search_carousel_admin_form
  *
- * @param $form
- * @param $form_state
- *
- * @return mixed
+ * @return array
+ *   Form.
  */
-function ting_search_carousel_ajax_callback($form, $form_state) {
+function ting_search_carousel_ajax_callback(array $form, array $form_state) {
   return $form;
 }
 
@@ -325,7 +330,7 @@ function ting_search_carousel_admin_form_submit(array $form, array &$form_state)
       $searches[] = array(
         'title' => $queries[$key]['title'],
         'subtitle' => $queries[$key]['subtitle'],
-        'query' => $queries[$key]['query']
+        'query' => $queries[$key]['query'],
       );
     }
   }

--- a/modules/ting_search_carousel/ting_search_carousel.admin.inc
+++ b/modules/ting_search_carousel/ting_search_carousel.admin.inc
@@ -81,7 +81,7 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
     '#theme' => 'ting_search_carousel_admin_form',
   );
 
-  if (empty($form_state['num_searches'])) {
+  if (!isset($form_state['num_searches'])) {
     $ids = array_keys($searches);
     if (!empty($ids)) {
       $form_state['num_searches'] = array_combine($ids, $ids);

--- a/modules/ting_search_carousel/ting_search_carousel.admin.inc
+++ b/modules/ting_search_carousel/ting_search_carousel.admin.inc
@@ -65,74 +65,40 @@ function ting_search_carousel_settings_admin_form($form, &$form_state) {
  *   Form structure.
  */
 function ting_search_carousel_admin_form(array $form, array &$form_state) {
-  $clicked_btn = '';
-  $remove_btn = NULL;
-  $num_searches = (!empty($form_state['values']['num_searches']))
-    ? $form_state['values']['num_searches']
-    : 0;
-
   $form['#tree'] = TRUE;
-
-  if (isset($form_state['clicked_button'])) {
-    $clicked_btn = $form_state['clicked_button']['#name'];
-
-    // Get a clicked 'remove' button.
-    foreach ($form_state['buttons'] as $k => $v) {
-      if ($v['#name'] == $clicked_btn) {
-        if (preg_match('/remove--[0-9]+$/', $v['#id'])) {
-          $remove_btn = $k;
-          break;
-        }
-      }
-    }
-  }
 
   $form['ting_search_carousel'] = array(
     '#type' => 'fieldset',
-    '#title' => 'Searches',
+    '#title' => t('Searches'),
   );
 
-  // Get current saved queries.
   $searches = variable_get('ting_search_carousel_searches', array());
 
-  $index = 0;
-  $count = 1;
-
-  // Display saved queries.
-  if (isset($searches[0]['title'])) {
-    $count = count($searches);
-    for (; $index < $count; $index++) {
-      $form['ting_search_carousel']['ting_searches'][$index] = ting_search_carousel_query_form($searches[$index], $index);
-    }
-  }
-
-  for (; $index < $num_searches + $count; $index++) {
-    $unsubmitted = array();
-    // Maybe prev field had some data in it...
-    if (isset($form_state['input']['title'][$index])) {
-      $unsubmitted = array(
-        'title' => $form_state['input']['title'][$index],
-        'subtitle' => $form_state['input']['subtitle'][$index],
-        'query' => $form_state['input']['query'][$index],
-      );
-    }
-
-    $form['ting_search_carousel']['ting_searches'][$index] = ting_search_carousel_query_form($unsubmitted, $index);
-  }
-
-  if (!empty($clicked_btn) && !is_null($remove_btn)) {
-    unset($form['ting_search_carousel']['ting_searches'][$remove_btn]);
-  }
-
-  // Keep track of query fields count.
-  $form['ting_search_carousel']['num_searches'] = array(
-    '#type' => 'hidden',
-    '#value' => $num_searches,
+  $form['ting_search_carousel']['ting_searches'] = array(
+    '#type' => 'container',
+    '#prefix' => '<div id="ting-search-carousel-wrapper">',
+    '#suffix' => '</div>',
+    '#theme' => 'ting_search_carousel_admin_form',
   );
+
+  if (empty($form_state['num_searches'])) {
+    $ids = array_keys($searches);
+    if (!empty($ids)) {
+      $form_state['num_searches'] = array_combine($ids, $ids);
+    }
+    else {
+      $form_state['num_searches'] = array(0 => 0);
+    }
+  }
+
+  foreach ($form_state['num_searches'] as $i) {
+    $form['ting_search_carousel']['ting_searches'][$i] = ting_search_carousel_query_form($searches[$i], $i);
+  }
 
   $form['ting_search_carousel']['add_search'] = array(
     '#type' => 'submit',
     '#value' => t('Add one more'),
+    '#name' => 'ting_search_carousel_add',
     '#submit' => array('ting_search_carousel_add_more_add_one'),
     '#ajax' => array(
       'callback' => 'ting_search_carousel_ajax_callback',
@@ -141,13 +107,6 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
       'effect' => 'fade',
     ),
   );
-
-  // Wrap the form, due to draggable items renewal.
-  $form['#prefix'] = '<div id="ting-search-carousel-wrapper">';
-  $form['#suffix'] = '</div>';
-
-  // Custom themer, mainly used for dragable table creation.
-  $form['#theme'] = array('ting_search_carousel_admin_form');
 
   $form['#submit'] = array('ting_search_carousel_admin_form_submit');
 
@@ -165,7 +124,24 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
  * @see ting_search_carousel_admin_form
  */
 function ting_search_carousel_add_more_add_one(array $form, array &$form_state) {
-  $form_state['values']['num_searches']++;
+  $max = max(array_values($form_state['num_searches']));
+  $form_state['num_searches'][$max + 1] = $max + 1;
+  $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Callback function for ajax remove search.
+ *
+ * @param array $form
+ *   Form.
+ * @param array $form_state
+ *   Form state.
+ *
+ * @see ting_search_carousel_admin_form
+ */
+function ting_search_carousel_remove_submit(array $form, array &$form_state) {
+  $elem = $form_state['triggering_element'];
+  unset($form_state['num_searches'][$elem['#search_id']]);
   $form_state['rebuild'] = TRUE;
 }
 
@@ -182,8 +158,8 @@ function ting_search_carousel_add_more_add_one(array $form, array &$form_state) 
  * @return array
  *   Form.
  */
-function ting_search_carousel_ajax_callback(array $form, array $form_state) {
-  return $form;
+function ting_search_carousel_ajax_callback(array $form, array &$form_state) {
+  return $form['ting_search_carousel']['ting_searches'];
 }
 
 /**
@@ -197,28 +173,21 @@ function ting_search_carousel_ajax_callback(array $form, array $form_state) {
  */
 function theme_ting_search_carousel_admin_form(array $variables) {
   $form = $variables['form'];
-  drupal_add_tabledrag('ting-search-carousel-admin-sort', 'order', 'sibling', 'sort');
+
 
   $header = array('Searches', '');
   $rows = array();
-  foreach (element_children($form['ting_search_carousel']['ting_searches']) as $key) {
+  foreach (element_children($form) as $key) {
     // Add class to group weight fields for drag and drop.
-    $form['ting_search_carousel']['ting_searches'][$key]['sort']['#attributes']['class'][] = 'sort';
-
-    // Get sort element.
-    $sort = $form['ting_search_carousel']['ting_searches'][$key]['sort'];
-    unset($form['ting_search_carousel']['ting_searches'][$key]['sort']);
+    $form[$key]['sort']['#attributes']['class'][] = 'sort';
 
     // Build rows.
     $classes = array('draggable');
-    if (isset($form['ting_search_carousel']['ting_searches'][$key]['#prefix'])) {
-      $classes[] = 'search-query-hidden';
-    }
 
     $rows[] = array(
       'data' => array(
-        drupal_render($form['ting_search_carousel']['ting_searches'][$key]),
-        drupal_render($sort),
+        drupal_render($form[$key]['data']),
+        drupal_render($form[$key]['sort']),
       ),
       'class' => $classes,
     );
@@ -231,12 +200,13 @@ function theme_ting_search_carousel_admin_form(array $variables) {
     'caption' => '',
     'colgroups' => array(),
     'sticky' => FALSE,
-    'empty' => 'EMPTY',
+    'empty' => t('At this moments not one searhes doesnt exists.'),
   );
   $output = theme('table', $table_vars);
 
   // Render remaining elements.
   $output .= drupal_render_children($form);
+  drupal_add_tabledrag('ting-search-carousel-admin-sort', 'order', 'sibling', 'sort');
 
   return $output;
 }
@@ -257,17 +227,14 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
 
   $form['sort'] = array(
     '#type' => 'weight',
+    '#title' => t('Weight'),
     '#delta' => 5,
-    '#default_value' => 0,
+    '#default_value' => (isset($item['sort'])) ? $item['sort'] : 0,
     '#value' => 0,
-    '#attributes' => array(
-      'class' => array(
-        'sort-hidden',
-      ),
-    ),
+    '#title_display' => 'invisible',
   );
 
-  $form['title'] = array(
+  $form['data']['title'] = array(
     '#type' => 'textfield',
     '#title' => t('Title'),
     '#description' => t('The title of the search is used for the tab in the carousel. Keep it short.'),
@@ -275,14 +242,14 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
     '#prefix' => '<div class="search-carousel-query">',
   );
 
-  $form['subtitle'] = array(
+  $form['data']['subtitle'] = array(
     '#type' => 'textfield',
     '#title' => t('Description'),
     '#description' => t('The subtitle displayed next to the search results.'),
     '#default_value' => isset($item['subtitle']) ? $item['subtitle'] : '',
   );
 
-  $form['query'] = array(
+  $form['data']['query'] = array(
     '#type' => 'textfield',
     '#title' => t('Query'),
     '#maxlength' => 2048,
@@ -290,16 +257,17 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
     '#default_value' => isset($item['query']) ? $item['query'] : '',
   );
 
-  $form['remove'] = array(
-    '#type' => 'button',
+  $form['data']['remove'] = array(
+    '#type' => 'submit',
     '#value' => t('Remove'),
-    '#name' => 'remove_' . $index,
+    '#name' => 'ting_search_carousel_remove_' . $index,
+    '#search_id' => $index,
     '#attributes' => array(
       'class' => array(
         'remove',
       ),
     ),
-    '#suffix' => '</div><div class="clearfix"></div>',
+    '#submit' => array('ting_search_carousel_remove_submit'),
     '#ajax' => array(
       'callback' => 'ting_search_carousel_ajax_callback',
       'wrapper' => 'ting-search-carousel-wrapper',
@@ -326,11 +294,11 @@ function ting_search_carousel_admin_form_submit(array $form, array &$form_state)
 
   foreach ($queries as $key => $query) {
     // Make an array for saving, ignoring queries w/o title.
-    if (!empty($queries[$key]['title'])) {
+    if (!empty($queries[$key]['data']['title'])) {
       $searches[] = array(
-        'title' => $queries[$key]['title'],
-        'subtitle' => $queries[$key]['subtitle'],
-        'query' => $queries[$key]['query'],
+        'title' => $queries[$key]['data']['title'],
+        'subtitle' => $queries[$key]['data']['subtitle'],
+        'query' => $queries[$key]['data']['query'],
       );
     }
   }

--- a/modules/ting_search_carousel/ting_search_carousel.admin.inc
+++ b/modules/ting_search_carousel/ting_search_carousel.admin.inc
@@ -72,7 +72,9 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
     '#title' => t('Searches'),
   );
 
-  $searches = variable_get('ting_search_carousel_searches', array());
+  if (empty($form_state['num_searches'])) {
+    $form_state['existing_searches'] = variable_get('ting_search_carousel_searches', array());
+  }
 
   $form['ting_search_carousel']['ting_searches'] = array(
     '#type' => 'container',
@@ -82,7 +84,7 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
   );
 
   if (!isset($form_state['num_searches'])) {
-    $ids = array_keys($searches);
+    $ids = array_keys($form_state['existing_searches']);
     if (!empty($ids)) {
       $form_state['num_searches'] = array_combine($ids, $ids);
     }
@@ -92,7 +94,7 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
   }
 
   foreach ($form_state['num_searches'] as $i) {
-    $form['ting_search_carousel']['ting_searches'][$i] = ting_search_carousel_query_form($searches[$i], $i);
+    $form['ting_search_carousel']['ting_searches'][$i] = ting_search_carousel_query_form($form_state['existing_searches'][$i], $i);
   }
 
   $form['ting_search_carousel']['add_search'] = array(
@@ -142,6 +144,7 @@ function ting_search_carousel_add_more_add_one(array $form, array &$form_state) 
 function ting_search_carousel_remove_submit(array $form, array &$form_state) {
   $elem = $form_state['triggering_element'];
   unset($form_state['num_searches'][$elem['#search_id']]);
+  unset($form_state['existing_searches'][$elem['#search_id']]);
   $form_state['rebuild'] = TRUE;
 }
 
@@ -257,24 +260,26 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
     '#default_value' => isset($item['query']) ? $item['query'] : '',
   );
 
-  $form['data']['remove'] = array(
-    '#type' => 'submit',
-    '#value' => t('Remove'),
-    '#name' => 'ting_search_carousel_remove_' . $index,
-    '#search_id' => $index,
-    '#attributes' => array(
-      'class' => array(
-        'remove',
+  if ($index != 0) {
+    $form['data']['remove'] = array(
+      '#type' => 'submit',
+      '#value' => t('Remove'),
+      '#name' => 'ting_search_carousel_remove_' . $index,
+      '#search_id' => $index,
+      '#attributes' => array(
+        'class' => array(
+          'remove',
+        ),
       ),
-    ),
-    '#submit' => array('ting_search_carousel_remove_submit'),
-    '#ajax' => array(
-      'callback' => 'ting_search_carousel_ajax_callback',
-      'wrapper' => 'ting-search-carousel-wrapper',
-      'method' => 'replace',
-      'effect' => 'fade',
-    ),
-  );
+      '#submit' => array('ting_search_carousel_remove_submit'),
+      '#ajax' => array(
+        'callback' => 'ting_search_carousel_ajax_callback',
+        'wrapper' => 'ting-search-carousel-wrapper',
+        'method' => 'replace',
+        'effect' => 'fade',
+      ),
+    );
+  }
 
   return $form;
 }

--- a/modules/ting_search_carousel/ting_search_carousel.admin.inc
+++ b/modules/ting_search_carousel/ting_search_carousel.admin.inc
@@ -65,10 +65,13 @@ function ting_search_carousel_settings_admin_form($form, &$form_state) {
  *   Form structure.
  */
 function ting_search_carousel_admin_form(array $form, array &$form_state) {
-  $searches_num = !empty($form_state['values']['num_searches']) ? $form_state['values']['num_searches'] : 0;
   $clicked_btn = '';
-  $remove_btn = '';
-  $hidden = variable_get('ting_carousel_search_queries_hidden', array());
+  $remove_btn = null;
+  $num_searches = (!empty($form_state['values']['num_searches']))
+    ? $form_state['values']['num_searches']
+    : 0;
+
+  $form['#tree'] = TRUE;
 
   if (isset($form_state['clicked_button'])) {
     $clicked_btn = $form_state['clicked_button']['#name'];
@@ -76,10 +79,8 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
     // Get a clicked 'remove' button.
     foreach ($form_state['buttons'] as $k => $v) {
       if ($v['#name'] == $clicked_btn) {
-        if (preg_match('/edit-remove/', $v['#id'])) {
+        if (preg_match('/remove--[0-9]+$/', $v['#id'])) {
           $remove_btn = $k;
-          $hidden[] = $remove_btn;
-          variable_set('ting_carousel_search_queries_hidden', $hidden);
           break;
         }
       }
@@ -92,7 +93,7 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
   );
 
   // Get current saved queries.
-  $searches = variable_get('ting_carousel_search_queries', array());
+  $searches = variable_get('ting_search_carousel_searches', array());
 
   $index = 0;
   $count = 1;
@@ -101,16 +102,11 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
   if (isset($searches[0]['title'])) {
     $count = count($searches);
     for (; $index < $count; $index++) {
-      $form['ting_search_carousel']['ting_searches']['search_' . $index] = ting_search_carousel_query_form($searches[$index], $index);
+      $form['ting_search_carousel']['ting_searches'][$index] = ting_search_carousel_query_form($searches[$index], $index);
     }
   }
 
-  // Whether add a new query field.
-  if ($clicked_btn == 'add_query') {
-    $searches_num++;
-  }
-
-  for (; $index < $searches_num + $count; $index++) {
+  for (; $index < $num_searches + $count; $index++) {
     $unsubmitted = array();
     // Maybe prev field had some data in it...
     if (isset($form_state['input']['title'][$index])) {
@@ -121,59 +117,67 @@ function ting_search_carousel_admin_form(array $form, array &$form_state) {
       );
     }
 
-    $form['ting_search_carousel']['ting_searches']['search_' . $index] = ting_search_carousel_query_form($unsubmitted, $index);
+    $form['ting_search_carousel']['ting_searches'][$index] = ting_search_carousel_query_form($unsubmitted, $index);
   }
 
-  // Hide removed fields.
-  for ($index = 0; $index < $searches_num + $count; $index++) {
-    if (in_array($index, $hidden)) {
-      // Hide title, used to sort needed queries when saving.
-      $form['ting_search_carousel']['ting_searches']['search_' . $index]['title[]']['#value'] = '';
-      $form['ting_search_carousel']['ting_searches']['search_' . $index]['#prefix'] = '<div class="search-query-hidden">';
-      $form['ting_search_carousel']['ting_searches']['search_' . $index]['#suffix'] = '</div>';
-    }
+  if (!empty($clicked_btn) && !is_null($remove_btn)) {
+    unset($form['ting_search_carousel']['ting_searches'][$remove_btn]);
   }
 
   // Keep track of query fields count.
   $form['ting_search_carousel']['num_searches'] = array(
     '#type' => 'hidden',
-    '#value' => $searches_num,
+    '#value' => $num_searches,
   );
 
-  // Ajaxified button for new fields.
-  $form['ting_search_carousel']['new_search_carousel_button'] = array(
-    '#type' => 'button',
-    '#value' => 'Add another',
-    '#name' => 'add_query',
+  $form['ting_search_carousel']['add_search'] = array(
+    '#type' => 'submit',
+    '#value' => t('Add one more'),
+    '#submit' => array('ting_search_carousel_add_more_add_one'),
     '#ajax' => array(
-      'callback' => 'ting_search_carousel_admin_form_ajaxify',
-      'wrapper' => 'ting-search-carousel-queries',
+      'callback' => 'ting_search_carousel_ajax_callback',
+      'wrapper' => 'ting-search-carousel-wrapper',
       'method' => 'replace',
       'effect' => 'fade',
     ),
   );
 
   // Wrap the form, due to draggable items renewal.
-  $form['#prefix'] = '<div id="ting-search-carousel-queries">';
+  $form['#prefix'] = '<div id="ting-search-carousel-wrapper">';
   $form['#suffix'] = '</div>';
+
   // Custom themer, mainly used for dragable table creation.
   $form['#theme'] = array('ting_search_carousel_admin_form');
-  // Custom form submit handler.
-  $form['#submit'] = array('ting_search_carousel_search_submit');
+
+  $form['#submit'] = array('ting_search_carousel_admin_form_submit');
 
   return system_settings_form($form);
 }
 
 /**
- * AJAX responder for field addition/removal fields.
+ * Callback function for ajax add more searches.
  *
- * @param array $form
- *   Form.
+ * @see ting_search_carousel_admin_form
  *
- * @return array
- *   Changed field to be updated.
+ * @param $form
+ * @param $form_state
  */
-function ting_search_carousel_admin_form_ajaxify(array $form, array &$form_state) {
+function ting_search_carousel_add_more_add_one($form, &$form_state) {
+  $form_state['values']['num_searches']++;
+  $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Callback for searches form.
+ *
+ * @see ting_search_carousel_admin_form
+ *
+ * @param $form
+ * @param $form_state
+ *
+ * @return mixed
+ */
+function ting_search_carousel_ajax_callback($form, $form_state) {
   return $form;
 }
 
@@ -194,11 +198,11 @@ function theme_ting_search_carousel_admin_form(array $variables) {
   $rows = array();
   foreach (element_children($form['ting_search_carousel']['ting_searches']) as $key) {
     // Add class to group weight fields for drag and drop.
-    $form['ting_search_carousel']['ting_searches'][$key]['sort[]']['#attributes']['class'][] = 'sort';
+    $form['ting_search_carousel']['ting_searches'][$key]['sort']['#attributes']['class'][] = 'sort';
 
     // Get sort element.
-    $sort = $form['ting_search_carousel']['ting_searches'][$key]['sort[]'];
-    unset($form['ting_search_carousel']['ting_searches'][$key]['sort[]']);
+    $sort = $form['ting_search_carousel']['ting_searches'][$key]['sort'];
+    unset($form['ting_search_carousel']['ting_searches'][$key]['sort']);
 
     // Build rows.
     $classes = array('draggable');
@@ -237,6 +241,8 @@ function theme_ting_search_carousel_admin_form(array $variables) {
  *
  * @param array $item
  *   Values for existing query.
+ * @param int $index
+ *   Current item index.
  *
  * @return array
  *   Fields structure.
@@ -244,7 +250,7 @@ function theme_ting_search_carousel_admin_form(array $variables) {
 function ting_search_carousel_query_form($item = array(), $index = 0) {
   $form = array();
 
-  $form['sort[]'] = array(
+  $form['sort'] = array(
     '#type' => 'weight',
     '#delta' => 5,
     '#default_value' => 0,
@@ -256,7 +262,7 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
     ),
   );
 
-  $form['title[]'] = array(
+  $form['title'] = array(
     '#type' => 'textfield',
     '#title' => t('Title'),
     '#description' => t('The title of the search is used for the tab in the carousel. Keep it short.'),
@@ -264,14 +270,14 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
     '#prefix' => '<div class="search-carousel-query">',
   );
 
-  $form['subtitle[]'] = array(
+  $form['subtitle'] = array(
     '#type' => 'textfield',
     '#title' => t('Description'),
     '#description' => t('The subtitle displayed next to the search results.'),
     '#default_value' => isset($item['subtitle']) ? $item['subtitle'] : '',
   );
 
-  $form['query[]'] = array(
+  $form['query'] = array(
     '#type' => 'textfield',
     '#title' => t('Query'),
     '#maxlength' => 2048,
@@ -279,7 +285,7 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
     '#default_value' => isset($item['query']) ? $item['query'] : '',
   );
 
-  $form['remove[]'] = array(
+  $form['remove'] = array(
     '#type' => 'button',
     '#value' => t('Remove'),
     '#name' => 'remove_' . $index,
@@ -290,8 +296,8 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
     ),
     '#suffix' => '</div><div class="clearfix"></div>',
     '#ajax' => array(
-      'callback' => 'ting_search_carousel_admin_form_ajaxify',
-      'wrapper' => 'ting-search-carousel-queries',
+      'callback' => 'ting_search_carousel_ajax_callback',
+      'wrapper' => 'ting-search-carousel-wrapper',
       'method' => 'replace',
       'effect' => 'fade',
     ),
@@ -308,29 +314,24 @@ function ting_search_carousel_query_form($item = array(), $index = 0) {
  * @param array $form_state
  *   Form state.
  */
-function ting_search_carousel_search_submit(array $form, array &$form_state) {
-  $count = count($form_state['input']['title']);
+function ting_search_carousel_admin_form_submit(array $form, array &$form_state) {
+  $queries = $form_state['input']['ting_search_carousel']['ting_searches'];
+
   $searches = array();
 
-  for ($i = 0; $i < $count; $i++) {
+  foreach ($queries as $key => $query) {
     // Make an array for saving, ignoring queries w/o title.
-    if (!empty($form_state['input']['title'][$i])) {
+    if (!empty($queries[$key]['title'])) {
       $searches[] = array(
-        'title' => $form_state['input']['title'][$i],
-        'subtitle' => $form_state['input']['subtitle'][$i],
-        'query' => $form_state['input']['query'][$i]
+        'title' => $queries[$key]['title'],
+        'subtitle' => $queries[$key]['subtitle'],
+        'query' => $queries[$key]['query']
       );
     }
   }
 
-  /*
-   * @TODO: Add clear cache button and detect changes in the query input fields
-   * so only partial cache can be rebuild. This will slow down the submit but
-   * may speed up the presentation for the users by kick starting the cache.
-   */
-
   // Save the queries as a persistent variable.
-  variable_set('ting_carousel_search_queries', $searches);
+  variable_set('ting_search_carousel_searches', array_values($searches));
 
   // Clear carousel search cache.
   cache_clear_all('ting_search_carousel_search_', 'cache', TRUE);

--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -117,7 +117,7 @@ function ting_search_carousel_ctools_plugin_directory($module, $plugin) {
  * Get front page entities.
  *
  * @param int $index
- *   The ting_carousel_search_queries index to get.
+ *   The ting_search_carousel_searches index to get.
  * @param int $start
  *   Start offset.
  * @param int $count


### PR DESCRIPTION
Når jeg klikker "Fjern", så AJAX reloader den, men den har ikke fjernet tab'en men kun fjernet titlen (hvilket er nemt at overse). Man skal gemme før den forsvinder helt.

Formularen bruger heller ikke Drupals add-more functionalitet, og vægtningen er også underlig: http://platform.dandigbib.org/issues/269

Den trænger til en kærlig hånd. Man kunne evt. slå det sammen med at gøre det muligt at tilføje flere karruseller.