### PR TITLE
2178: Fix search backend radios for small screens

### DIFF
--- a/modules/ting_search/js/ting_search_backends.js
+++ b/modules/ting_search/js/ting_search_backends.js
@@ -8,14 +8,14 @@
    */
   $(document).ready(function() {
     // Click the label link when a radio button is clicked.
-    $('#ting-search-backend-engines-form input[type="radio"]').change(function() {
+    $('.pane-search-backends input[type="radio"]').change(function() {
       var link = $(this).parent().find('a');
       Drupal.TingSearchOverlay();
       window.location = link.attr('href');
     });
 
     // When a label link is click, also check the radio button.
-    $('#ting-search-backend-engines-form a').click(function(event) {
+    $('.pane-search-backends a').click(function(event) {
       var radio = $(this).parent().parent().find('input[type="radio"]');
       if (radio.is(':checked')) {
         // If it is already checked do nothing.


### PR DESCRIPTION
http://platform.dandigbib.org/issues/2178

Since the form is added twice, '--2' is appended to the HTML-id and the selector doesn't work. Using panel-pane class in selector targets both forms.