### PR TITLE
Revert "2565 by Inlead: Enable ding_mobilesearch during new installations."

### DIFF
--- a/ding2.profile
+++ b/ding2.profile
@@ -661,7 +661,6 @@ function ding2_module_enable(&$install_state) {
   $modules[] = 'l10n_update';
   $modules[] = 'ting_infomedia';
   $modules[] = 'ding_eresource';
-  $modules[] = 'ding_mobilesearch';
 
   $operations = ding2_module_list_as_operations($modules);
 


### PR DESCRIPTION
Reverts ding2/ding2#791

Installing ding_mobilesearch as a part of the installation process breaks the installer.