### PR TITLE
2325: Update Organic Groups Menu to 3.0

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -259,9 +259,7 @@ projects[og][patch][] = "https://www.drupal.org/files/issues/entityreference_fie
 projects[og][patch][] = "https://www.drupal.org/files/issues/add-gid-to-relationship-field-1890370-34.patch"
 
 projects[og_menu][subdir] = "contrib"
-projects[og_menu][version] = "3.0-rc5"
-; Fixes JavaScript menu selection in edit node forms.
-projects[og_menu][patch][0] = "http://drupal.org/files/issues/selector_not_found-2276951-2.patch"
+projects[og_menu][version] = "3.0"
 
 projects[opening_hours][subdir] = "contrib"
 projects[opening_hours][version] = "1.6"


### PR DESCRIPTION
This fixes a security vulnerability.

Updating also means we can drop a patch which has been merged into
the newer version of the module.

There are no new permissions, configuration options or texts in the
newer version.