### PR TITLE
2565 by Inlead: Enable ding_mobilesearch during new installations.

### DIFF
--- a/ding2.profile
+++ b/ding2.profile
@@ -661,6 +661,7 @@ function ding2_module_enable(&$install_state) {
   $modules[] = 'l10n_update';
   $modules[] = 'ting_infomedia';
   $modules[] = 'ding_eresource';
+  $modules[] = 'ding_mobilesearch';
 
   $operations = ding2_module_list_as_operations($modules);
 


### PR DESCRIPTION
https://platform.dandigbib.org/issues/2565