### PR TITLE
2330: Add media permissions to more roles

### DIFF
--- a/modules/ding_permissions/ding_permissions.module
+++ b/modules/ding_permissions/ding_permissions.module
@@ -178,6 +178,8 @@ function ding_permissions_secure_permissions($role) {
       'use personalisation',
     ),
     'administrators' => array(
+      'access media browser',
+      'use media wysiwyg',
       'administer serendipity panes',
       'access administration pages',
       'access administration menu',
@@ -521,6 +523,8 @@ function ding_permissions_secure_permissions($role) {
       'administer personalisation',
     ),
     'editor' => array(
+      'access media browser',
+      'use media wysiwyg',
       'eck add ding_type ding_interaction entities',
       'eck edit ding_type ding_interaction entities',
       'eck delete ding_type ding_interaction entities',
@@ -673,6 +677,8 @@ function ding_permissions_secure_permissions($role) {
       'view the administration theme',
     ),
     'guest blogger' => array(
+      'access media browser',
+      'use media wysiwyg',
       'access administration menu',
       'access environment indicator',
       'access environment indicator development',


### PR DESCRIPTION
Admins, editors and guest bloggers should also have access to the
media module to be able to create content with images and video.