### PR TITLE
2998: Underline removed from wysiwyg

### DIFF
--- a/modules/ding_content/ding_content.features.wysiwyg.inc
+++ b/modules/ding_content/ding_content.features.wysiwyg.inc
@@ -25,7 +25,6 @@ function ding_content_wysiwyg_default_profiles() {
         'default' => array(
           'Bold' => 1,
           'Italic' => 1,
-          'Underline' => 1,
           'JustifyLeft' => 1,
           'JustifyCenter' => 1,
           'JustifyRight' => 1,


### PR DESCRIPTION
https://platform.dandigbib.org/issues/2998