### PR TITLE
2308: Update Drupal Core to 7.54

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The reset of this document explains how to download Drupal and patch the core
 to run a Ding2 based site.
 
 ## Dependencies
-* [Drupal 7.43](https://drupal.org/drupal-7.43-release-notes) - latest stable
+* [Drupal 7.54](https://www.drupal.org/project/drupal/releases/7.54) - latest stable
   version of Drupal Core that ding2 have been tested on and the last stable
   release when this was written.
 * [Drush 6.1.0](https://github.com/drush-ops/drush) - latest release when this
@@ -27,13 +27,13 @@ to run a Ding2 based site.
 
 ## Drupal
 Go into your web-root (from now on named DRUPAL) and execute this drush command
-to download a fresh copy of Drupal version 7.43. If you omit the version number
+to download a fresh copy of Drupal version 7.54. If you omit the version number
 the newest version of Drupal will be downloaded.
 ```sh
-  ~$ drush dl drupal-7.43
-  ~$ mv drupal-7.43/* .
-  ~$ mv drupal-7.43/.* .
-  ~$ rm -r drupal-7.43
+  ~$ drush dl drupal-7.54
+  ~$ mv drupal-7.54/* .
+  ~$ mv drupal-7.54/.* .
+  ~$ rm -r drupal-7.54
 ```
 
 ### Patches

--- a/ding2.profile
+++ b/ding2.profile
@@ -221,7 +221,6 @@ function ding2_add_settings(&$install_state) {
     'ting_material_details',
     'ding_base',
     'ding_user_frontend',
-    'ding_path_alias',
     'ding_content',
     'ding_page',
     'ding_frontend',

--- a/drupal.make
+++ b/drupal.make
@@ -3,10 +3,9 @@ api = 2
 
 ; Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.44
+projects[drupal][version] = 7.54
 projects[drupal][patch][] = http://drupal.org/files/issues/menu-get-item-rebuild-1232346-45.patch
 projects[drupal][patch][] = http://drupal.org/files/ssl-socket-transports-1879970-13.patch
-projects[drupal][patch][] = http://www.drupal.org/files/issues/autocomplete-1232416-205-7x.patch
 projects[drupal][patch][] = http://drupal.org/files/issues/translate_role_names-2205581-1.patch
 
 ; Get the profile, which will contain the next makefile.

--- a/drupal.make
+++ b/drupal.make
@@ -2,12 +2,8 @@ core = 7.x
 api = 2
 
 ; Core
-; As d.o is having issues with the update XML file, we are using this form for downloading core.
-; See this: https://drupal.org/node/2126123
 projects[drupal][type] = core
 projects[drupal][version] = 7.44
-projects[drupal][download][type] = get
-projects[drupal][download][url] = http://ftp.drupal.org/files/projects/drupal-7.44.tar.gz
 projects[drupal][patch][] = http://drupal.org/files/issues/menu-get-item-rebuild-1232346-45.patch
 projects[drupal][patch][] = http://drupal.org/files/ssl-socket-transports-1879970-13.patch
 projects[drupal][patch][] = http://www.drupal.org/files/issues/autocomplete-1232416-205-7x.patch

--- a/modules/ding_permissions/ding_permissions.module
+++ b/modules/ding_permissions/ding_permissions.module
@@ -228,6 +228,7 @@ function ding_permissions_secure_permissions($role) {
       'administer fe promote',
       'administer features',
       'administer fieldgroups',
+      'administer fields',
       'administer file types',
       'administer files',
       'administer filters',


### PR DESCRIPTION
Drupal 7.44 has several security vulnerabilities. Updating will fix 
these.

The new version introduces a new permission “administer fields”. This
permission is only granted to administrators

Updating also means we can drop a patch as the issue it addressed was 
fixed in 7.51.

Update documentation accordingly.

The new version may introduce new strings.

The new version may introduce a few additional configuration options.
We use the defaults here.

While we are at is we also drop FTP based downloading of Drupal Core.