### PR TITLE
2305: Patch Features against SA-CONTRIB-2016-020

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -85,6 +85,8 @@ projects[expire][version] = "2.0-rc4"
 
 projects[features][subdir] = "contrib"
 projects[features][version] = "2.0"
+; Fix for SA-CONTRIB-2016-020 - https://www.drupal.org/node/2705637
+projects[features][patch][0] = "http://cgit.drupalcode.org/features/patch/?id=c1e04f451816bd004f2096e469ec26ae9c534f3a"
 
 projects[features_extra][subdir] = "contrib"
 projects[features_extra][version] = "1.0-beta1"


### PR DESCRIPTION
This closes a security hole. The change is also included in release
2.9 but updating Features may also introduce other changes and thus
introduce risk.