### PR TITLE
3073: FBS session cache

### DIFF
--- a/modules/alma/alma.module
+++ b/modules/alma/alma.module
@@ -775,7 +775,7 @@ function alma_field_attach_view_alter(&$output, $context) {
  */
 function alma_ding_session_cache_defaults() {
   return array(
-    'titel' => 'Alma (reservations, loans)',
+    'title' => 'Alma (reservations, loans)',
     'enabled' => TRUE,
     'expire' => 3600,
   );

--- a/modules/ding_loan/ding_loan.module
+++ b/modules/ding_loan/ding_loan.module
@@ -50,6 +50,6 @@ function ding_loan_ding_session_cache_defaults() {
   return array(
     'title' => 'Ding loans',
     'enabled' => TRUE,
-    'expire' => 3600,
+    'expire' => 60,
   );
 }

--- a/modules/ding_loan/ding_loan.module
+++ b/modules/ding_loan/ding_loan.module
@@ -48,7 +48,7 @@ function ding_loan_sort_expiry($a, $b) {
  */
 function ding_loan_ding_session_cache_defaults() {
   return array(
-    'titel' => 'Ding loans',
+    'title' => 'Ding loans',
     'enabled' => TRUE,
     'expire' => 3600,
   );

--- a/modules/ding_loan/ding_loan.module
+++ b/modules/ding_loan/ding_loan.module
@@ -50,6 +50,6 @@ function ding_loan_ding_session_cache_defaults() {
   return array(
     'title' => 'Ding loans',
     'enabled' => TRUE,
-    'expire' => 60,
+    'expire' => 3600,
   );
 }

--- a/modules/ding_provider/ding_provider.debt.inc
+++ b/modules/ding_provider/ding_provider.debt.inc
@@ -84,4 +84,18 @@ class DingProviderDebt extends DingEntityBase {
     );
     $this->_populate($properties, $data);
   }
+
+  /**
+   * Ensures that properties are populated on deserialization.
+   */
+  public function __wakeup() {
+    foreach (get_object_vars($this) as $prop => $val) {
+      if (isset($this->properties[$prop]) && $this->properties[$prop] === self::NULL) {
+        $this->properties[$prop] = $val;
+      }
+      elseif (isset($this->properties[$prop])) {
+        $this->$prop = $this->properties[$prop];
+      }
+    }
+  }
 }

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -1096,7 +1096,7 @@ function ding_reservation_ding_session_cache_defaults() {
   return array(
     'title' => 'Ding reservation',
     'enabled' => TRUE,
-    'expire' => 3600,
+    'expire' => 60,
   );
 }
 

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -1094,7 +1094,7 @@ function ding_reservation_cache_clear() {
  */
 function ding_reservation_ding_session_cache_defaults() {
   return array(
-    'titel' => 'Ding reservation',
+    'title' => 'Ding reservation',
     'enabled' => TRUE,
     'expire' => 3600,
   );

--- a/modules/ding_session_cache/ding_session_cache.module
+++ b/modules/ding_session_cache/ding_session_cache.module
@@ -86,18 +86,21 @@ function ding_session_cache_set($module, $cid, $data) {
  *   Name of the module that the date is stored under (prefix).
  * @param string $cid
  *   Index data is stored under.
+ * @param bool $default
+ *   Default value if cache for the $cid is empty.
  *
  * @return mixed
  *   If data found it's returned else FALSE.
  */
-function ding_session_cache_get($module, $cid) {
+function ding_session_cache_get($module, $cid, $default = FALSE) {
   if (_ding_session_cache_enabled($module)) {
     $cache = cache_get(_ding_session_cache_get_cid($module, $cid), 'cache_ding_session_cache');
     if (isset($cache->expire) && $cache->expire > REQUEST_TIME) {
       return $cache->data;
     }
   }
-  return FALSE;
+
+  return $default;
 }
 
 /**

--- a/modules/ding_session_cache/ding_session_cache.module
+++ b/modules/ding_session_cache/ding_session_cache.module
@@ -38,7 +38,7 @@ function ding_session_cache_form_system_performance_settings_alter(&$form, &$for
       $result = $function();
       $form['ding_session_cache'][$module] = array(
         '#type' => 'fieldset',
-        '#title' => $result['titel'],
+        '#title' => $result['title'],
         'enabled' => array(
           '#type' => 'checkbox',
           '#title' => 'Enabled',
@@ -47,7 +47,7 @@ function ding_session_cache_form_system_performance_settings_alter(&$form, &$for
         'expire' => array(
           '#type' => 'select',
           '#title' => t('Maximum cache lifetime'),
-          '#default_value' => isset($defaults[$module]['expire']) ? $defaults[$module]['expire'] : $result['enabled'],
+          '#default_value' => isset($defaults[$module]['expire']) ? $defaults[$module]['expire'] : $result['expire'],
           '#options' => $period,
         ),
       );

--- a/modules/ding_session_cache/ding_session_cache.module
+++ b/modules/ding_session_cache/ding_session_cache.module
@@ -90,7 +90,8 @@ function ding_session_cache_set($module, $cid, $data) {
  *   Default value if cache for the $cid is empty.
  *
  * @return mixed
- *   If data found it's returned else FALSE.
+ *   If data found it's returned else the default parameters value. If no
+ *   default value is given FALSE is returned.
  */
 function ding_session_cache_get($module, $cid, $default = FALSE) {
   if (_ding_session_cache_enabled($module)) {

--- a/modules/fbs/fbs.info
+++ b/modules/fbs/fbs.info
@@ -5,6 +5,7 @@ package = Providers
 dependencies[] = date_popup
 dependencies[] = ding_provider
 dependencies[] = ding_reservation
+dependencies[] = ding_session_cache
 dependencies[] = ding_user
 dependencies[] = entity
 dependencies[] = features

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -29,6 +29,20 @@ function fbs_xautoload($adapter) {
 }
 
 /**
+ * Implements hook_ding_session_cache_defaults().
+ *
+ * Set default ding_session_cache settings and tell ding_session_cache that this
+ * module supports it.
+ */
+function fbs_ding_session_cache_defaults() {
+  return array(
+    'title' => 'FBS (information from FBS)',
+    'enabled' => TRUE,
+    'expire' => 3600,
+  );
+}
+
+/**
  * Implements hook_libraries_info().
  *
  * For defining external libraries.

--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -10,97 +10,117 @@
  *
  * @param object $account
  *   User to get debt listing for.
+ * @param bool $reset
+ *   If TRUE cache is reset (default: FALSE)
  *
  * @return array
  *   Debt information.
  */
-function fbs_debt_list($account) {
-  $result = array();
-  $res = array();
+function fbs_debt_list($account, $reset = FALSE) {
+  $results = &drupal_static(__FUNCTION__, NULL);
 
-  try {
-    $res = fbs_service()->Payment->getFees(fbs_service()->agencyId, fbs_patron_id($account), FALSE, FALSE);
-  }
-  catch (Exception $e) {
-    watchdog_exception('fbs', $e);
-  }
+  if (is_null($results) || $reset) {
+    // Check if ding_session_cache is available.
+    if (module_exists('ding_session_cache') && !$reset) {
+      $results = ding_session_cache_get('fbs', 'debt', NULL);
+    }
 
-  $ids = array();
-  foreach ($res as $fee) {
-    foreach ($fee->materials as $material) {
-      $ids[$material->recordId] = $material->recordId;
+    // If both static cache and session cache failed, try reloading information
+    // from FBS.
+    if (is_null($results) || $reset) {
+      $results = array();
+      $res = array();
+
+      try {
+        $res = fbs_service()->Payment->getFees(fbs_service()->agencyId, fbs_patron_id($account), FALSE, FALSE);
+      }
+      catch (Exception $e) {
+        watchdog_exception('fbs', $e);
+      }
+
+      $ids = array();
+      foreach ($res as $fee) {
+        foreach ($fee->materials as $material) {
+          $ids[$material->recordId] = $material->recordId;
+        }
+      }
+
+      // Translate record ids and preload entities.
+      if ($ids) {
+        $ids = ding_provider_build_entity_id($ids);
+        $entities = array();
+        // Since ding_entitye_load_multiple() returns array keyed by local tid, we
+        // make e new array keyed by data well PiD.
+        foreach (ding_entity_load_multiple(array_filter($ids)) as $key => $entity) {
+          $entities[$entity->ding_entity_id] = $entity;
+        }
+      }
+
+      foreach ($res as $fee) {
+        $id = $fee->feeId;
+
+        $data = array(
+          'date' => $fee->creationDate,
+          'display_name' => $fee->reasonMessage,
+          // FBS only provides the amount left to be paid on each fee, so this
+          // will only reflect that.
+          'amount' => $fee->amount,
+          // And the only thing we can do here is set it to zero, as the original
+          // amount isn't available.
+          'amount_paid' => 0,
+          'invoice_number' => NULL,
+          'type' => $fee->reasonMessage,
+        );
+
+        // If the has associated materials; collect some information about them and
+        // try to build a more useful title.
+        $materials = array();
+        foreach ($fee->materials as $material) {
+          $ding_entity_id = $ids[$material->recordId];
+          if (isset($entities[$ding_entity_id])) {
+            $entity = $entities[$ding_entity_id];
+            // Create title that links to the object.
+            $uri = entity_uri('ting_object', $entity);
+
+            $title = t('@material_title (@material_number)', array(
+              '@material_title' => $entity->getTitle(),
+              '@material_number' => $material->materialItemNumber,
+            ));
+            $materials[] = l($title, $uri['path'], $uri['options']);
+          }
+          else {
+            // TODO: Maybe we can do better before falling back to this. E.g. like
+            // trying to use a pseudo entity like ding_reservation.
+            $materials[] = t('Unknown material (@material_number)', array(
+              '@material_number' => $material->materialItemNumber,
+            ));
+          }
+        }
+
+        if (!empty($materials)) {
+          // Apply som inline span-elements, so the different materials in the
+          // display_name can be easily styled.
+          $data['display_name'] = '<span>' . implode('</span><span>', $materials) . '</span>';
+
+          if (count($materials) == 1) {
+            $data['material_type'] = !empty($entity) ? $entity->type : t('Unknown type');
+          }
+          else {
+            $data['material_type'] = t('Multiple materials');
+          }
+        }
+
+        $results[$id] = new DingProviderDebt($id, $data);
+      }
+
+      // Store the loans into ding session cache.
+      if (module_exists('ding_session_cache')) {
+        ding_session_cache_set('fbs', 'debt', $results);
+      }
     }
   }
 
-  // Translate record ids and preload entities.
-  if ($ids) {
-    $ids = ding_provider_build_entity_id($ids);
-    $entities = array();
-    // Since ding_entitye_load_multiple() returns array keyed by local tid, we
-    // make e new array keyed by data well PiD.
-    foreach (ding_entity_load_multiple(array_filter($ids)) as $key => $entity) {
-      $entities[$entity->ding_entity_id] = $entity;
-    }
-  }
-
-  foreach ($res as $fee) {
-    $id = $fee->feeId;
-
-    $data = array(
-      'date' => $fee->creationDate,
-      'display_name' => $fee->reasonMessage,
-      // FBS only provides the amount left to be paid on each fee, so this
-      // will only reflect that.
-      'amount' => $fee->amount,
-      // And the only thing we can do here is set it to zero, as the original
-      // amount isn't available.
-      'amount_paid' => 0,
-      'invoice_number' => NULL,
-      'type' => $fee->reasonMessage,
-    );
-
-    // If the has associated materials; collect some information about them and
-    // try to build a more useful title.
-    $materials = array();
-    foreach ($fee->materials as $material) {
-      $ding_entity_id = $ids[$material->recordId];
-      if (isset($entities[$ding_entity_id])) {
-        $entity = $entities[$ding_entity_id];
-        // Create title that links to the object.
-        $uri = entity_uri('ting_object', $entity);
-
-        $title = t('@material_title (@material_number)', array(
-          '@material_title' => $entity->getTitle(),
-          '@material_number' => $material->materialItemNumber,
-        ));
-        $materials[] = l($title, $uri['path'], $uri['options']);
-      }
-      else {
-        // TODO: Maybe we can do better before falling back to this. E.g. like
-        // trying to use a pseudo entity like ding_reservation.
-        $materials[] = t('Unknown material (@material_number)', array(
-          '@material_number' => $material->materialItemNumber,
-        ));
-      }
-    }
-
-    if (!empty($materials)) {
-      // Apply som inline span-elements, so the different materials in the
-      // display_name can be easily styled.
-      $data['display_name'] = '<span>' . implode('</span><span>', $materials) . '</span>';
-
-      if (count($materials) == 1) {
-        $data['material_type'] = !empty($entity) ? $entity->type : t('Unknown type');
-      }
-      else {
-        $data['material_type'] = t('Multiple materials');
-      }
-    }
-
-    $result[$id] = new DingProviderDebt($id, $data);
-  }
-
-  return $result;
+  return $results;
 }
 
 /**
@@ -144,6 +164,11 @@ function fbs_debt_payment_received($account, $debt_ids = array(), $order_id = NU
       watchdog('fbs', 'Could not register payment for patron @patron_id, order id @order_id, fee id @fee_id', $variables, WATCHDOG_ERROR);
       return FALSE;
     }
+  }
+
+  // Clear ding session cache.
+  if (module_exists('ding_session_cache')) {
+    ding_session_cache_clear('fbs', 'debt');
   }
 
   return TRUE;

--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -166,5 +166,10 @@ function fbs_debt_payment_received($account, $debt_ids = array(), $order_id = NU
     }
   }
 
+  // Clear ding session cache.
+  if (module_exists('ding_session_cache')) {
+    ding_session_cache_clear('fbs', 'debt');
+  }
+
   return TRUE;
 }

--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -166,10 +166,5 @@ function fbs_debt_payment_received($account, $debt_ids = array(), $order_id = NU
     }
   }
 
-  // Clear ding session cache.
-  if (module_exists('ding_session_cache')) {
-    ding_session_cache_clear('fbs', 'debt');
-  }
-
   return TRUE;
 }

--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -11,7 +11,7 @@
  * @param object $account
  *   User to get debt listing for.
  * @param bool $reset
- *   If TRUE cache is reset (default: FALSE)
+ *   If TRUE cache is reset (default: FALSE).
  *
  * @return array
  *   Debt information.

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -10,61 +10,82 @@
  *
  * @param object $account
  *   User to fetch list for.
+ * @param bool $reset
+ *   If TRUE cache is reset (default: FALSE)
  *
  * @return array
  *   Loan information.
  */
-function fbs_loan_list($account) {
-  $res = array();
-  try {
-    $res = fbs_service()->MaterialLoans->getLoans(fbs_service()->agencyId, fbs_patron_id($account));
-  }
-  catch (Exception $e) {
-    watchdog_exception('fbs', $e);
-  }
+function fbs_loan_list($account, $reset = FALSE) {
+  $results = &drupal_static(__FUNCTION__, array());
 
-  $ids = array();
-  foreach ($res as $loan) {
-    $ids[$loan->loanDetails->recordId] = $loan->loanDetails->recordId;
-  }
-  $ids = ding_provider_build_entity_id($ids);
-
-  $result = array();
-  foreach ($res as $loan) {
-    $id = $loan->loanDetails->loanId;
-
-    $loan_data = array(
-      'ding_entity_id' => $ids[$loan->loanDetails->recordId],
-      'loan_date' => $loan->loanDetails->loanDate,
-      'expiry' => $loan->loanDetails->dueDate,
-      'renewable' => $loan->isRenewable,
-      'materials_number' => $loan->loanDetails->materialItemNumber,
-    );
-
-    // If this is a periodical, add in issue data.
-    if (isset($loan->loanDetails->periodical)) {
-      $periodical = $loan->loanDetails->periodical;
-      $vol = $periodical->volume;
-      if (!empty($periodical->volumeNumber)) {
-        $vol .= '.' . $periodical->volumeNumber;
-      }
-      if (!empty($periodical->volumeYear)) {
-        $loan_data['notes'] = t('Issue @vol, @year', array('@vol' => $vol, '@year' => $periodical->volumeYear));
-      }
-      else {
-        $loan_data['notes'] = t('Issue @vol', array('@vol' => $vol));
-      }
+  if (empty($results) || $reset) {
+    // Check if ding_session_cache is available.
+    if (module_exists('ding_session_cache') && !$reset) {
+      $results = ding_session_cache_get('fbs', 'loans');
     }
 
-    // Handle inter library loans.
-    if (!empty($loan->loanDetails->ilBibliographicRecord)) {
-      $loan_data['display_name'] = $loan->loanDetails->ilBibliographicRecord->title;
-    }
+    // If both static cache and session cache failed, try reloading information
+    // from FBS.
+    if (empty($results) || $reset) {
+      $res = array();
+      try {
+        $res = fbs_service()->MaterialLoans->getLoans(fbs_service()->agencyId, fbs_patron_id($account));
+      } catch (Exception $e) {
+        watchdog_exception('fbs', $e);
+      }
 
-    $result[$id] = new DingProviderLoan($id, $loan_data);
+      $ids = array();
+      foreach ($res as $loan) {
+        $ids[$loan->loanDetails->recordId] = $loan->loanDetails->recordId;
+      }
+      $ids = ding_provider_build_entity_id($ids);
+
+      foreach ($res as $loan) {
+        $id = $loan->loanDetails->loanId;
+
+        $loan_data = array(
+          'ding_entity_id' => $ids[$loan->loanDetails->recordId],
+          'loan_date' => $loan->loanDetails->loanDate,
+          'expiry' => $loan->loanDetails->dueDate,
+          'renewable' => $loan->isRenewable,
+          'materials_number' => $loan->loanDetails->materialItemNumber,
+        );
+
+        // If this is a periodical, add in issue data.
+        if (isset($loan->loanDetails->periodical)) {
+          $periodical = $loan->loanDetails->periodical;
+          $vol = $periodical->volume;
+          if (!empty($periodical->volumeNumber)) {
+            $vol .= '.' . $periodical->volumeNumber;
+          }
+          if (!empty($periodical->volumeYear)) {
+            $loan_data['notes'] = t('Issue @vol, @year', array(
+              '@vol' => $vol,
+              '@year' => $periodical->volumeYear
+            ));
+          }
+          else {
+            $loan_data['notes'] = t('Issue @vol', array('@vol' => $vol));
+          }
+        }
+
+        // Handle inter library loans.
+        if (!empty($loan->loanDetails->ilBibliographicRecord)) {
+          $loan_data['display_name'] = $loan->loanDetails->ilBibliographicRecord->title;
+        }
+
+        $results[$id] = new DingProviderLoan($id, $loan_data);
+      }
+
+      // Store the loans into ding session cache.
+      if (module_exists('ding_session_cache')) {
+        ding_session_cache_set('fbs', 'loans', $results);
+      }
+    }
   }
 
-  return $result;
+  return $results;
 }
 
 /**
@@ -106,6 +127,11 @@ function fbs_loan_renew($account, $loans) {
         $result[$loan->loanDetails->loanId] = DingProviderLoan::STATUS_RENEWAL_RESERVED;
       }
     }
+  }
+
+  // Clear ding session cache.
+  if (module_exists('ding_session_cache')) {
+    ding_session_cache_clear('fbs', 'loans');
   }
 
   return $result;

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -22,7 +22,7 @@ function fbs_loan_list($account, $reset = FALSE) {
   if (empty($results) || $reset) {
     // Check if ding_session_cache is available.
     if (module_exists('ding_session_cache') && !$reset) {
-      $results = ding_session_cache_get('fbs', 'loans');
+      $results = ding_session_cache_get('fbs', 'loans', array());
     }
 
     // If both static cache and session cache failed, try reloading information

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -17,21 +17,24 @@
  *   Loan information.
  */
 function fbs_loan_list($account, $reset = FALSE) {
-  $results = &drupal_static(__FUNCTION__, array());
+  $results = &drupal_static(__FUNCTION__, NULL);
 
-  if (empty($results) || $reset) {
+  if (is_null($results) || $reset) {
     // Check if ding_session_cache is available.
     if (module_exists('ding_session_cache') && !$reset) {
-      $results = ding_session_cache_get('fbs', 'loans', array());
+      $results = ding_session_cache_get('fbs', 'loans', NULL);
     }
 
     // If both static cache and session cache failed, try reloading information
     // from FBS.
-    if (empty($results) || $reset) {
+    if (is_null($results) || $reset) {
+      $results = array();
+
       $res = array();
       try {
         $res = fbs_service()->MaterialLoans->getLoans(fbs_service()->agencyId, fbs_patron_id($account));
-      } catch (Exception $e) {
+      }
+      catch (Exception $e) {
         watchdog_exception('fbs', $e);
       }
 

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -11,7 +11,7 @@
  * @param object $account
  *   User to fetch list for.
  * @param bool $reset
- *   If TRUE cache is reset (default: FALSE)
+ *   If TRUE cache is reset (default: FALSE).
  *
  * @return array
  *   Loan information.
@@ -65,7 +65,7 @@ function fbs_loan_list($account, $reset = FALSE) {
           if (!empty($periodical->volumeYear)) {
             $loan_data['notes'] = t('Issue @vol, @year', array(
               '@vol' => $vol,
-              '@year' => $periodical->volumeYear
+              '@year' => $periodical->volumeYear,
             ));
           }
           else {

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -107,17 +107,17 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
       if (module_exists('ding_session_cache')) {
         ding_session_cache_set('fbs', 'reservation', $results);
       }
+    }
+  }
 
-      // Filter the result based on the requested type of reservations.
-      if ($requested_type) {
-        if (isset($results[$requested_type])) {
-          return $results[$requested_type];
-        }
-        else {
-          watchdog('fbs', 'Unknown reservation type (%type) requested', array('%type' => $requested_type), WATCHDOG_ERROR);
-          return array();
-        }
-      }
+  // Filter the result based on the requested type of reservations.
+  if ($requested_type) {
+    if (isset($results[$requested_type])) {
+      return $results[$requested_type];
+    }
+    else {
+      watchdog('fbs', 'Unknown reservation type (%type) requested', array('%type' => $requested_type), WATCHDOG_ERROR);
+      return array();
     }
   }
 

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -24,7 +24,7 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
   if (empty($results) || $reset) {
     // Check if ding_session_cache is available.
     if (module_exists('ding_session_cache') && !$reset) {
-      $results = ding_session_cache_get('fbs', 'reservation');
+      $results = ding_session_cache_get('fbs', 'reservation', array());
     }
 
     // If both static cache and session cache failed, try reloading information

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -12,95 +12,116 @@
  *   User to list reservations for.
  * @param string|null $requested_type
  *   Type of reservations to list. Null for all.
+ * @param bool $reset
+ *   If TRUE cache is reset (default: FALSE)
  *
  * @return array
  *   Reservation info.
  */
-function fbs_reservation_list($account, $requested_type = NULL) {
-  $res = array();
-  try {
-    $res = fbs_service()->Reservations->getReservations(fbs_service()->agencyId, fbs_patron_id($account));
-  }
-  catch (Exception $e) {
-    watchdog_exception('fbs', $e);
-  }
+function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) {
+  $results = &drupal_static(__FUNCTION__, array());
 
-  $result = array(
-    DING_RESERVATION_READY => array(),
-    DING_RESERVATION_NOT_READY => array(),
-    DING_RESERVATION_INTERLIBRARY_LOANS => array(),
-  );
-
-  $ids = array();
-  foreach ($res as $reservation) {
-    $ids[$reservation->recordId] = $reservation->recordId;
-  }
-  $ids = ding_provider_build_entity_id($ids);
-
-  foreach ($res as $reservation) {
-    $type = $reservation->state == 'readyForPickup' ? DING_RESERVATION_READY : DING_RESERVATION_NOT_READY;
-    $type = $reservation->state == 'interLibraryReservation' ? DING_RESERVATION_INTERLIBRARY_LOANS : $type;
-
-    $ding_reservation = array(
-      'ding_entity_id' => $ids[$reservation->recordId],
-      'id' => $reservation->reservationId,
-      'pickup_branch_id' => $reservation->pickupBranch,
-      'created' => $reservation->dateOfReservation,
-      'expiry' => $reservation->expiryDate,
-      // Required by ding_reservation.
-      'reservation_type' => $type,
-    );
-
-    if ($type === DING_RESERVATION_READY) {
-      $ding_reservation['pickup_date'] = $reservation->pickupDeadline;
-      $ding_reservation['pickup_order_id'] = $reservation->pickupNumber;
-      $ding_reservation['order_arrived'] = TRUE;
-    }
-    elseif ($type === DING_RESERVATION_NOT_READY || $type === DING_RESERVATION_INTERLIBRARY_LOANS) {
-      if (!empty($reservation->numberInQueue)) {
-        $ding_reservation['queue_number'] = $reservation->numberInQueue;
-      }
+  if (empty($results) || $reset) {
+    // Check if ding_session_cache is available.
+    if (module_exists('ding_session_cache') && !$reset) {
+      $results = ding_session_cache_get('fbs', 'reservation');
     }
 
-    // Add in periodical information if it is one.
-    if ($reservation->periodical) {
-      $periodical = $reservation->periodical;
-      $vol = $periodical->volume;
-      if (!empty($periodical->volumeNumber)) {
-        $vol .= '.' . $periodical->volumeNumber;
+    // If both static cache and session cache failed, try reloading information
+    // from FBS.
+    if (empty($results) || $reset) {
+      $results = array(
+        DING_RESERVATION_READY => array(),
+        DING_RESERVATION_NOT_READY => array(),
+        DING_RESERVATION_INTERLIBRARY_LOANS => array(),
+      );
+      $res = array();
+      try {
+        $res = fbs_service()->Reservations->getReservations(fbs_service()->agencyId, fbs_patron_id($account));
+      } catch (Exception $e) {
+        watchdog_exception('fbs', $e);
       }
 
-      if (!empty($periodical->displayText)) {
-        $ding_reservation['notes'] = check_plain($periodical->displayText);
+      $ids = array();
+      foreach ($res as $reservation) {
+        $ids[$reservation->recordId] = $reservation->recordId;
       }
-      elseif (!empty($periodical->volumeYear)) {
-        $ding_reservation['notes'] = t('Issue @vol, @year', array('@vol' => $vol, '@year' => $periodical->volumeYear));
+      $ids = ding_provider_build_entity_id($ids);
+
+      foreach ($res as $reservation) {
+        $type = $reservation->state == 'readyForPickup' ? DING_RESERVATION_READY : DING_RESERVATION_NOT_READY;
+        $type = $reservation->state == 'interLibraryReservation' ? DING_RESERVATION_INTERLIBRARY_LOANS : $type;
+
+        $ding_reservation = array(
+          'ding_entity_id' => $ids[$reservation->recordId],
+          'id' => $reservation->reservationId,
+          'pickup_branch_id' => $reservation->pickupBranch,
+          'created' => $reservation->dateOfReservation,
+          'expiry' => $reservation->expiryDate,
+          // Required by ding_reservation.
+          'reservation_type' => $type,
+        );
+
+        if ($type === DING_RESERVATION_READY) {
+          $ding_reservation['pickup_date'] = $reservation->pickupDeadline;
+          $ding_reservation['pickup_order_id'] = $reservation->pickupNumber;
+          $ding_reservation['order_arrived'] = TRUE;
+        }
+        elseif ($type === DING_RESERVATION_NOT_READY || $type === DING_RESERVATION_INTERLIBRARY_LOANS) {
+          if (!empty($reservation->numberInQueue)) {
+            $ding_reservation['queue_number'] = $reservation->numberInQueue;
+          }
+        }
+
+        // Add in periodical information if it is one.
+        if ($reservation->periodical) {
+          $periodical = $reservation->periodical;
+          $vol = $periodical->volume;
+          if (!empty($periodical->volumeNumber)) {
+            $vol .= '.' . $periodical->volumeNumber;
+          }
+
+          if (!empty($periodical->displayText)) {
+            $ding_reservation['notes'] = check_plain($periodical->displayText);
+          }
+          elseif (!empty($periodical->volumeYear)) {
+            $ding_reservation['notes'] = t('Issue @vol, @year', array(
+              '@vol' => $vol,
+              '@year' => $periodical->volumeYear
+            ));
+          }
+          else {
+            $ding_reservation['notes'] = t('Issue @vol', array('@vol' => $vol));
+          }
+        }
+
+        // Handle inter library loans.
+        if (!empty($reservation->ilBibliographicRecord)) {
+          $ding_reservation['display_name'] = $reservation->ilBibliographicRecord->title;
+        }
+
+        $results[$type][$ding_reservation['id']] = new DingProviderReservation($ding_reservation['id'], $ding_reservation);
       }
-      else {
-        $ding_reservation['notes'] = t('Issue @vol', array('@vol' => $vol));
+
+      // Store the reservations into ding session cache.
+      if (module_exists('ding_session_cache')) {
+        ding_session_cache_set('fbs', 'reservation', $results);
+      }
+
+      // Filter the result based on the requested type of reservations.
+      if ($requested_type) {
+        if (isset($results[$requested_type])) {
+          return $results[$requested_type];
+        }
+        else {
+          watchdog('fbs', 'Unknown reservation type (%type) requested', array('%type' => $requested_type), WATCHDOG_ERROR);
+          return array();
+        }
       }
     }
-
-    // Handle inter library loans.
-    if (!empty($reservation->ilBibliographicRecord)) {
-      $ding_reservation['display_name'] = $reservation->ilBibliographicRecord->title;
-    }
-
-    $result[$type][$ding_reservation['id']] = new DingProviderReservation($ding_reservation['id'], $ding_reservation);
   }
 
-  // Filter the result based on the requested type of reservations.
-  if ($requested_type) {
-    if (isset($result[$requested_type])) {
-      return $result[$requested_type];
-    }
-    else {
-      watchdog('fbs', 'Unknown reservation type (%type) requested', array('%type' => $requested_type), WATCHDOG_ERROR);
-      return array();
-    }
-  }
-
-  return $result;
+  return $results;
 }
 
 /**
@@ -148,6 +169,11 @@ function fbs_reservation_create($account, $record_id, $options) {
   if (!empty($response->success)) {
     /** @var \FBS\Model\ReservationDetails $res_details */
 
+    // Clear ding session cache.
+    if (module_exists('ding_session_cache')) {
+      ding_session_cache_clear('fbs', 'reservation');
+    }
+
     $res_details = $result->reservationDetails;
     return array(
       'branch' => $res_details->pickupBranch,
@@ -189,6 +215,9 @@ function fbs_reservation_create($account, $record_id, $options) {
  *   Reservations to update.
  * @param array $options
  *   Update options.
+ *
+ * @return bool
+ *   TRUE if no errors else FALSE.
  */
 function fbs_reservation_update($account, $reservation_ids, $options) {
   $batch = new FBS\Model\UpdateReservationBatch();
@@ -203,12 +232,19 @@ function fbs_reservation_update($account, $reservation_ids, $options) {
 
   try {
     fbs_service()->Reservations->updateReservations(fbs_service()->agencyId, fbs_patron_id($account), $batch);
+
+    // Clear ding session cache.
+    if (module_exists('ding_session_cache')) {
+      ding_session_cache_clear('fbs', 'reservation');
+    }
   }
   catch (Exception $e) {
     watchdog_exception('fbs', $e);
 
     return FALSE;
   }
+
+  return TRUE;
 }
 
 /**
@@ -216,18 +252,28 @@ function fbs_reservation_update($account, $reservation_ids, $options) {
  *
  * @param object $account
  *   User to delete reservations for.
- * @param array $reservation_ids
+ * @param array $reservation_id
  *   Reservations to delete.
+ *
+ * @return bool
+ *   TRUE if no errors else FALSE.
  */
 function fbs_reservation_delete($account, $reservation_id) {
   try {
     fbs_service()->Reservations->deleteReservations(fbs_service()->agencyId, fbs_patron_id($account), $reservation_id);
+
+    // Clear ding session cache.
+    if (module_exists('ding_session_cache')) {
+      ding_session_cache_clear('fbs', 'reservation');
+    }
   }
   catch (Exception $e) {
     watchdog_exception('fbs', $e);
 
     return FALSE;
   }
+
+  return TRUE;
 }
 
 /**

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -13,7 +13,7 @@
  * @param string|null $requested_type
  *   Type of reservations to list. Null for all.
  * @param bool $reset
- *   If TRUE cache is reset (default: FALSE)
+ *   If TRUE cache is reset (default: FALSE).
  *
  * @return array
  *   Reservation info.
@@ -88,7 +88,7 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
           elseif (!empty($periodical->volumeYear)) {
             $ding_reservation['notes'] = t('Issue @vol, @year', array(
               '@vol' => $vol,
-              '@year' => $periodical->volumeYear
+              '@year' => $periodical->volumeYear,
             ));
           }
           else {

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -19,17 +19,17 @@
  *   Reservation info.
  */
 function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) {
-  $results = &drupal_static(__FUNCTION__, array());
+  $results = &drupal_static(__FUNCTION__, NULL);
 
-  if (empty($results) || $reset) {
+  if (is_null($results) || $reset) {
     // Check if ding_session_cache is available.
     if (module_exists('ding_session_cache') && !$reset) {
-      $results = ding_session_cache_get('fbs', 'reservation', array());
+      $results = ding_session_cache_get('fbs', 'reservation', NULL);
     }
 
     // If both static cache and session cache failed, try reloading information
     // from FBS.
-    if (empty($results) || $reset) {
+    if (is_null($results) || $reset) {
       $results = array(
         DING_RESERVATION_READY => array(),
         DING_RESERVATION_NOT_READY => array(),
@@ -38,7 +38,8 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
       $res = array();
       try {
         $res = fbs_service()->Reservations->getReservations(fbs_service()->agencyId, fbs_patron_id($account));
-      } catch (Exception $e) {
+      }
+      catch (Exception $e) {
         watchdog_exception('fbs', $e);
       }
 

--- a/modules/fbs/includes/fbs.user.inc
+++ b/modules/fbs/includes/fbs.user.inc
@@ -194,7 +194,7 @@ function fbs_user_create($cpr, $pin_code, $name, $mail, $branch_id) {
   }
 }
 
-/** 
+/**
  * Implements clear_cache().
  *
  * This hook is only called from ding_dibs after a payment have been accepted.
@@ -203,5 +203,8 @@ function fbs_user_create($cpr, $pin_code, $name, $mail, $branch_id) {
  *   Drupal user account object.
  */
 function fbs_user_clear_cache($account) {
-  // As the FBS currently only uses a static cache for debt... do nothing.
+  // Clear ding session cache.
+  if (module_exists('ding_session_cache')) {
+    ding_session_cache_clear('fbs', 'debt');
+  }
 }

--- a/modules/openruth/openruth.module
+++ b/modules/openruth/openruth.module
@@ -548,7 +548,7 @@ function openruth_field_attach_view_alter(&$output, $context) {
  */
 function openruth_ding_session_cache_defaults() {
   return array(
-    'titel' => 'Openruth (reservations, loans)',
+    'title' => 'Openruth (reservations, loans)',
     'enabled' => TRUE,
     'expire' => 3600,
   );


### PR DESCRIPTION
Added ding_session_cache to FBS as in the old providers. Without this FBS var called 9-12 times to show the user profile page and on every page load after login (6-9 times for logged in users to build header menu).

See https://platform.dandigbib.org/issues/3073