### PR TITLE
2301: Update Views Bulk Operations to 3.3

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -394,7 +394,7 @@ projects[views][subdir] = "contrib"
 projects[views][version] = "3.8"
 
 projects[views_bulk_operations][subdir] = "contrib"
-projects[views_bulk_operations][version] = "3.2"
+projects[views_bulk_operations][version] = "3.3"
 
 projects[views_responsive_grid][subdir] = "contrib"
 projects[views_responsive_grid][version] = "1.3"


### PR DESCRIPTION
Release 3.2 contains a security vulnerability.

There are no changes to configuration, permissions or texts between the
two version.