### PR TITLE
2544: Revert required-state introduced by features

### DIFF
--- a/modules/fbs/fbs.info
+++ b/modules/fbs/fbs.info
@@ -47,4 +47,10 @@ files[] = includes/classes/FBSLogInterface.php
 files[] = includes/classes/FBSLogStdout.php
 files[] = includes/classes/FBS.php
 mtime = 1499431707
-required = 1
+# Features will mark any module that implements hook_field_info() as required.
+# This causes the module to be enabled automatically during site-install, which
+# in the case of a Ding-provider is a problem.
+# To prevent "required = 1" line below has been commented out. When a future
+# feature-export reintroduce the line make sure to ignore it and keep this
+# block of comments and the out-commented line intact.
+# required = 1


### PR DESCRIPTION
https://github.com/ding2/ding2/pull/701 introduced a change to fbs.info that made the module required which causes it to be enabled during site-install regardless of which other provider is specified.

This PR out-comments the line, and adds a warning that will hopefully prevent the line to be re-introduced as a part of a feature-update.

The original change was made as part of https://platform.dandigbib.org/issues/2544