### PR TITLE
2540: Fixed. Text-align right removed for items in user-menu

### DIFF
--- a/themes/ddbasic/sass/components/menu.scss
+++ b/themes/ddbasic/sass/components/menu.scss
@@ -502,7 +502,6 @@ ul.topbar-menu {
     }
 
     li {
-      text-align: right;
       margin: 0;
 
       &.user-log-out {


### PR DESCRIPTION
http://platform.dandigbib.org/issues/2540