### PR TITLE
2307: Update jQuery Update to 2.7

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -144,7 +144,7 @@ projects[job_scheduler][subdir] = "contrib"
 projects[job_scheduler][version] = "2.0-alpha3"
 
 projects[jquery_update][subdir] = "contrib"
-projects[jquery_update][version] = "2.6"
+projects[jquery_update][version] = "2.7"
 
 projects[languageicons][subdir] = "contrib"
 projects[languageicons][version] = "1.0"


### PR DESCRIPTION
Release 2.7 contains a security vulnerability.

There are no changes to configuration, permissions or texts between the
two version.