### PR TITLE
2293 by Inlead: Make FBS reservation error translateable.

### DIFF
--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -175,7 +175,7 @@ function fbs_reservation_create($account, $record_id, $options) {
       case 'success':
       default:
         watchdog('fbs', 'Unexpected state "@state" on failed reservaiton', array('@state' => $result->result), WATCHDOG_WARNING);
-        throw new DingProviderUserException('Unknown error from library system while attempting to reserve.');
+        throw new DingProviderUserException(t('Unknown error from library system while attempting to reserve.'));
     };
   }
 }


### PR DESCRIPTION
http://platform.dandigbib.org/issues/2293