### PR TITLE
2439: Fix dobbelt encoding in tabroll title

### DIFF
--- a/modules/ding_tabroll/ding_tabroll.module
+++ b/modules/ding_tabroll/ding_tabroll.module
@@ -21,43 +21,39 @@ function ding_tabroll_theme($existing, $type, $theme, $path) {
         'title' => NULL,
       ),
       'template' => 'templates/views-view-unformatted--ding-tabroll',
-      'original hook' => 'views_view_unformatted',
+      'base hook' => 'views_view_unformatted',
       'path' => $path,
-      'preprocess functions' => array(
-        'template_preprocess',
-        'template_preprocess_views_view_unformatted',
-        'ding_tabroll_preprocess',
-        'ding_tabroll_preprocess_views_view_unformatted__ding_tabroll',
-      ),
     ),
     'views_view_fields__ding_tabroll' => array(
       'arguments' => array('view' => NULL, 'options' => NULL, 'row' => NULL),
       'template' => 'templates/views-view-fields--ding-tabroll',
-      'original hook' => 'views_view_fields',
+      'base hook' => 'views_view_fields',
       'path' => $path,
-      'preprocess functions' => array(
-        'template_preprocess',
-        'template_preprocess_views_view_fields',
-        'ding_tabroll_preprocess_views_view_fields__ding_tabroll',
-      ),
     ),
   );
 }
 
 /**
- * Implements ding_tabroll_preprocess().
+ * Implements hook_preprocess_views_view_unformatted().
  *
  * Adds jQuery UI tabs and default JavaScript/CSS for the front page and
  * libraries tab-roll.
  */
-function ding_tabroll_preprocess($variables) {
-  $path = drupal_get_path('module', 'ding_tabroll');
+function ding_tabroll_preprocess_views_view_unformatted(&$variables) {
+  if ($variables['view']->name == 'ding_tabroll') {
+    $path = drupal_get_path('module', 'ding_tabroll');
 
-  // Add jQuery UI tabs library.
-  drupal_add_library('system', 'ui.tabs');
+    // Add jQuery UI tabs library.
+    drupal_add_library('system', 'ui.tabs');
 
-  // Add default CSS and JavaScript.
-  drupal_add_js($path . '/js/ding_tabroll.js');
+    // Add default CSS and JavaScript.
+    drupal_add_js($path . '/js/ding_tabroll.js');
+
+    // Add fix to get tabs rotate back.
+    // @see http://jqueryui.com/upgrade-guide/1.9/#removed-rotate-method
+    drupal_add_js($path . '/js/jquery-ui-tabs-rotate.js');
+  }
+}
 
   // Add fix to get tabs rotate back.
   // @see http://jqueryui.com/upgrade-guide/1.9/#removed-rotate-method

--- a/modules/ding_tabroll/ding_tabroll.module
+++ b/modules/ding_tabroll/ding_tabroll.module
@@ -55,9 +55,23 @@ function ding_tabroll_preprocess_views_view_unformatted(&$variables) {
   }
 }
 
-  // Add fix to get tabs rotate back.
-  // @see http://jqueryui.com/upgrade-guide/1.9/#removed-rotate-method
-  drupal_add_js($path . '/js/jquery-ui-tabs-rotate.js');
+function ding_tabroll_preprocess_views_view_fields(&$variables) {
+  if ($variables['view']->name == 'ding_tabroll') {
+    $fields = $variables['fields'];
+
+    // This is fallback if both links is left empty.
+    $url = '<front>';
+
+    // Determine if link should be internal or external.
+    if (!empty($fields['field_ding_tabroll_link']->raw)) {
+      $url = 'node/' . $fields['field_ding_tabroll_link']->raw;
+    }
+    elseif (!empty($fields['field_ding_tabroll_ext']->content)) {
+      $url = $fields['field_ding_tabroll_ext']->content;
+    }
+
+    $variables['url'] = $url;
+  }
 }
 
 /**

--- a/modules/ding_tabroll/templates/views-view-fields--ding-tabroll.tpl.php
+++ b/modules/ding_tabroll/templates/views-view-fields--ding-tabroll.tpl.php
@@ -11,6 +11,6 @@
 </div>
 
 <div class="info">
-  <h3><?php print l($fields['title']->content, $url); ?></h3>
+  <h3><?php print l($fields['title']->raw, $url); ?></h3>
   <p><?php print $fields['field_ding_tabroll_lead']->content; ?></p>
 </div>

--- a/modules/ding_tabroll/templates/views-view-fields--ding-tabroll.tpl.php
+++ b/modules/ding_tabroll/templates/views-view-fields--ding-tabroll.tpl.php
@@ -7,10 +7,10 @@
  */
 ?>
 <div class="image">
-  <?php print l($fields['field_ding_tabroll_image']->content, $fields['field_ding_tabroll_link']->raw ? 'node/' . $fields['field_ding_tabroll_link']->raw : $fields['field_ding_tabroll_ext']->content, array('html' => TRUE)); ?>
+  <?php print l($fields['field_ding_tabroll_image']->content, $url, array('html' => TRUE)); ?>
 </div>
 
 <div class="info">
-  <h3><?php print l($fields['title']->content, $fields['field_ding_tabroll_link']->raw ? 'node/' . $fields['field_ding_tabroll_link']->raw : $fields['field_ding_tabroll_ext']->content); ?></h3>
+  <h3><?php print l($fields['title']->content, $url); ?></h3>
   <p><?php print $fields['field_ding_tabroll_lead']->content; ?></p>
 </div>


### PR DESCRIPTION
http://platform.dandigbib.org/issues/2439

This also corrects hook_theme() to use the correct 'base hook' instead of 'original hook'. Se the following for more info:

https://api.drupal.org/api/views/help!api-default-views.html/7.x-3.x
https://drupal.stackexchange.com/questions/25846/how-to-tell-drupal-to-look-for-templates-in-module-directory
https://www.drupal.org/node/2106635

The problem with not using 'base hook' is that we have to specify processors manually. As we can see if we take a closer look at https://api.drupal.org/api/drupal/includes%21theme.inc/function/_theme_process_registry/7.x, this locks them down and prevents other modules and themes from using variable processors on our theme suggestion.

There seems to be a lot of misinformation about this. For example the Views doc above claims that using 'base hook' to get processors added automatically, is not possible if our module doesn't have a higher weight that module of the base hook. This doesn't seem to be true.
