### PR TITLE
2321: Update Search API to 1.18

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -339,9 +339,7 @@ projects[services_views][subdir] = "contrib"
 projects[services_views][version] = "1.1"
 
 projects[search_api][subdir] = "contrib"
-projects[search_api][version] = "1.16"
-; Fix search_api warnings and notices. should be removed when upgrading to 1.17.
-projects[search_api][patch][] = "https://www.drupal.org/files/issues/2563793-9--multiple_types_issues.patch"
+projects[search_api][version] = "1.18"
 
 projects[search_api_multi][subdir] = "contrib"
 projects[search_api_multi][version] = "1.3"


### PR DESCRIPTION
This fixes [a security vulnerability](https://www.drupal.org/node/2710063).

Updating also means we can drop a patch which has been merged into
the new release.

There are no new permissions or configuration changes.

The new version does have new texts in the administrative interface.