### PR TITLE
2324: Update Organic Groups to 2.9

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -252,11 +252,7 @@ projects[oembed][version] = "1.0-rc2"
 projects[oembed][patch][] = "http://www.drupal.org/files/issues/oembed-remove_hook_sytem_info_alter-2502817-1.patch"
 
 projects[og][subdir] = "contrib"
-projects[og][version] = "2.7"
-projects[og][patch][] = "https://www.drupal.org/files/issues/entityreference_fields_do_not_validate-2249261-10.patch"
-; Fix using organic groups for relationships in views
-; https://www.drupal.org/node/1890370
-projects[og][patch][] = "https://www.drupal.org/files/issues/add-gid-to-relationship-field-1890370-34.patch"
+projects[og][version] = "2.9"
 
 projects[og_menu][subdir] = "contrib"
 projects[og_menu][version] = "3.0-rc5"


### PR DESCRIPTION
This fixes a security vulnerability.

The update also means that we can drop two patches which have been
merged into the newer version.

The new version may introduce new strings.

The new version may introduce new configuration options.
We use the defaults here.

The new version does not introduce any new permissions.