### PR TITLE
3096: Fix fatal error when creating list

### DIFF
--- a/modules/p2/ding_list/include/form.inc
+++ b/modules/p2/ding_list/include/form.inc
@@ -209,7 +209,7 @@ function ding_list_create_list_form($form, &$form_state, $existing = FALSE) {
     $form_state['existing'] = FALSE;
   }
 
-  if (ding_list_allowed($existing, DING_LIST_OPERATION_EDIT_TITLE)) {
+  if (!$existing || ding_list_allowed($existing, DING_LIST_OPERATION_EDIT_TITLE)) {
     $form['title'] = array(
       '#type' => 'textfield',
       '#title' => t('Title'),


### PR DESCRIPTION
The form builder checks if title can be changed for the given list, but doesn't take new lists into account.

https://platform.dandigbib.org/issues/3096