### PR TITLE
Core: Update PHP requirement to 5.6 / Ubuntu 14.04 compatability

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ of the [TING concept](http://ting.dk).
 
 # Installation
 This README assumes that you have install a configured your server with a
-working Apache/Nginx, APC, Memcached, PHP 5.4 and Varnish 3.x (optional). The
+working Apache/Nginx, APC, Memcached, PHP 5.6 and Varnish 3.x (optional). The
 stack should be optimized to run a Drupal site.
 
 If you want to try out Ding2 you can download [the latest release](https://github.com/ding2/ding2/releases/latest). The `ding2-7.x-[version].tar.gz` file contain a full Drupal installation including Drupal Core, third party modules and Ding2 code needed to run the site.

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   php:
-    # We support PHP 5.4 so choose the latest version supported by Circle.
-    version: 5.4.37
+    # We support PHP 5.6 so choose the latest version supported by Circle.
+    version: 5.6.22
   node:
     # Our frontend asset pipeline requires 0.12.0 or greater.
     version: 0.12.0
@@ -12,9 +12,9 @@ machine:
 dependencies:
   post:
     # Increase memory limit to 512M. This is required by ding2.
-    - echo "memory_limit = 512M" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
+    - echo "memory_limit = 512M" > /opt/circleci/.phpenv/versions/$(phpenv global)/etc/conf.d/memory.ini
     # Disable mail sending. Sendmail is not working on Circle.
-    - echo "sendmail_path = /bin/true" > ~/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
+    - echo "sendmail_path = /bin/true" > /opt/circleci/.phpenv/versions/$(phpenv global)/etc/conf.d/sendmail.ini
     # Clean up existing global composer installation. It contains dependencies
     # which do not match the PHP version we use. This prevents installation of
     # other packages.

--- a/ding2.make
+++ b/ding2.make
@@ -42,10 +42,13 @@ projects[ctools][patch][] = "https://www.drupal.org/files/issues/ctools-readd_ac
 projects[date][subdir] = "contrib"
 projects[date][version] = "2.8"
 
-; Patch to fix empty order_id. See https://drupal.org/node/2107389
 projects[dibs][subdir] = "contrib"
 projects[dibs][version] = "1.0"
+; Patch to fix empty order_id. See https://drupal.org/node/2107389
 projects[dibs][patch][] = "http://drupal.org/files/dibs-2107389-2.patch"
+; Patch make dibs_split_payments payment_transaction_id a NOT NULL database field.
+; https://www.drupal.org/node/2812891
+projects[dibs][patch][] = "https://www.drupal.org/files/issues/mysql_5.7_compatibility-2812891-2.patch"
 
 projects[diff][subdir] = "contrib"
 projects[diff][version] = "3.2"

--- a/ding2.make
+++ b/ding2.make
@@ -221,6 +221,9 @@ projects[menu_position][version] = "1.1"
 
 projects[message][subdir] = "contrib"
 projects[message][version] = "1.10"
+; Patch messages to make message id a NOT NULL database field.
+; https://www.drupal.org/node/2051751
+projects[message][patch][0] = "https://www.drupal.org/files/message-primary_nullable-2051751-7.patch"
 
 projects[metatag][subdir] = "contrib"
 projects[metatag][version] = "1.21"

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -15,6 +15,7 @@ function bpi_schema() {
     'fields' => array(
       'id' => array(
         'type' => 'serial',
+        'not null' => TRUE
       ),
       'nid' => array(
         'type' => 'int',


### PR DESCRIPTION
The latest version of the BPI client requires PHP 5.6. We have decided
to bump the requirements for the entire platform as well.

Consequently we update our documentation and continuous integration
environment accordingly.