### PR TITLE
2170: introduce a type-filter on the news feed

### DIFF
--- a/modules/ding_news/ding_news.views_default.inc
+++ b/modules/ding_news/ding_news.views_default.inc
@@ -829,6 +829,7 @@ function ding_news_views_default_views() {
 
   /* Display: Library Feed */
   $handler = $view->new_display('feed', 'Library Feed', 'ding_news_library_feed');
+  $handler->display->display_options['defaults']['title'] = FALSE;
   $handler->display->display_options['pager']['type'] = 'some';
   $handler->display->display_options['pager']['options']['items_per_page'] = '20';
   $handler->display->display_options['pager']['options']['offset'] = '0';
@@ -883,7 +884,7 @@ function ding_news_views_default_views() {
     'ding_news_list_library' => 0,
     'panel_pane_2' => 0,
   );
-  $handler->display->display_options['sitename_title'] = 1;
+  $handler->display->display_options['sitename_title'] = 0;
 
   /* Display: Feed */
   $handler = $view->new_display('feed', 'Feed', 'ding_news_feed');
@@ -1889,6 +1890,7 @@ function ding_news_views_default_views() {
     t('Library Feed'),
     t('Organic Groups medlemsskab fra indhold'),
     t('Group node from OG membership'),
+    t('%1'),
     t('Feed'),
     t('Simple news list'),
     t('News list (library)'),

--- a/modules/ding_news/ding_news.views_default.inc
+++ b/modules/ding_news/ding_news.views_default.inc
@@ -834,8 +834,47 @@ function ding_news_views_default_views() {
   $handler->display->display_options['pager']['options']['offset'] = '0';
   $handler->display->display_options['style_plugin'] = 'rss';
   $handler->display->display_options['row_plugin'] = 'node_rss';
+  $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Content: Author */
+  $handler->display->display_options['relationships']['uid']['id'] = 'uid';
+  $handler->display->display_options['relationships']['uid']['table'] = 'node';
+  $handler->display->display_options['relationships']['uid']['field'] = 'uid';
+  /* Relationship: OG membership: OG membership from Node */
+  $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';
+  $handler->display->display_options['relationships']['og_membership_rel']['table'] = 'node';
+  $handler->display->display_options['relationships']['og_membership_rel']['field'] = 'og_membership_rel';
+  $handler->display->display_options['relationships']['og_membership_rel']['label'] = 'Organic Groups medlemsskab fra indhold';
+  $handler->display->display_options['relationships']['og_membership_rel']['required'] = TRUE;
+  /* Relationship: OG membership: Group Node from OG membership */
+  $handler->display->display_options['relationships']['og_membership_related_node_group']['id'] = 'og_membership_related_node_group';
+  $handler->display->display_options['relationships']['og_membership_related_node_group']['table'] = 'og_membership';
+  $handler->display->display_options['relationships']['og_membership_related_node_group']['field'] = 'og_membership_related_node_group';
+  $handler->display->display_options['relationships']['og_membership_related_node_group']['relationship'] = 'og_membership_rel';
   $handler->display->display_options['defaults']['arguments'] = FALSE;
-  $handler->display->display_options['path'] = 'node/%/news/feed';
+  /* Contextual filter: Library */
+  $handler->display->display_options['arguments']['nid']['id'] = 'nid';
+  $handler->display->display_options['arguments']['nid']['table'] = 'node';
+  $handler->display->display_options['arguments']['nid']['field'] = 'nid';
+  $handler->display->display_options['arguments']['nid']['relationship'] = 'og_membership_related_node_group';
+  $handler->display->display_options['arguments']['nid']['ui_name'] = 'Library';
+  $handler->display->display_options['arguments']['nid']['exception']['title'] = 'Alle';
+  $handler->display->display_options['arguments']['nid']['title_enable'] = TRUE;
+  $handler->display->display_options['arguments']['nid']['title'] = '%1';
+  $handler->display->display_options['arguments']['nid']['default_argument_type'] = 'fixed';
+  $handler->display->display_options['arguments']['nid']['summary']['number_of_records'] = '0';
+  $handler->display->display_options['arguments']['nid']['summary']['format'] = 'default_summary';
+  $handler->display->display_options['arguments']['nid']['summary_options']['items_per_page'] = '25';
+  /* Contextual filter: News type */
+  $handler->display->display_options['arguments']['tid']['id'] = 'tid';
+  $handler->display->display_options['arguments']['tid']['table'] = 'taxonomy_index';
+  $handler->display->display_options['arguments']['tid']['field'] = 'tid';
+  $handler->display->display_options['arguments']['tid']['ui_name'] = 'News type';
+  $handler->display->display_options['arguments']['tid']['exception']['title'] = 'Alle';
+  $handler->display->display_options['arguments']['tid']['default_argument_type'] = 'fixed';
+  $handler->display->display_options['arguments']['tid']['summary']['number_of_records'] = '0';
+  $handler->display->display_options['arguments']['tid']['summary']['format'] = 'default_summary';
+  $handler->display->display_options['arguments']['tid']['summary_options']['items_per_page'] = '25';
+  $handler->display->display_options['path'] = 'node/%/news/feed/%';
   $handler->display->display_options['displays'] = array(
     'default' => 0,
     'ding_news_frontpage_list' => 0,
@@ -1848,6 +1887,8 @@ function ding_news_views_default_views() {
     t('næste ›'),
     t('sidste »'),
     t('Library Feed'),
+    t('Organic Groups medlemsskab fra indhold'),
+    t('Group node from OG membership'),
     t('Feed'),
     t('Simple news list'),
     t('News list (library)'),
@@ -1858,6 +1899,7 @@ function ding_news_views_default_views() {
     t('news list by user'),
     t('Groups news list'),
     t('Group news'),
+    t('.'),
     t('Groups panes'),
     t('News list (groups)'),
   );


### PR DESCRIPTION
This PR introduces an optional filter on news-type to the library news filter, and fixes a bug where the feed was not filtered by library.

Before the PR eg
https://bibliotek.kk.dk/node/24/news/feed would show 20 news-items across all libraries
after the PR
https://bibliotek.kk.dk/node/24/news/feed will now only show news-items for the library node 24

Futhermore the PR makes it possible to filter further down to a specific news type, eg. 
https://bibliotek.kk.dk/node/24/news/feed/11562

Would only show news-items categorized by the news-category term with id 11562 (Servicemeddelser - lokal)