### PR TITLE
1770: fixes for carousels

### DIFF
--- a/modules/ding_carousel/ding_carousel.theme.inc
+++ b/modules/ding_carousel/ding_carousel.theme.inc
@@ -23,6 +23,17 @@ function template_preprocess_ding_carousel(&$vars) {
     );
   }
 
+  // This is an empty carousel, which slick don't handle well (as in it will
+  // make a infinite loop and kill the browser). So e.g. 0 hits search
+  // carousel's are fixed here be simply placing a single placeholder slide.
+  if (empty($vars['items'])) {
+    $vars['items'][] = array(
+      '#type' => 'ding_carousel_item',
+      '#content' => $carousel['#placeholder'],
+      '#placeholder' => TRUE,
+    );
+  }
+
   // Fill up with placeholders if there's not enough items.
   if (count($vars['items']) < $carousel['#placeholders']) {
     while (count($vars['items']) < $carousel['#placeholders']) {

--- a/modules/p2/ding_list/ding_list.module
+++ b/modules/p2/ding_list/ding_list.module
@@ -215,6 +215,7 @@ function ding_list_menu() {
     'page callback' => 'ding_list_carousel_ajax',
     'page arguments' => array(3, 4),
     'access callback' => 'ding_list_user_has_access',
+    'access arguments' => array(3),
     'file' => 'include/menu_callbacks.inc',
     'type' => MENU_CALLBACK,
   );

--- a/modules/p2/ding_list/include/functions.inc
+++ b/modules/p2/ding_list/include/functions.inc
@@ -802,7 +802,7 @@ function ding_list_get_permission_permissions($permission = FALSE) {
 /**
  * Check if a user has access to a list, with the given permissions.
  *
- * @param mixed $list
+ * @param object|int $list
  *   List entity or the lists id.
  * @param string $permission
  *   The permission to check against.
@@ -818,16 +818,16 @@ function ding_list_get_permission_permissions($permission = FALSE) {
 function ding_list_user_has_access($list, $permission = DING_LIST_PERMISSION_VIEW, $account = NULL, $token = FALSE) {
   $access = &drupal_static(__FUNCTION__, array());
 
-  // If used as menu access callback the list have to be loaded.
-  if (is_numeric($list)) {
-    $list = ding_list_get_list($list);
-  }
-
   // The access key is the key used by the static cache, and it's a unique key
   // defined by all the arguments given the function.
   $access_key = md5(serialize(func_get_args()));
   if (isset($access[$access_key])) {
     return $access[$access_key];
+  }
+
+  // If used as menu access callback the list have to be loaded.
+  if (is_numeric($list)) {
+    $list = ding_list_get_list($list);
   }
 
   if (ding_base_get_value('ding_type', $list, 'field_list_type') == DING_LIST_TYPE_LOAN_HISTORY

--- a/modules/p2/ding_list/include/functions.inc
+++ b/modules/p2/ding_list/include/functions.inc
@@ -802,8 +802,8 @@ function ding_list_get_permission_permissions($permission = FALSE) {
 /**
  * Check if a user has access to a list, with the given permissions.
  *
- * @param object $list
- *   List entity.
+ * @param mixed $list
+ *   List entity or the lists id.
  * @param string $permission
  *   The permission to check against.
  * @param object $account
@@ -817,6 +817,11 @@ function ding_list_get_permission_permissions($permission = FALSE) {
  */
 function ding_list_user_has_access($list, $permission = DING_LIST_PERMISSION_VIEW, $account = NULL, $token = FALSE) {
   $access = &drupal_static(__FUNCTION__, array());
+
+  // If used as menu access callback the list have to be loaded.
+  if (is_numeric($list)) {
+    $list = ding_list_get_list($list);
+  }
 
   // The access key is the key used by the static cache, and it's a unique key
   // defined by all the arguments given the function.

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -1001,11 +1001,13 @@ function ddbasic_preprocess_form_element(&$variables) {
 function ddbasic_preprocess_ding_carousel(&$variables) {
   // Add ajax to make reserve links work.
   drupal_add_library('system', 'drupal.ajax');
+  drupal_add_library('system', 'ui.widget');
 
   // The ding carousel's do not use the standard Drupal ajax API so it doesn't
-  // automatically include availability and covers handling.
+  // automatically include availability, covers and rating handling.
   drupal_add_js(drupal_get_path('module', 'ding_availability') . '/js/ding_availability.js');
   drupal_add_js(drupal_get_path('module', 'ting_covers') . '/js/ting-covers.js');
+  drupal_add_js(drupal_get_path('module', 'ding_entity_rating') . '/js/ding_entity_rating.js');
 }
 
 /**


### PR DESCRIPTION
* Fixed access callback for ajax loading ding lists in carousels
* Ensures that 0-hit search carousel don't make infinite loop in JS. 
* Fixes ratings in carousel items.

See https://platform.dandigbib.org/issues/1770