### PR TITLE
3151: Fix iOS 11 modal bug

### DIFF
--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -35,6 +35,16 @@ body {
   &.overlay-is-active,
   &.popupbar-is-open {
     overflow: hidden;
+
+    // This is a fix for the modal bug in iOS 11.
+    // See: https://hackernoon.com/how-to-fix-the-ios-11-input-element-in-fixed-modals-bug-aaf66c7ba3f8
+    // Using position: fixed on body-element seems to work. !important is
+    // currently used because the body element is styled inline with
+    // position: relative;
+    // width: 100% ensures that everything looks normal, when the fix is applied.
+    position: fixed !important;
+    width: 100%;
+
     &::after {
       @include transition(
         opacity $speed $ease,
@@ -611,7 +621,7 @@ ul.tabs.primary {
     left: 0;
     width: 100%;
     height: 100%;
-    
+
   }
   .search-overlay--text {
     color: $white;


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3151

The bug moves the caret outside of the input fields. This makes it hard to log in, resulting in some users giving up entirely. This has only been observed on iPhones so far. I have testet on iPad and the additional screen space seems to prevent the problem.

In some situations the caret moves on top of the submit button, making it impossible to push.

See: https://hackernoon.com/how-to-fix-the-ios-11-input-element-in-fixed-modals-bug-aaf66c7ba3f8 for an illustration of the problem and more info.

Also: https://stackoverflow.com/questions/46339063/ios-11-safari-bootstrap-modal-text-area-outside-of-cursor.

I considered using user agent checking (cheking for iPhone iOS 11) on client or server side:
https://github.com/hgoebl/mobile-detect.js 
https://github.com/serbanghita/Mobile-Detect

But since the fix doesn't seem to have any side-affects (after using width: 100% on body), I dropped it. If we find some issues, we can look into mobile detect.

Preferably Apple will fix this bug soon, so that we can just remove it again.

Also, I was not happy to use !important on position: fixed, but position: relative is added with inline styling to the body-element. I couldn't find where this rule was added.