### PR TITLE
Don't render empty campaigns 

### DIFF
--- a/modules/ding_campaign/plugins/content_types/campaign.inc
+++ b/modules/ding_campaign/plugins/content_types/campaign.inc
@@ -102,7 +102,10 @@ function ding_campaign_campaign_content_type_edit_form_validate($form, &$form_st
 
     // Give an error if a value less than 1 was entered.
     if (!empty($val) && $count < $min_value) {
-      form_set_error($value, t('%value must be a number larger than zero.', array('%value' => drupal_ucfirst(str_replace('_', ' ', $value)))));
+      form_set_error($value, t('%value must be a number larger than zero.',
+          array(
+            '%value' => drupal_ucfirst(str_replace('_', ' ', $value)),
+          )));
     }
     // Otherwise, store the sanitised value in the form state.
     else {

--- a/modules/ding_campaign/plugins/content_types/campaign.inc
+++ b/modules/ding_campaign/plugins/content_types/campaign.inc
@@ -38,8 +38,7 @@ function ding_campaign_campaign_content_type_render($subtype, $conf, $panel_args
   // Set default value if it was not set in panel settings.
   $style = (!empty($conf['ding_campaign_image_style'])) ? $conf['ding_campaign_image_style'] : 'medium';
 
-  $output = ding_campaign_display($context_data, $count, $offset, $style);
-  $block->content['#markup'] = drupal_render($output);
+  $block->content = ding_campaign_display($context_data, $count, $offset, $style);
 
   return $block;
 }


### PR DESCRIPTION
Don't render block content, as it'll never be empty

CTools hides the pane when empty($block->content), but an array with
an empty #markup is never empty.

Also, there's no need for drupal_render as ctools will do that for us.