### PR TITLE
3076: ding webtrekk fixes

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -65,7 +65,7 @@ function ding_webtrekk_panels_pane_content_alter($content, $pane, $args, $contex
   if ($pane->type == 'search_result' && $pane->configuration['type'] == 'ting_search' && strpos(current_path(), 'search/ting') === 0) {
     if ($search_result = drupal_static('ting_search_results', FALSE)) {
       $params = [
-        'pageTitle' => $content->original_title,
+        'pageTitle' => 'Search ting',
         'OSS' => $search_result->search_key,
         'OSSr' => $search_result->numTotalObjects,
       ];
@@ -91,7 +91,7 @@ function ding_webtrekk_views_post_execute(&$view) {
     $params = [
       'internalSearch' => array_shift($view->args),
       'numberSearchResults' => $view->total_rows,
-      'pageTitle' => $view->human_name,
+      'pageTitle' => 'Search content',
     ];
     _ding_webtrekk_set_data_layer_values($params);
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -17,7 +17,7 @@ function ding_webtrekk_menu() {
     'access arguments' => ['administer site configuration'],
     'file' => 'ding_webtrekk.admin.inc',
   ];
-  
+
   return $items;
 }
 
@@ -62,7 +62,7 @@ function ding_webtrekk_page_alter(&$page) {
  * Track ting search results.
  */
 function ding_webtrekk_panels_pane_content_alter($content, $pane, $args, $contexts) {
-  if ($pane->type == 'search_result' && $pane->configuration['type'] == 'ting_search') {
+  if ($pane->type == 'search_result' && $pane->configuration['type'] == 'ting_search' && strpos(current_path(), 'search/ting') === 0) {
     if ($search_result = drupal_static('ting_search_results', FALSE)) {
       $params = [
         'pageTitle' => $content->original_title,
@@ -80,7 +80,7 @@ function ding_webtrekk_panels_pane_content_alter($content, $pane, $args, $contex
  * Track internal search results.
  */
 function ding_webtrekk_views_post_execute(&$view) {
-  if ($view->name == 'ding_multiple_search') {
+  if ($view->name == 'ding_multiple_search' && strpos(current_path(), 'search/node') === 0) {
     // This view is loaded 2 times. Prevent from loading params multiple times.
     $loaded = &drupal_static(__FUNCTION__);
     if (!empty($loaded)) {

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -54,16 +54,13 @@ function ding_webtrekk_page_alter(&$page) {
       'scope' => 'footer',
     ],
   ];
-}
 
-/**
- * Implements hook_panels_pane_content_alter().
- *
- * Track ting search results.
- */
-function ding_webtrekk_panels_pane_content_alter($content, $pane, $args, $contexts) {
-  if ($pane->type == 'search_result' && $pane->configuration['type'] == 'ting_search' && strpos(current_path(), 'search/ting') === 0) {
-    if ($search_result = drupal_static('ting_search_results', FALSE)) {
+  // Track ting search results. We take advantage of the fact that ting_search
+  // module stores the result in a static variable when search is triggered via
+  // search_data() function from core search module. Since this is not tied to
+  // any path, we also check current_path().
+  if (strpos(current_path(), 'search/ting') === 0) {
+    if ($search_result = drupal_static('ting_search_results', FALSE) {
       $params = [
         'pageTitle' => 'Search ting',
         'OSS' => $search_result->search_key,

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -60,7 +60,7 @@ function ding_webtrekk_page_alter(&$page) {
   // search_data() function from core search module. Since this is not tied to
   // any path, we also check current_path().
   if (strpos(current_path(), 'search/ting') === 0) {
-    if ($search_result = drupal_static('ting_search_results', FALSE) {
+    if ($search_result = drupal_static('ting_search_results', FALSE)) {
       $params = [
         'pageTitle' => 'Search ting',
         'OSS' => $search_result->search_key,
@@ -77,6 +77,10 @@ function ding_webtrekk_page_alter(&$page) {
  * Track internal search results.
  */
 function ding_webtrekk_views_post_execute(&$view) {
+  // We also check current_path to ensure we're tracking on the correct page.
+  // For example, the view is also executed on ting_search search page to show
+  // the number of results to the user, if they searched in content instead.
+  // See search_backend.inc ctools content type plugin from ting_search.
   if ($view->name == 'ding_multiple_search' && strpos(current_path(), 'search/node') === 0) {
     // This view is loaded 2 times. Prevent from loading params multiple times.
     $loaded = &drupal_static(__FUNCTION__);


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3076

OSS parameters was added twice because of the changes in https://platform.dandigbib.org/issues/629.

Updated the page titles also. Before the page title for Search node, was ding_multiple_search.

Also includes the fix to track empty searches.