### PR TITLE
2861: Field-group name added as class. Field removed from view-mode

### DIFF
--- a/modules/ding_ddbasic/ding_ddbasic.module
+++ b/modules/ding_ddbasic/ding_ddbasic.module
@@ -117,3 +117,24 @@ function ding_ddbasic_module_implements_alter(&$implementations, $hook) {
     $implementations['ding_ddbasic'] = $group;
   }
 }
+
+/**
+ * Implements hook_field_group_pre_render().
+ *
+ * This function gives you the oppertunity to create the given
+ * wrapper element that can contain the fields.
+ * In the example beneath, some variables are prepared and used when building the
+ * actual wrapper element. All elements in drupal fapi can be used.
+ *
+ * Note that at this point, the field group has no notion of the fields in it.
+ *
+ * There is also an alternative way of handling this. The default implementation
+ * within field_group calls "field_group_pre_render_<format_type>".
+ * @see field_group_pre_render_fieldset.
+ *
+ * @param Array $elements by address.
+ * @param Object $group The Field group info.
+ */
+function ding_ddbasic_field_group_pre_render(& $element, $group, & $form) {
+  $group->format_settings['instance_settings']['classes'] .= ' ' . drupal_html_class($group->group_name);
+}

--- a/modules/ding_ddbasic/ding_ddbasic.module
+++ b/modules/ding_ddbasic/ding_ddbasic.module
@@ -136,5 +136,5 @@ function ding_ddbasic_module_implements_alter(&$implementations, $hook) {
  * @param Object $group The Field group info.
  */
 function ding_ddbasic_field_group_pre_render(& $element, $group, & $form) {
-  $group->format_settings['instance_settings']['classes'] .= ' ' . drupal_html_class($group->group_name);
+  $group->format_settings['instance_settings']['classes'] .= ' field-group-format ' . drupal_html_class($group->group_name);
 }

--- a/modules/ding_ddbasic/ding_ddbasic.module
+++ b/modules/ding_ddbasic/ding_ddbasic.module
@@ -120,21 +120,7 @@ function ding_ddbasic_module_implements_alter(&$implementations, $hook) {
 
 /**
  * Implements hook_field_group_pre_render().
- *
- * This function gives you the oppertunity to create the given
- * wrapper element that can contain the fields.
- * In the example beneath, some variables are prepared and used when building the
- * actual wrapper element. All elements in drupal fapi can be used.
- *
- * Note that at this point, the field group has no notion of the fields in it.
- *
- * There is also an alternative way of handling this. The default implementation
- * within field_group calls "field_group_pre_render_<format_type>".
- * @see field_group_pre_render_fieldset.
- *
- * @param Array $elements by address.
- * @param Object $group The Field group info.
  */
-function ding_ddbasic_field_group_pre_render(& $element, $group, & $form) {
+function ding_ddbasic_field_group_pre_render(&$element, $group, &$form) {
   $group->format_settings['instance_settings']['classes'] .= ' field-group-format ' . drupal_html_class($group->group_name);
 }

--- a/modules/ting_material_details/ting_material_details.features.field_instance.inc
+++ b/modules/ting_material_details/ting_material_details.features.field_instance.inc
@@ -59,7 +59,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 14,
+        'weight' => 15,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -138,7 +138,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 27,
+        'weight' => 26,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -217,7 +217,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 28,
+        'weight' => 27,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -296,7 +296,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 26,
+        'weight' => 25,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -375,7 +375,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 25,
+        'weight' => 24,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -454,7 +454,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 30,
+        'weight' => 29,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -533,7 +533,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 24,
+        'weight' => 23,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -612,7 +612,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 29,
+        'weight' => 28,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -691,7 +691,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 34,
+        'weight' => 33,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -770,7 +770,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 35,
+        'weight' => 34,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -928,7 +928,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 33,
+        'weight' => 32,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1007,7 +1007,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 32,
+        'weight' => 31,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1087,7 +1087,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 31,
+        'weight' => 30,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1166,7 +1166,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 23,
+        'weight' => 22,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1245,7 +1245,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 21,
+        'weight' => 20,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1324,7 +1324,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 13,
+        'weight' => 14,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1403,7 +1403,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 22,
+        'weight' => 21,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1482,7 +1482,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 12,
+        'weight' => 13,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1561,7 +1561,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 11,
+        'weight' => 12,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1719,7 +1719,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 10,
+        'weight' => 11,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1798,7 +1798,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 15,
+        'weight' => 16,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1877,7 +1877,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 16,
+        'weight' => 17,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1956,10 +1956,9 @@ function ting_material_details_field_default_field_instances() {
       ),
       'teaser' => array(
         'label' => 'hidden',
-        'module' => 'ting_material_details',
         'settings' => array(),
-        'type' => 'ting_details_single',
-        'weight' => 44,
+        'type' => 'hidden',
+        'weight' => 3,
       ),
       'ting_reference_preview' => array(
         'label' => 'hidden',
@@ -2038,7 +2037,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 20,
+        'weight' => 19,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -2117,7 +2116,7 @@ function ting_material_details_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 19,
+        'weight' => 18,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -39,7 +39,7 @@
           }
         }
       }
-      .group_text {
+      .group-text {
         @include transition(
           left $speed $ease,
           width $speed $ease,
@@ -56,7 +56,7 @@
           pointer-events: none;
         }
 
-        .group_inner {
+        .group-inner {
           position: relative;
           background: linear-gradient($charcoal 0%, $charcoal-opacity-extra-dark 100%);
           &::after {
@@ -86,12 +86,12 @@
         z-index: 2;
       }
       &.move-right {
-        .group_text {
+        .group-text {
           left: 100%;
         }
       }
       &.move-left {
-        .group_text {
+        .group-text {
           left: -158.53659%;
         }
       }
@@ -176,7 +176,7 @@
             width: getColumn(3 of 2);
             background: $charcoal;
             box-shadow: $box-shadow;
-            .group_inner {
+            .group-inner {
               &::after {
                 @include transition(
                   opacity $speed-fast $hover-delay $ease


### PR DESCRIPTION
https://platform.dandigbib.org/issues/2861

The field_group module was updated in this issue https://platform.dandigbib.org/issues/1905

After the update the field-group name was no longer printet out as a class. We have added a pre render to do this.

Furthermore a field has been removed from the teaser view-mode, and the correct class-names are used in the scss.