### PR TITLE
2320: Update Views to 3.16

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -391,7 +391,7 @@ projects[virtual_field][subdir] = "contrib"
 projects[virtual_field][version] = "1.2"
 
 projects[views][subdir] = "contrib"
-projects[views][version] = "3.8"
+projects[views][version] = "3.16"
 
 projects[views_bulk_operations][subdir] = "contrib"
 projects[views_bulk_operations][version] = "3.2"


### PR DESCRIPTION
This fixes [multiple security vulnerabilities up until 3.15](https://www.drupal.org/project/views/releases?api_version%5B%5D=103).

We update to 3.16 as 3.15 has some changes which hav subsequently been
reverted to earlier behaviour. We do not want to risk updating the
system due to these changes only to have to change them back in a
subsequent update.

The new version may introduce new strings.

The new version may introduce new configuration options.
We use the defaults here.

The new version does not introduce any new permissions.