### PR TITLE
Core: Remove version information from non-release branch

### DIFF
--- a/ding2.info
+++ b/ding2.info
@@ -3,7 +3,6 @@ description = Install a Ding based library site.
 core = 7.x
 distribution_name = "Ding 2"
 exclusive = TRUE
-version = 7.x-4.0.0-beta2
 
 ; Core modules.
 dependencies[] = block

--- a/ding2.make
+++ b/ding2.make
@@ -438,7 +438,7 @@ projects[xautoload][version] = "5.7"
 libraries[bpi-client][destination] = "modules/bpi/lib"
 libraries[bpi-client][download][type] = "git"
 libraries[bpi-client][download][url] = "http://github.com/ding2/bpi-client.git"
-libraries[bpi-client][download][tag] = "7.x-4.0.0-beta2"
+libraries[bpi-client][download][branch] = "master"
 
 libraries[ckeditor][download][type] = "get"
 libraries[ckeditor][download][url] = http://download.cksource.com/CKEditor/CKEditor/CKEditor%204.4.7/ckeditor_4.4.7_full.zip
@@ -492,7 +492,7 @@ libraries[psr7][destination] = "libraries"
 
 libraries[ting-client][download][type] = "git"
 libraries[ting-client][download][url] = "http://github.com/ding2/ting-client.git"
-libraries[ting-client][download][tag] = "7.x-4.0.0-beta2"
+libraries[ting-client][download][branch] = "master"
 libraries[ting-client][destination] = "modules/ting/lib"
 
 libraries[zen-grids][download][type] = "git"

--- a/drupal.make
+++ b/drupal.make
@@ -12,4 +12,4 @@ projects[drupal][patch][] = http://drupal.org/files/issues/translate_role_names-
 projects[ding2][type] = "profile"
 projects[ding2][download][type] = "git"
 projects[ding2][download][url] = "git@github.com:ding2/ding2.git"
-projects[ding2][download][tag] = "7.x-4.0.0-beta2"
+projects[ding2][download][branch] = "master"


### PR DESCRIPTION
Otherwise builds will include obsolete versions of the code.