### PR TITLE
Issue 1736: Save pincode in user_creds

### DIFF
--- a/modules/fbs/includes/fbs.user.inc
+++ b/modules/fbs/includes/fbs.user.inc
@@ -62,6 +62,7 @@ function fbs_user_authenticate($name, $pincode) {
     // We have to save the library card number/CPR number, as the pincode
     // change call uses it.
     $result['creds']['library_card_number'] = $name;
+    $result['creds']['pass'] = $pincode;
 
     $result['user'] = array(
       'mail' => $res->patron->emailAddress,


### PR DESCRIPTION
Unlike alma and openruth fbs does NOT save pincode in user creds. Thomas may have a way of doing it in a different way, but this change makes infomedia work.