### PR TITLE
2317: Update metagtag to 1.21

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -223,7 +223,7 @@ projects[message][subdir] = "contrib"
 projects[message][version] = "1.10"
 
 projects[metatag][subdir] = "contrib"
-projects[metatag][version] = "1.10"
+projects[metatag][version] = "1.21"
 
 projects[mmeu][subdir] = "contrib"
 projects[mmeu][version] = "1.0"


### PR DESCRIPTION
This fixes a security vulnerability.

The new version does not introduce any configuration or permission
changes which require updates.

The new version introduces new strings but they are purely admin
facing.