### PR TITLE
2300: Update module filter to 2.0

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -227,7 +227,7 @@ projects[mmeu][subdir] = "contrib"
 projects[mmeu][version] = "1.0"
 
 projects[module_filter][subdir] = "contrib"
-projects[module_filter][version] = "1.8"
+projects[module_filter][version] = "2.0"
 
 ; NanoSOAP is currently not placed in contrib at this was not the case
 ; when using recursive make files.


### PR DESCRIPTION
Release 1.x is no longer supported and thus does not receive security
updates.

The configuration options for the two modules are partly mirrored
between the two releases. The new one adds a few new options. We use 
the default configuration for the old module so we use the default configuration for the new one as well.

The new version does not introduce any new permissions so this part
does not require any changes.

The new version introduces new strings but they are purely admin
facing so do not require any updates.