### PR TITLE
3062: Syndicate campaigns in BPI

### DIFF
--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -295,6 +295,8 @@ function bpi_admin_get_field_mapping_form($bpi_type, $content_type, array $field
 function bpi_admin_content_mapping_form_submit(array $form, array &$form_state) {
   // Reindex bpi_mappings array.
   $form_state['values']['bpi_mappings'] = isset($form_state['values']['bpi_mappings']) ? array_values($form_state['values']['bpi_mappings']) : array();
+  // Ensure that all mapped content types have the BPI workflow field.
+  bpi_ensure_bpi_workflow_fields();
 }
 
 /**

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -299,14 +299,7 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
  */
 function bpi_admin_get_field_mapping_form($bpi_node_type, $content_type, array $field_mapping) {
   $hook = 'bpi_get_field_mapping_form';
-  foreach (module_implements($hook) as $module) {
-    $mapping = module_invoke($module, $hook, $bpi_node_type, $content_type, $field_mapping);
-    if ($mapping) {
-      return $mapping;
-    }
-  }
-
-  return NULL;
+  return bpi_module_invoke_one($hook, $bpi_node_type, $content_type, $field_mapping);
 }
 
 /**

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -143,12 +143,7 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
 
   $bpi_types = array();
   $hook = 'bpi_syndicate_get_bpi_types';
-  foreach (module_implements($hook) as $module) {
-    $types = module_invoke($module, $hook);
-    if (is_array($types)) {
-      $bpi_types = array_merge($bpi_types, $types);
-    }
-  }
+  $bpi_types = module_invoke_all($hook);
   $bpi_types = array_unique($bpi_types);
   $bpi_node_type_options = array();
   foreach ($bpi_types as $type) {

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -165,20 +165,20 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
     $form_state['deleted_mappings'] = array();
   }
   for ($i = 0; $i < $form_state['num_mappings']; $i++) {
-    $default_values = isset($bpi_mappings[$i]) ? $bpi_mappings[$i] : array();
-    $bpi_node_type = isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : NULL;
+    $saved_mapping = bpi_create_mapping(isset($bpi_mappings[$i]) ? $bpi_mappings[$i] : array());
+    $bpi_node_type = $saved_mapping['bpi_node_type'];
     if (isset($form_state['values']['bpi_mappings'][$i]['bpi_node_type'])) {
       $bpi_node_type = $form_state['values']['bpi_mappings'][$i]['bpi_node_type'];
     }
-    $selected_node_type = isset($default_values['bpi_content_type']) ? $default_values['bpi_content_type'] : NULL;
-    if (isset($form_state['values']['bpi_mappings'][$i]['bpi_content_type'])) {
-      $selected_node_type = $form_state['values']['bpi_mappings'][$i]['bpi_content_type'];
+    $selected_node_type = $saved_mapping['content_type'];
+    if (isset($form_state['values']['bpi_mappings'][$i]['content_type'])) {
+      $selected_node_type = $form_state['values']['bpi_mappings'][$i]['content_type'];
     }
 
     $mapping = array(
       '#type' => 'fieldset',
       '#title' => t('Mapping (@bpi_type)', array(
-        '@bpi_type' => isset($default_values['bpi_node_type']) ? t($default_values['bpi_node_type']) : '–')
+        '@bpi_type' => $saved_mapping['bpi_node_type'] ? t($saved_mapping['bpi_node_type']) : '–')
       ),
       '#collapsible' => TRUE,
     );
@@ -196,7 +196,7 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
           '#title' => t('BPI node type'),
           '#description' => t('Enter the BPI node type, e.g. ding_news, campaign, carousel.'),
           '#options' => $bpi_node_type_options,
-          '#default_value' => isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : NULL,
+          '#default_value' => $saved_mapping['bpi_node_type'],
           '#ajax' => array(
             'callback' => 'bpi_admin_content_mapping_form_update_bpi_type',
             'wrapper' => 'bpi-wrapper',
@@ -204,23 +204,24 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
           '#required' => TRUE,
         ),
 
-        'bpi_content_type' => array(
+        'content_type' => array(
           '#type' => 'select',
           '#title' => t('Content type'),
           '#description' => t('Select a content type into which content from BPI will be syndicated. If you change the content type, you have to save the form before editing the field mapping.'),
           '#options' => $node_types,
-          '#default_value' => isset($default_values['bpi_content_type']) ? $default_values['bpi_content_type'] : NULL,
+          '#default_value' => $saved_mapping['content_type'],
           '#ajax' => array(
             'callback' => 'bpi_admin_content_mapping_form_update_content_type_fields',
             'wrapper' => 'bpi-wrapper',
           ),
+          '#required' => TRUE,
         ),
       );
 
-      $field_mapping = isset($default_values['bpi_field_mapping']) ? $default_values['bpi_field_mapping'] : array();
+      $field_mapping = $saved_mapping['field_mapping'];
       $field_mapping_form = bpi_admin_get_field_mapping_form($bpi_node_type, $selected_node_type, $field_mapping);
       if ($field_mapping_form) {
-        $item['bpi_field_mapping'] = array(
+        $item['field_mapping'] = array(
           '#type' => 'fieldset',
           '#title' => t('Field mapping'),
           '#description' => t('Define you custom mapping rules. Each dropdown maps BPI related fields to your content fields.'),
@@ -228,18 +229,18 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
           '#suffix' => '</div>',
         );
 
-        $item['bpi_field_mapping'] += $field_mapping_form;
+        $item['field_mapping'] += $field_mapping_form;
       }
       drupal_alter('bpi_mapping_form', $bpi_node_type, $item);
 
       $mapping += $item;
 
-      if (isset($default_values['bpi_node_type'])) {
+      if ($saved_mapping['bpi_node_type']) {
         $mapping += array(
           'remove_mapping' => array(
             '#type' => 'submit',
             '#value' => t('Remove mapping of @bpi_type', array(
-              '@bpi_type' => isset($default_values['bpi_node_type']) ? t($default_values['bpi_node_type']) : '–',
+              '@bpi_type' => t($saved_mapping['bpi_node_type']),
             )),
             '#name' => 'remove_mapping_' . $i,
             '#submit' => array('bpi_admin_content_mapping_form_add_mapping_remove_one'),

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -286,12 +286,21 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
 }
 
 /**
- * BPI field mapping form.
+ * Get form for editing BPI field mapping.
+ *
+ * @param string $bpi_node_type
+ *   The BPI node type.
+ * @param string $content_type
+ *   The Drupal content type.
+ * @param array $field_mapping
+ *   The field mapping (@see bpi_get_mappings() for details).
+ *
+ * @return array|null
  */
-function bpi_admin_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
+function bpi_admin_get_field_mapping_form($bpi_node_type, $content_type, array $field_mapping) {
   $hook = 'bpi_get_field_mapping_form';
   foreach (module_implements($hook) as $module) {
-    $mapping = module_invoke($module, $hook, $bpi_type, $content_type, $field_mapping);
+    $mapping = module_invoke($module, $hook, $bpi_node_type, $content_type, $field_mapping);
     if ($mapping) {
       return $mapping;
     }

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -207,8 +207,7 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
         'bpi_content_type' => array(
           '#type' => 'select',
           '#title' => t('Content type'),
-          '#description' => t('Select a content type into which content from BPI will be syndicated.')
-          .'<br/>' . t('If you change the content type, you have to save the form before editing the field mapping.'),
+          '#description' => t('Select a content type into which content from BPI will be syndicated. If you change the content type, you have to save the form before editing the field mapping.'),
           '#options' => $node_types,
           '#default_value' => isset($default_values['bpi_content_type']) ? $default_values['bpi_content_type'] : NULL,
           '#ajax' => array(

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -188,7 +188,8 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
           '#markup' => 'Save to confirm',
         ),
       );
-    } else {
+    }
+    else {
       $item = array(
         'bpi_node_type' => array(
           '#type' => 'select',
@@ -207,7 +208,7 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
           '#type' => 'select',
           '#title' => t('Content type'),
           '#description' => t('Select a content type into which content from BPI will be syndicated.')
-          .'<br/>'. t('If you change the content type, you have to save the form before editing the field mapping.'),
+          .'<br/>' . t('If you change the content type, you have to save the form before editing the field mapping.'),
           '#options' => $node_types,
           '#default_value' => isset($default_values['bpi_content_type']) ? $default_values['bpi_content_type'] : NULL,
           '#ajax' => array(
@@ -239,7 +240,7 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
           'remove_mapping' => array(
             '#type' => 'submit',
             '#value' => t('Remove mapping of @bpi_type', array(
-              '@bpi_type' => isset($default_values['bpi_node_type']) ? t($default_values['bpi_node_type']) : '–'
+              '@bpi_type' => isset($default_values['bpi_node_type']) ? t($default_values['bpi_node_type']) : '–',
             )),
             '#name' => 'remove_mapping_' . $i,
             '#submit' => array('bpi_admin_content_mapping_form_add_mapping_remove_one'),
@@ -284,6 +285,9 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
   return system_settings_form($form);
 }
 
+/**
+ * BPI field mapping form.
+ */
 function bpi_admin_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
   $hook = 'bpi_get_field_mapping_form';
   foreach (module_implements($hook) as $module) {
@@ -296,6 +300,9 @@ function bpi_admin_get_field_mapping_form($bpi_type, $content_type, array $field
   return NULL;
 }
 
+/**
+ * BPI field mapping form submit handler.
+ */
 function bpi_admin_content_mapping_form_submit(array $form, array &$form_state) {
   // Reindex bpi_mappings array.
   $form_state['values']['bpi_mappings'] = isset($form_state['values']['bpi_mappings']) ? array_values($form_state['values']['bpi_mappings']) : array();

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -130,85 +130,141 @@ function bpi_admin_settings_form_validate(&$form, &$form_state) {
  *
  * @ingroup forms
  */
-function bpi_admin_content_mapping_form($form, $form_state) {
-  $node_types = node_type_get_names();
-  $node_types_names = array_keys($node_types);
+function bpi_admin_content_mapping_form(array $form, array &$form_state) {
+  $bpi_mappings = bpi_get_mappings();
 
-  $form['bpi_content_type'] = array(
-    '#type' => 'select',
-    '#title' => t('Content type'),
-    '#description' => t('Select a content type into which content from BPI will be syndicated.'),
-    '#options' => $node_types,
-    '#default_value' => variable_get('bpi_content_type', reset($node_types_names)),
-    '#ajax' => array(
-      'callback' => '_bpi_content_mapper_ctype_fields',
-      'wrapper' => 'bpi-field-mapper-wrapper',
-      'effect' => 'fade',
-      'method' => 'replace',
-    ),
-  );
-
-  // Get filter list of field instances.
-  $selected_node_type = $form['bpi_content_type']['#default_value'];
-
-  if (isset($form_state['values']['bpi_content_type'])) {
-    $selected_node_type = $form_state['values']['bpi_content_type'];
-  }
-
-  $field_instances = bpi_get_field_instances($selected_node_type);
-
-  $form['bpi_mapper'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Field mapping'),
-    '#description' => t('Define you custom mapping rules. Each dropdown maps BPI related fields to your content fields.'),
-    '#prefix' => '<div id="bpi-field-mapper-wrapper">',
+  $form['#tree'] = TRUE;
+  $form['bpi_mappings'] = array(
+    '#type' => 'container',
+    '#title' => t('BPI content mappings'),
+    '#prefix' => '<div id="bpi-wrapper">',
     '#suffix' => '</div>',
   );
 
-  $form['bpi_mapper']['bpi_field_title'] = array(
-    '#type' => 'select',
-    '#title' => t('BPI title'),
-    '#description' => t('Titles are automatically assigned.'),
-    '#options' => array('title' => t('Title')),
-    '#default_value' => variable_get('bpi_field_title', 'title'),
-    '#disabled' => TRUE,
-  );
+  $bpi_types = array();
+  $hook = 'bpi_syndicate_get_bpi_types';
+  foreach (module_implements($hook) as $module) {
+    $types = module_invoke($module, $hook);
+    if (is_array($types)) {
+      $bpi_types = array_merge($bpi_types, $types);
+    }
+  }
+  $bpi_types = array_unique($bpi_types);
+  $bpi_node_type_options = array();
+  foreach ($bpi_types as $type) {
+    $bpi_node_type_options[$type] = t($type);
+  }
+  asort($bpi_node_type_options);
 
-  $form['bpi_mapper']['bpi_field_teaser'] = array(
-    '#type' => 'select',
-    '#title' => t('BPI teaser'),
-    '#description' => t('The field to extract the teaser from. If the content type have a body summary, assign it to the body field.'),
-    '#options' => $field_instances,
-    '#default_value' => variable_get('bpi_field_teaser', ''),
-  );
+  $node_types = node_type_get_names();
 
-  $form['bpi_mapper']['bpi_field_body'] = array(
-    '#type' => 'select',
-    '#title' => t('BPI body'),
-    '#description' => t('Field to extract the main cotenten from (body field).'),
-    '#options' => $field_instances,
-    '#default_value' => variable_get('bpi_field_body', ''),
-  );
+  if (empty($form_state['num_mappings'])) {
+    $form_state['num_mappings'] = max(0, count($bpi_mappings));
+  }
+  if (!isset($form_state['deleted_mappings'])) {
+    $form_state['deleted_mappings'] = array();
+  }
+  for ($i = 0; $i < $form_state['num_mappings']; $i++) {
+    $default_values = isset($bpi_mappings[$i]) ? $bpi_mappings[$i] : array();
+    $bpi_node_type = isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : NULL;
+    if (isset($form_state['values']['bpi_mappings'][$i]['bpi_node_type'])) {
+      $bpi_node_type = $form_state['values']['bpi_mappings'][$i]['bpi_node_type'];
+    }
+    $selected_node_type = isset($default_values['bpi_content_type']) ? $default_values['bpi_content_type'] : NULL;
+    if (isset($form_state['values']['bpi_mappings'][$i]['bpi_content_type'])) {
+      $selected_node_type = $form_state['values']['bpi_mappings'][$i]['bpi_content_type'];
+    }
 
-  $form['bpi_mapper']['bpi_field_tags'] = array(
-    '#type' => 'select',
-    '#title' => t('BPI tags'),
-    '#description' => t('Field used to get tags from.'),
-    '#options' => $field_instances,
-    '#default_value' => variable_get('bpi_field_tags', ''),
-  );
+    $mapping = array(
+      '#type' => 'fieldset',
+      '#title' => t('Mapping (@bpi_type)', array('@bpi_type' => isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : '–')),
+      '#collapsible' => TRUE,
+    );
+    if (isset($form_state['deleted_mappings'][$i])) {
+      $mapping += array(
+        'message' => array(
+          '#markup' => 'Save to confirm',
+        ),
+      );
+    } else {
+      $item = array(
+        'bpi_node_type' => array(
+          '#type' => 'select',
+          '#title' => t('BPI node type'),
+          '#description' => t('Enter the BPI node type, e.g. ding_news, campaign, carousel.'),
+          '#options' => $bpi_node_type_options,
+          '#default_value' => isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : NULL,
+          '#ajax' => array(
+            'callback' => 'bpi_admin_content_mapping_form_update_bpi_type',
+            'wrapper' => 'bpi-wrapper',
+          ),
+          '#required' => TRUE,
+        ),
 
-  $form['bpi_mapper']['bpi_field_materials'] = array(
-    '#type' => 'select',
-    '#title' => t('BPI materials'),
-    '#description' => t('Field used to get reference to the T!NG data well.'),
-    '#options' => $field_instances,
-    '#default_value' => variable_get('bpi_field_materials', ''),
+        'bpi_content_type' => array(
+          '#type' => 'select',
+          '#title' => t('Content type'),
+          '#description' => t('Select a content type into which content from BPI will be syndicated.')
+          .'<br/>'. t('If you change the content type, you have to save the form before editing the field mapping.'),
+          '#options' => $node_types,
+          '#default_value' => isset($default_values['bpi_content_type']) ? $default_values['bpi_content_type'] : NULL,
+          '#ajax' => array(
+            'callback' => 'bpi_admin_content_mapping_form_update_content_type_fields',
+            'wrapper' => 'bpi-wrapper',
+          ),
+        ),
+      );
+
+      $field_mapping = isset($default_values['bpi_field_mapping']) ? $default_values['bpi_field_mapping'] : array();
+      $field_mapping_form = bpi_admin_get_field_mapping_form($bpi_node_type, $selected_node_type, $field_mapping);
+      if ($field_mapping_form) {
+        $item['bpi_field_mapping'] = array(
+          '#type' => 'fieldset',
+          '#title' => t('Field mapping'),
+          '#description' => t('Define you custom mapping rules. Each dropdown maps BPI related fields to your content fields.'),
+          '#prefix' => '<div id="bpi-field-mapper-wrapper">',
+          '#suffix' => '</div>',
+        );
+
+        $item['bpi_field_mapping'] += $field_mapping_form;
+      }
+      drupal_alter('bpi_mapping_form', $bpi_node_type, $item);
+
+      $mapping += $item;
+
+      if (isset($default_values['bpi_node_type'])) {
+        $mapping += array(
+          'remove_mapping' => array(
+            '#type' => 'submit',
+            '#value' => t('Remove mapping of @bpi_type', array('@bpi_type' => isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : '–')),
+            '#name' => 'remove_mapping_' . $i,
+            '#submit' => array('bpi_admin_content_mapping_form_add_mapping_remove_one'),
+            '#ajax' => array(
+              'callback' => 'bpi_admin_content_mapping_form_add_mapping_callback',
+              'wrapper' => 'bpi-wrapper',
+            ),
+          ),
+        );
+      }
+    }
+
+    $form['bpi_mappings'][$i] = $mapping;
+  }
+
+  $form['add_mapping'] = array(
+    '#type' => 'submit',
+    '#value' => t('Add mapping'),
+    '#submit' => array('bpi_admin_content_mapping_form_add_mapping_add_one'),
+    '#ajax' => array(
+      'callback' => 'bpi_admin_content_mapping_form_add_mapping_callback',
+      'wrapper' => 'bpi-wrapper',
+    ),
   );
 
   $form['bpi_syndication'] = array(
     '#type' => 'fieldset',
     '#title' => t('Syndication settings'),
+    '#tree' => FALSE,
   );
 
   $form['bpi_syndication']['bpi_syndicate_tags'] = array(
@@ -219,27 +275,75 @@ function bpi_admin_content_mapping_form($form, $form_state) {
   );
 
   $form['#attached']['css'][] = drupal_get_path('module', 'bpi') . '/css/bpi-admin.styles.css';
+  $form['#submit'][] = 'bpi_admin_content_mapping_form_submit';
 
   return system_settings_form($form);
 }
 
+function bpi_admin_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
+  $hook = 'bpi_get_field_mapping_form';
+  foreach (module_implements($hook) as $module) {
+    $mapping = module_invoke($module, $hook, $bpi_type, $content_type, $field_mapping);
+    if ($mapping) {
+      return $mapping;
+    }
+  }
+
+  return NULL;
+}
+
+function bpi_admin_content_mapping_form_submit(array $form, array &$form_state) {
+  // Reindex bpi_mappings array.
+  $form_state['values']['bpi_mappings'] = isset($form_state['values']['bpi_mappings']) ? array_values($form_state['values']['bpi_mappings']) : array();
+}
+
 /**
- * Custom form AJAX callback.
- *
- * @see bpi_admin_content_mapping_form()
- *
- * @param array $form
- *   Form structure.
- * @param array $form_state
- *   Form state values.
- *
- * @return array
- *   Element to be altered via AJAX.
- *
- * @ingroup forms
+ * Callback for setting BPI content type field selectors.
  */
-function _bpi_content_mapper_ctype_fields(&$form, &$form_state) {
-  return $form['bpi_mapper'];
+function bpi_admin_content_mapping_form_update_bpi_type($form, $form_state) {
+  return $form['bpi_mappings'];
+}
+
+/**
+ * Callback for setting Drupal content type field selectors.
+ */
+function bpi_admin_content_mapping_form_update_content_type_fields($form, $form_state) {
+  return $form['bpi_mappings'];
+}
+
+/**
+ * Callback for both ajax-enabled buttons.
+ */
+function bpi_admin_content_mapping_form_add_mapping_callback($form, $form_state) {
+  return $form['bpi_mappings'];
+}
+
+/**
+ * Submit handler for the "Add mapping" button.
+ *
+ * Increments the counter and causes a rebuild.
+ */
+function bpi_admin_content_mapping_form_add_mapping_add_one($form, &$form_state) {
+  $form_state['num_mappings']++;
+  $form_state['rebuild'] = TRUE;
+}
+
+/**
+ * Submit handler for the "Remove mapping" button.
+ *
+ * Decrements the counter and causes a form rebuild.
+ */
+function bpi_admin_content_mapping_form_add_mapping_remove_one($form, &$form_state) {
+  if (isset($form_state['triggering_element']['#name'])
+    && preg_match('/^remove_mapping_(?<index>[0-9]+)$/', $form_state['triggering_element']['#name'], $matches)) {
+    $index = $matches['index'];
+    $bpi_mappings = bpi_get_mappings();
+    if (isset($bpi_mappings[$index])) {
+      $form_state['deleted_mappings'][$index] = $index;
+      $form_state['rebuild'] = TRUE;
+      drupal_set_message(t('Save to remove mapping of @bpi_type', array('@bpi_type' => $bpi_mappings[$index]['bpi_node_type'])), 'warning');
+    }
+  }
 }
 
 /**

--- a/modules/bpi/bpi.admin.inc
+++ b/modules/bpi/bpi.admin.inc
@@ -177,7 +177,9 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
 
     $mapping = array(
       '#type' => 'fieldset',
-      '#title' => t('Mapping (@bpi_type)', array('@bpi_type' => isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : '–')),
+      '#title' => t('Mapping (@bpi_type)', array(
+        '@bpi_type' => isset($default_values['bpi_node_type']) ? t($default_values['bpi_node_type']) : '–')
+      ),
       '#collapsible' => TRUE,
     );
     if (isset($form_state['deleted_mappings'][$i])) {
@@ -236,7 +238,9 @@ function bpi_admin_content_mapping_form(array $form, array &$form_state) {
         $mapping += array(
           'remove_mapping' => array(
             '#type' => 'submit',
-            '#value' => t('Remove mapping of @bpi_type', array('@bpi_type' => isset($default_values['bpi_node_type']) ? $default_values['bpi_node_type'] : '–')),
+            '#value' => t('Remove mapping of @bpi_type', array(
+              '@bpi_type' => isset($default_values['bpi_node_type']) ? t($default_values['bpi_node_type']) : '–'
+            )),
             '#name' => 'remove_mapping_' . $i,
             '#submit' => array('bpi_admin_content_mapping_form_add_mapping_remove_one'),
             '#ajax' => array(
@@ -343,7 +347,9 @@ function bpi_admin_content_mapping_form_add_mapping_remove_one($form, &$form_sta
     if (isset($bpi_mappings[$index])) {
       $form_state['deleted_mappings'][$index] = $index;
       $form_state['rebuild'] = TRUE;
-      drupal_set_message(t('Save to remove mapping of @bpi_type', array('@bpi_type' => $bpi_mappings[$index]['bpi_node_type'])), 'warning');
+      drupal_set_message(t('Save to remove mapping of @bpi_type', array(
+        '@bpi_type' => t($bpi_mappings[$index]['bpi_node_type']))
+      ), 'warning');
     }
   }
 }

--- a/modules/bpi/bpi.api.php
+++ b/modules/bpi/bpi.api.php
@@ -13,7 +13,7 @@
 /**
  * Return a list of BPI node types a module can handle.
  *
- * @return array
+ * @return string[]
  *   An array of BPI type names.
  */
 function hook_bpi_syndicate_get_bpi_types() {

--- a/modules/bpi/bpi.api.php
+++ b/modules/bpi/bpi.api.php
@@ -42,10 +42,10 @@ function hook_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_
  *
  * @param string $bpi_type
  *   The BPI node type.
- * @param array $form_item
+ * @param array $form
  *   The form.
  */
-function hook_bpi_mapping_form_alter($bpi_type, array &$form_item) {
+function hook_bpi_mapping_form_alter($bpi_type, array &$form) {
 }
 
 /**

--- a/modules/bpi/bpi.api.php
+++ b/modules/bpi/bpi.api.php
@@ -81,13 +81,16 @@ function hook_bpi_convert_to_bpi_alter(array &$bpi_content, $node, array $mappin
 /**
  * Get bpi image type for an image field.
  *
+ * A "bpi image type" is basically a name describing how the image is used;
+ * example image types: 'image', 'list_image', 'title_image'.
+ *
  * @param string $image_field_name
  *   The image field name.
  * @param object $node
  *   The node.
  *
  * @return string|NULL
- *   The image type.
+ *   The bpi image type.
  */
 function hook_bpi_get_image_type($image_field_name, $node) {
     return NULL;

--- a/modules/bpi/bpi.api.php
+++ b/modules/bpi/bpi.api.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @file
+ * Describe hooks provided by the BPI module.
+ */
+
+/**
+ * @addtogroup hooks
+ * @{
+ */
+
+/**
+ * Return a list of BPI node type a module can handle.
+ *
+ * @return array
+ *   An array of BPI type names.
+ */
+function hook_bpi_syndicate_get_bpi_types() {
+}
+
+function hook_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
+}
+
+function hook_bpi_mapping_form_alter($bpi_type, array &$form_item) {
+}
+
+function hook_bpi_syndicate_action_url($bpi_type, $bpi_id, array $mapping) {
+}
+
+/**
+ * Alter data to be pushed to BPI.
+ *
+ * @param array $bpi_content
+ *   The BPI content.
+ * @param array $node
+ *   The node..
+ * @param array $mapping
+ *   The BPI mapping of the node.
+ */
+function hook_bpi_convert_to_bpi_alter(array &$bpi_content, $node, array $mapping) {
+}
+
+/**
+ * Get bpi image type for an image field.
+ *
+ * @param string $image_field_name
+ *   The image field name.
+ * @param object $node
+ *   The node.
+ *
+ * @return string|NULL
+ *   The image type.
+ */
+function hook_bpi_get_image_type($image_field_name, $node) {
+}
+
+/**
+ * @} End of "addtogroup hooks".
+ */

--- a/modules/bpi/bpi.api.php
+++ b/modules/bpi/bpi.api.php
@@ -23,17 +23,17 @@ function hook_bpi_syndicate_get_bpi_types() {
 /**
  * Get form for mapping a BPI node to a Drupal content type.
  *
- * @param string $bpi_type
- *   The BPI type.
+ * @param string $bpi_node_type
+ *   The BPI node type.
  * @param string $content_type
  *   The Drupal content type.
  * @param array $field_mapping
- *   The current field mapping.
+ *   The field mapping (@see bpi_get_mappings() for details).
  *
  * @return array
  *   The mapping form.
  */
-function hook_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
+function hook_bpi_get_field_mapping_form($bpi_node_type, $content_type, array $field_mapping) {
     return array();
 }
 

--- a/modules/bpi/bpi.api.php
+++ b/modules/bpi/bpi.api.php
@@ -11,21 +11,58 @@
  */
 
 /**
- * Return a list of BPI node type a module can handle.
+ * Return a list of BPI node types a module can handle.
  *
  * @return array
  *   An array of BPI type names.
  */
 function hook_bpi_syndicate_get_bpi_types() {
+    return array();
 }
 
+/**
+ * Get form for mapping a BPI node to a Drupal content type.
+ *
+ * @param string $bpi_type
+ *   The BPI type.
+ * @param string $content_type
+ *   The Drupal content type.
+ * @param array $field_mapping
+ *   The current field mapping.
+ *
+ * @return array
+ *   The mapping form.
+ */
 function hook_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
+    return array();
 }
 
+/**
+ * Alter the form for defining a BPI node mapping.
+ *
+ * @param string $bpi_type
+ *   The BPI node type.
+ * @param array $form_item
+ *   The form.
+ */
 function hook_bpi_mapping_form_alter($bpi_type, array &$form_item) {
 }
 
+/**
+ * Get a url used for syndicating a BPI node.
+ *
+ * @param string $bpi_type
+ *   The BPI node type.
+ * @param string $bpi_id
+ *   The BPI node id.
+ * @param array $mapping
+ *   The mapping for the node type.
+ *
+ * @return string|NULL
+ *   The syndicate url.
+ */
 function hook_bpi_syndicate_action_url($bpi_type, $bpi_id, array $mapping) {
+    return NULL;
 }
 
 /**
@@ -53,6 +90,7 @@ function hook_bpi_convert_to_bpi_alter(array &$bpi_content, $node, array $mappin
  *   The image type.
  */
 function hook_bpi_get_image_type($image_field_name, $node) {
+    return NULL;
 }
 
 /**

--- a/modules/bpi/bpi.bpi.inc
+++ b/modules/bpi/bpi.bpi.inc
@@ -20,7 +20,7 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
     $field_options = array('' => '') + bpi_get_field_instances($content_type);
 
     return array(
-      'bpi_field_title' => array(
+      'title' => array(
         '#type' => 'select',
         '#title' => t('BPI title'),
         '#description' => t('Titles are automatically assigned.'),
@@ -29,35 +29,35 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
         '#disabled' => TRUE,
       ),
 
-      'bpi_field_teaser' => array(
+      'teaser' => array(
         '#type' => 'select',
         '#title' => t('BPI teaser'),
         '#description' => t('The field to extract the teaser from. If the content type have a body summary, assign it to the body field.'),
         '#options' => $field_options,
-        '#default_value' => isset($field_mapping['bpi_field_teaser']) ? $field_mapping['bpi_field_teaser'] : NULL,
+        '#default_value' => $field_mapping['teaser'],
       ),
 
-      'bpi_field_body' => array(
+      'body' => array(
         '#type' => 'select',
         '#title' => t('BPI body'),
         '#description' => t('Field to extract the main content from (body field).'),
         '#options' => $field_options,
-        '#default_value' => isset($field_mapping['bpi_field_body']) ? $field_mapping['bpi_field_body'] : NULL,
+        '#default_value' => $field_mapping['body'],
       ),
 
-      'bpi_field_tags' => array(
+      'tags' => array(
         '#type' => 'select',
         '#title' => t('BPI tags'),
         '#options' => $field_options,
-        '#default_value' => isset($field_mapping['bpi_field_tags']) ? $field_mapping['bpi_field_tags'] : NULL,
+        '#default_value' => $field_mapping['tags'],
       ),
 
-      'bpi_field_materials' => array(
+      'materials' => array(
         '#type' => 'select',
         '#title' => t('BPI materials'),
         '#description' => t('Field used to get reference to the T!NG data well.'),
         '#options' => $field_options,
-        '#default_value' => isset($field_mapping['bpi_field_materials']) ? $field_mapping['bpi_field_materials'] : NULL,
+        '#default_value' => $field_mapping['materials'],
       ),
     );
   }
@@ -70,7 +70,7 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
  */
 function bpi_bpi_syndicate_action_url($bpi_type, $bpi_id, array $mapping) {
   if (in_array($bpi_type, bpi_bpi_syndicate_get_bpi_types())) {
-    return url(str_replace('_', '-', 'node/add/' . $mapping['bpi_content_type']), array('query' => array('bpi_type' => $bpi_type, 'bpi_id' => $bpi_id)));
+    return url(str_replace('_', '-', 'node/add/' . $mapping['content_type']), array('query' => array('bpi_type' => $bpi_type, 'bpi_id' => $bpi_id)));
   }
 
   return NULL;

--- a/modules/bpi/bpi.bpi.inc
+++ b/modules/bpi/bpi.bpi.inc
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @file
+ * Implementation of BPI hooks.
+ */
+
+/**
+ * Implements hook_bpi_syndicate_get_bpi_types().
+ */
+function bpi_bpi_syndicate_get_bpi_types() {
+  return array('article');
+}
+
+/**
+ * Implements hook_bpi_get_field_mapping().
+ */
+function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
+  if (in_array($bpi_type, bpi_bpi_syndicate_get_bpi_types())) {
+    $field_options = array('' => '') + bpi_get_field_instances($content_type);
+
+    return array(
+      'bpi_field_title' => array(
+        '#type' => 'select',
+        '#title' => t('BPI title'),
+        '#description' => t('Titles are automatically assigned.'),
+        '#options' => array('title' => t('Title')),
+        '#value' => 'title',
+        '#disabled' => TRUE,
+      ),
+
+      'bpi_field_teaser' => array(
+        '#type' => 'select',
+        '#title' => t('BPI teaser'),
+        '#description' => t('The field to extract the teaser from. If the content type have a body summary, assign it to the body field.'),
+        '#options' => $field_options,
+        '#default_value' => isset($field_mapping['bpi_field_teaser']) ? $field_mapping['bpi_field_teaser'] : NULL,
+      ),
+
+      'bpi_field_body' => array(
+        '#type' => 'select',
+        '#title' => t('BPI body'),
+        '#description' => t('Field to extract the main content from (body field).'),
+        '#options' => $field_options,
+        '#default_value' => isset($field_mapping['bpi_field_body']) ? $field_mapping['bpi_field_body'] : NULL,
+      ),
+
+      'bpi_field_tags' => array(
+        '#type' => 'select',
+        '#title' => t('BPI tags'),
+        '#description' => t(''),
+        '#options' => $field_options,
+        '#default_value' => isset($field_mapping['bpi_field_tags']) ? $field_mapping['bpi_field_tags'] : NULL,
+      ),
+
+      'bpi_field_materials' => array(
+        '#type' => 'select',
+        '#title' => t('BPI materials'),
+        '#description' => t('Field used to get reference to the T!NG data well.'),
+        '#options' => $field_options,
+        '#default_value' => isset($field_mapping['bpi_field_materials']) ? $field_mapping['bpi_field_materials'] : NULL,
+      ),
+    );
+  }
+
+  return NULL;
+}
+
+/**
+ * Implements bpi_syndicate_action_url().
+ */
+function bpi_bpi_syndicate_action_url($bpi_type, $bpi_id, array $mapping) {
+  if (in_array($bpi_type, bpi_bpi_syndicate_get_bpi_types())) {
+    return url(str_replace('_', '-', 'node/add/' . $mapping['bpi_content_type']), array('query' => array('bpi_type' => $bpi_type, 'bpi_id' => $bpi_id)));
+  }
+
+  return NULL;
+}

--- a/modules/bpi/bpi.bpi.inc
+++ b/modules/bpi/bpi.bpi.inc
@@ -17,7 +17,7 @@ function bpi_bpi_syndicate_get_bpi_types() {
  */
 function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
   if (in_array($bpi_type, bpi_bpi_syndicate_get_bpi_types())) {
-    $field_options = array('' => '') + bpi_get_field_instances($content_type);
+    $field_options = bpi_get_field_instances($content_type);
 
     return array(
       'title' => array(
@@ -34,6 +34,7 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
         '#title' => t('BPI teaser'),
         '#description' => t('The field to extract the teaser from. If the content type have a body summary, assign it to the body field.'),
         '#options' => $field_options,
+        '#empty_value' => '',
         '#default_value' => $field_mapping['teaser'],
       ),
 
@@ -42,6 +43,7 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
         '#title' => t('BPI body'),
         '#description' => t('Field to extract the main content from (body field).'),
         '#options' => $field_options,
+        '#empty_value' => '',
         '#default_value' => $field_mapping['body'],
       ),
 
@@ -49,6 +51,7 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
         '#type' => 'select',
         '#title' => t('BPI tags'),
         '#options' => $field_options,
+        '#empty_value' => '',
         '#default_value' => $field_mapping['tags'],
       ),
 
@@ -57,6 +60,7 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
         '#title' => t('BPI materials'),
         '#description' => t('Field used to get reference to the T!NG data well.'),
         '#options' => $field_options,
+        '#empty_value' => '',
         '#default_value' => $field_mapping['materials'],
       ),
     );

--- a/modules/bpi/bpi.bpi.inc
+++ b/modules/bpi/bpi.bpi.inc
@@ -48,7 +48,6 @@ function bpi_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_m
       'bpi_field_tags' => array(
         '#type' => 'select',
         '#title' => t('BPI tags'),
-        '#description' => t(''),
         '#options' => $field_options,
         '#default_value' => isset($field_mapping['bpi_field_tags']) ? $field_mapping['bpi_field_tags'] : NULL,
       ),

--- a/modules/bpi/bpi.images.inc
+++ b/modules/bpi/bpi.images.inc
@@ -245,14 +245,8 @@ function bpi_get_image_type($image_field_name, $node) {
   }
 
   $hook = 'bpi_get_image_type';
-  foreach (module_implements($hook) as $module) {
-    $image_type = module_invoke($module, $hook, $image_field_name, $node);
-    if ($image_type) {
-      return $image_type;
-    }
-  }
-
-  return NULL;
+  // Get image type from first module able to handle the node.
+  return bpi_module_invoke_one($hook, $image_field_name, $node);
 }
 
 /**

--- a/modules/bpi/bpi.images.inc
+++ b/modules/bpi/bpi.images.inc
@@ -243,6 +243,15 @@ function bpi_get_image_type($image_field_name, $node) {
   if (preg_match($pattern, $image_field_name, $matches)) {
     return $matches['image_type'];
   }
+
+  $hook = 'bpi_get_image_type';
+  foreach (module_implements($hook) as $module) {
+    $image_type = module_invoke($module, $hook, $image_field_name, $node);
+    if ($image_type) {
+      return $image_type;
+    }
+  }
+
   return NULL;
 }
 

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -232,13 +232,13 @@ function bpi_update_7007(&$sandbox) {
     $bpi_mappings = array(
       array(
         'bpi_node_type' => 'article',
-        'bpi_content_type' => variable_get('bpi_content_type', ''),
-        'bpi_field_mapping' => array(
-          'bpi_field_title' => variable_get('bpi_field_title', ''),
-          'bpi_field_teaser' => variable_get('bpi_field_teaser', ''),
-          'bpi_field_body' => variable_get('bpi_field_body', ''),
-          'bpi_field_tags' => variable_get('bpi_field_tags', ''),
-          'bpi_field_materials' => variable_get('bpi_field_materials', ''),
+        'content_type' => variable_get('bpi_content_type', ''),
+        'field_mapping' => array(
+          'title' => variable_get('bpi_field_title', ''),
+          'teaser' => variable_get('bpi_field_teaser', ''),
+          'body' => variable_get('bpi_field_body', ''),
+          'tags' => variable_get('bpi_field_tags', ''),
+          'materials' => variable_get('bpi_field_materials', ''),
         ),
       ),
     );

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -218,9 +218,27 @@ function bpi_update_7005() {
 }
 
 /**
+ * Update the database with the newest translations.
+ */
+function bpi_translation_update() {
+  // Update build-in translation group.
+  $file = new stdClass();
+  $file->uri = drupal_get_path('module', 'bpi') . '/translations/da.po';
+  $file->filename = basename($file->uri);
+  _locale_import_po($file, 'da', LOCALE_IMPORT_KEEP, 'default');
+}
+
+/**
+ * Update our own translations.
+ */
+function bpi_update_7006() {
+  bpi_translation_update();
+}
+
+/**
  * Convert single BPI mapping to list of mappings.
  */
-function bpi_update_7006(&$sandbox) {
+function bpi_update_7007(&$sandbox) {
   if (variable_get('bpi_content_type', '')) {
     $bpi_mappings = array(
       array(

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -218,17 +218,6 @@ function bpi_update_7005() {
 }
 
 /**
- * Update the database with the newest translations.
- */
-function bpi_translation_update() {
-  // Update build-in translation group.
-  $file = new stdClass();
-  $file->uri = drupal_get_path('module', 'bpi') . '/translations/da.po';
-  $file->filename = basename($file->uri);
-  _locale_import_po($file, 'da', LOCALE_IMPORT_KEEP, 'default');
-}
-
-/**
  * Update our own translations.
  */
 function bpi_update_7006() {

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -216,3 +216,33 @@ function bpi_update_7005() {
   }
   variable_set('views_defaults', $views_defaults);
 }
+
+/**
+ * Convert single BPI mapping to list of mappings.
+ */
+function bpi_update_7006(&$sandbox) {
+  if (variable_get('bpi_content_type', '')) {
+    $bpi_mappings = array(
+      array(
+        'bpi_node_type' => 'article',
+        'bpi_content_type' => variable_get('bpi_content_type', ''),
+        'bpi_field_mapping' => array(
+          'bpi_field_title' => variable_get('bpi_field_title', ''),
+          'bpi_field_teaser' => variable_get('bpi_field_teaser', ''),
+          'bpi_field_body' => variable_get('bpi_field_body', ''),
+          'bpi_field_tags' => variable_get('bpi_field_tags', ''),
+          'bpi_field_materials' => variable_get('bpi_field_materials', ''),
+        ),
+      ),
+    );
+
+    bpi_set_mappings($bpi_mappings);
+
+    variable_del('bpi_content_type');
+    variable_del('bpi_field_title');
+    variable_del('bpi_field_teaser');
+    variable_del('bpi_field_body');
+    variable_del('bpi_field_tags');
+    variable_del('bpi_field_materials');
+  }
+}

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1321,7 +1321,7 @@ function bpi_ensure_bpi_workflow_fields() {
           'bundle' => $content_type,
           'mode' => $mode,
           'label' => 'BPI',
-          'weight' => '100',
+          'weight' => '36',
           'children' => array($field_name),
           'format_type' => 'tab',
           'format_settings' => array(

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -264,12 +264,12 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
     return;
   }
 
-  $bpi_ctype = $mapping['bpi_content_type'];
+  $content_type = $mapping['content_type'];
 
   $form_state['node']->bpi_id = $bpi_id;
 
   // Checking is_new to see if it's a create node form, not edit.
-  if ($form_id == $bpi_ctype . '_node_form' && !isset($form_state['node']->is_new) && $bpi_id) {
+  if ($form_id == $content_type . '_node_form' && !isset($form_state['node']->is_new) && $bpi_id) {
     $form_state['node']->bpi_id = $bpi_id;
     try {
       $bpi = bpi_client_instance();
@@ -307,11 +307,11 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
 
       return;
     }
-    $field_mapping = $mapping['bpi_field_mapping'];
+    $field_mapping = $mapping['field_mapping'];
     $form['title']['#default_value'] = isset($bpi_content['title']) ? $bpi_content['title'] : '';
-    $teaser = isset($field_mapping['bpi_field_teaser']) ? $field_mapping['bpi_field_teaser'] : NULL;
-    $body = isset($field_mapping['bpi_field_body']) ? $field_mapping['bpi_field_body'] : NULL;
-    $materials_field = isset($field_mapping['bpi_field_materials']) ? $field_mapping['bpi_field_materials'] : NULL;
+    $teaser = isset($field_mapping['teaser']) ? $field_mapping['teaser'] : NULL;
+    $body = isset($field_mapping['body']) ? $field_mapping['body'] : NULL;
+    $materials_field = isset($field_mapping['materials']) ? $field_mapping['materials'] : NULL;
 
     // Current language will be set to undefined, because this module is
     // lexigraphically before the locale module. If e.g. the weight in the
@@ -378,9 +378,9 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
       bpi_clear_syndicated_images();
     }
 
-    if (variable_get('bpi_syndicate_tags')) {
+    if (variable_get('bpi_syndicate_tags') && isset($field_mapping['tags'])) {
       $bpi_tags = $bpi_node->getTags();
-      $tags_field = variable_get('bpi_field_tags', '');
+      $tags_field = $field_mapping['tags'];
       if (!empty($bpi_tags) && !empty($tags_field) && isset($form[$tags_field][$current_language])) {
         $form[$tags_field][$current_language]['#default_value'] = implode(', ', $bpi_tags);
       }
@@ -398,7 +398,7 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
   }
 
   // Add BPI fields.
-  if ($form_id == $bpi_ctype . '_node_form') {
+  if ($form_id == $content_type . '_node_form') {
     // Don't show BPI fields if user doesn't have access to the workflow tab.
     $node = $form['#node'];
     if (!workflow_tab_access("node", $node)) {
@@ -1139,17 +1139,70 @@ function bpi_preprocess_bpi_preview_item(&$variables) {
 }
 
 /**
+ * Create a BPI mapping by merging in default values.
+ *
+ * @see bpi_get_mappings() for details on mappings.
+ *
+ * @param array $mapping
+ *   The (partial) mapping.
+ *
+ * @return array
+ *   The BPI mapping with defaults applied.
+ */
+function bpi_create_mapping(array $mapping) {
+  $default_mapping = array(
+    'bpi_node_type' => NULL,
+    'content_type' => NULL,
+    'field_mapping' => array(),
+  );
+
+  $mapping = array_merge($default_mapping, $mapping);
+
+  return $mapping;
+}
+
+/**
  * Set BPI mappings.
+ *
+ * @see bpi_get_mappings() for details on mappings.
  *
  * @param array $bpi_mappings
  *   The mappings.
  */
-function bpi_set_mappings(array $bpi_mappings) {
-  variable_set('bpi_mappings', $bpi_mappings);
+function bpi_set_mappings(array $mappings) {
+  // Make sure that all mappings have default values.
+  $mappings = array_map('bpi_create_mapping', $mappings);
+
+  variable_set('bpi_mappings', $mappings);
 }
 
 /**
  * Get all BPI mappings.
+ *
+ * A BPI mapping maps a Drupal content type to a BPI content type. A mapping
+ * is an array with the following keys
+ *
+ *   'bpi_node_type' string the BPI node type, e.g. "article" or "campaign".
+ *   'content_type' string The Drupal content type.
+ *   'field_mapping' array Mapping (string => string) from BPI node field to
+ *                         Drupal content type field
+ *
+ * The value of 'field_mapping' depends on the Drupal content type.
+ *
+ * An example mapping for the "ding_news" Drupal content type:
+ *
+ *   array(
+ *     'bpi_node_type' => 'article',
+ *     'content_type' => 'ding_news',
+ *     'field_mapping' => array(
+ *       'title' => 'title',
+ *       'teaser' => 'field_ding_news_lead',
+ *       'body' => 'field_ding_news_body',
+ *       'tags' => 'field_ding_news_tags',
+ *       'materials' => 'field_ding_news_materials',
+ *     ),
+ *   )
+ *
  *
  * @return array
  *   All defined mappings.
@@ -1160,6 +1213,8 @@ function bpi_get_mappings() {
 
 /**
  * Get mapping of a BPI node type.
+ *
+ * @see bpi_get_mappings() for details on the mapping.
  *
  * @param string $bpi_type
  *   The BPI node type.
@@ -1182,6 +1237,8 @@ function bpi_get_mapping($bpi_type) {
 /**
  * Get mapping of a BPI node type by Drupal content type.
  *
+ * @see bpi_get_mappings() for details on the mapping.
+ *
  * @param string $content_type
  *   The Drupal content type.
  *
@@ -1192,7 +1249,7 @@ function bpi_get_mapping_by_content_type($content_type) {
   $mappings = bpi_get_mappings();
 
   foreach ($mappings as $mapping) {
-    if (isset($mapping['bpi_content_type']) && $mapping['bpi_content_type'] === $content_type) {
+    if ($mapping['content_type'] === $content_type) {
       return $mapping;
     }
   }
@@ -1211,7 +1268,7 @@ function bpi_ensure_bpi_workflow_fields() {
     $mappings = bpi_get_mappings();
     foreach ($mappings as $mapping) {
       // Create workflow field.
-      $content_type = $mapping['bpi_content_type'];
+      $content_type = $mapping['content_type'];
       $field_instance = field_info_instance($entity_type, $field_name, $content_type);
       if ($field_instance === NULL) {
         $instance = array(

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1228,7 +1228,7 @@ function bpi_ensure_bpi_workflow_fields() {
             ),
             'type' => 'workflow_default',
             'weight' => 35,
-          )
+          ),
         );
         field_create_instance($instance);
         drupal_set_message(t('Added BPI workflow field to content type @content_type', array('@content_type' => $content_type)));
@@ -1238,7 +1238,7 @@ function bpi_ensure_bpi_workflow_fields() {
       $group_name = 'group_workflow';
       $mode = 'form';
       if (!field_group_exists($group_name, $entity_type, $content_type, $mode)) {
-        $group = (object)array(
+        $group = (object) array(
           'identifier' => $group_name . '|' . $entity_type . '|' . $content_type . '|' . $mode,
           'group_name' => $group_name,
           'entity_type' => $entity_type,

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1199,3 +1199,72 @@ function bpi_get_mapping_by_content_type($content_type) {
 
   return NULL;
 }
+
+/**
+ * Ensure that all content types used by BPI has the BPI workflow field.
+ */
+function bpi_ensure_bpi_workflow_fields() {
+  $entity_type = 'node';
+  $field_name = 'field_bpi_workflow';
+  $workflow_field = field_info_field($field_name);
+  if ($workflow_field !== NULL) {
+    $mappings = bpi_get_mappings();
+    foreach ($mappings as $mapping) {
+      // Create workflow field.
+      $content_type = $mapping['bpi_content_type'];
+      $field_instance = field_info_instance($entity_type, $field_name, $content_type);
+      if ($field_instance === NULL) {
+        $instance = array(
+          'field_name' => $field_name,
+          'entity_type' => 'node',
+          'label' => 'BPI workflow',
+          'bundle' => $content_type,
+          'widget' => array(
+            'active' => 1,
+            'module' => 'workflowfield',
+            'settings' => array(
+              'comment' => 1,
+              'name_as_title' => 1,
+            ),
+            'type' => 'workflow_default',
+            'weight' => 35,
+          )
+        );
+        field_create_instance($instance);
+        drupal_set_message(t('Added BPI workflow field to content type @content_type', array('@content_type' => $content_type)));
+      }
+
+      // Create workflow group.
+      $group_name = 'group_workflow';
+      $mode = 'form';
+      if (!field_group_exists($group_name, $entity_type, $content_type, $mode)) {
+        $group = (object)array(
+          'identifier' => $group_name . '|' . $entity_type . '|' . $content_type . '|' . $mode,
+          'group_name' => $group_name,
+          'entity_type' => $entity_type,
+          'bundle' => $content_type,
+          'mode' => $mode,
+          'label' => 'BPI',
+          'weight' => '100',
+          'children' => array($field_name),
+          'format_type' => 'tab',
+          'format_settings' => array(
+            'label' => 'BPI',
+            'instance_settings' => array(
+              'required_fields' => 0,
+              'classes' => '',
+              'description' => 'Data in this group will only be saved when "Save and push" is used.',
+            ),
+            'formatter' => 'closed',
+          ),
+        );
+        drupal_set_message(t('Saving BPI workflow group'));
+        field_group_group_save($group);
+
+        // Enable the field group.
+        ctools_include('export');
+        ctools_export_crud_enable('field_group', $group->identifier);
+      }
+    }
+  }
+}

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1258,7 +1258,6 @@ function bpi_ensure_bpi_workflow_fields() {
             'formatter' => 'closed',
           ),
         );
-        drupal_set_message(t('Saving BPI workflow group'));
         field_group_group_save($group);
 
         // Enable the field group.

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -88,14 +88,6 @@ function bpi_menu() {
     'file' => 'bpi.preview.inc',
   );
 
-  $menu['admin/bpi/syndicate/%/%'] = array(
-    'page callback' => 'bpi_syndicate_action',
-    'page arguments' => array(3, 4),
-    'access arguments' => array('bpi syndicate content'),
-    'type' => MENU_CALLBACK,
-    'file' => 'bpi.syndicate.inc',
-  );
-
   $menu['admin/bpi/statistics/nojs'] = array(
     'title' => 'BPI statistics',
     'page callback' => 'bpi_statistics',

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1115,6 +1115,7 @@ function bpi_features_views_default_views_alter(&$views) {
   }
 }
 
+
 /**
  * Implements hook_preprocess_HOOK().
  *
@@ -1128,6 +1129,32 @@ function bpi_preprocess_bpi_preview_item(&$variables) {
   if ($bpi_agency_id === $bpi_item['agency_id']) {
     $variables['hide_syndicate_link'] = TRUE;
   }
+}
+
+/**
+ * Invoke hook in modules and return first non-empty result if any.
+ *
+ * @param $hook
+ *   The name of the hook to invoke.
+ * @param ...
+ *   Arguments to pass to the hook.
+ *
+ * @return mixed|null
+ */
+function bpi_module_invoke_one($hook) {
+  $args = func_get_args();
+  unset($args[0]);
+  foreach (module_implements($hook) as $module) {
+    $function = $module . '_' . $hook;
+    if (function_exists($function)) {
+      $result = call_user_func_array($function, $args);
+      if (!empty($result)) {
+        return $result;
+      }
+    }
+  }
+
+  return NULL;
 }
 
 /**

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -8,6 +8,7 @@
 
 include_once drupal_get_path('module', 'bpi') . '/bpi.images.inc';
 include_once drupal_get_path('module', 'bpi') . '/bpi.push.inc';
+include_once drupal_get_path('module', 'bpi') . '/bpi.bpi.inc';
 
 /**
  * URL search query key.
@@ -87,9 +88,9 @@ function bpi_menu() {
     'file' => 'bpi.preview.inc',
   );
 
-  $menu['admin/bpi/syndicate/%'] = array(
+  $menu['admin/bpi/syndicate/%/%'] = array(
     'page callback' => 'bpi_syndicate_action',
-    'page arguments' => array(3),
+    'page arguments' => array(3, 4),
     'access arguments' => array('bpi syndicate content'),
     'type' => MENU_CALLBACK,
     'file' => 'bpi.syndicate.inc',
@@ -228,6 +229,7 @@ function bpi_theme($existing, $type, $theme, $path) {
       'template' => 'bpi-filter-item',
     ),
     'bpi_preview_item' => array(
+      'variables' => array('item' => array(), 'no_actions' => FALSE),
       'path' => $path . '/templates/',
       'template' => 'bpi-preview-item',
     ),
@@ -249,13 +251,21 @@ function bpi_theme($existing, $type, $theme, $path) {
  * handler, which will add our own submit handler.
  */
 function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
-  $bpi_ctype = variable_get('bpi_content_type', '');
+  $bpi_type = isset($_GET['bpi_type']) ? (string) $_GET['bpi_type'] : FALSE;
+  $bpi_id = isset($_GET['bpi_id']) ? (string) $_GET['bpi_id'] : FALSE;
 
-  if (empty($bpi_ctype)) {
+  if (empty($bpi_type) || empty($bpi_id)) {
     return;
   }
 
-  $bpi_id = isset($_GET['bpi_id']) ? (string) $_GET['bpi_id'] : FALSE;
+  $mapping = bpi_get_mapping($bpi_type);
+
+  if (empty($mapping)) {
+    return;
+  }
+
+  $bpi_ctype = $mapping['bpi_content_type'];
+
   $form_state['node']->bpi_id = $bpi_id;
 
   // Checking is_new to see if it's a create node form, not edit.
@@ -297,11 +307,11 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
 
       return;
     }
-
+    $field_mapping = $mapping['bpi_field_mapping'];
     $form['title']['#default_value'] = isset($bpi_content['title']) ? $bpi_content['title'] : '';
-    $teaser = variable_get('bpi_field_teaser', '');
-    $body = variable_get('bpi_field_body', '');
-    $materials_field = variable_get('bpi_field_materials', '');
+    $teaser = isset($field_mapping['bpi_field_teaser']) ? $field_mapping['bpi_field_teaser'] : NULL;
+    $body = isset($field_mapping['bpi_field_body']) ? $field_mapping['bpi_field_body'] : NULL;
+    $materials_field = isset($field_mapping['bpi_field_materials']) ? $field_mapping['bpi_field_materials'] : NULL;
 
     // Current language will be set to undefined, because this module is
     // lexigraphically before the locale module. If e.g. the weight in the
@@ -382,6 +392,9 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
     elseif (isset($form[$body][$current_language][0])) {
       $form[$body][$current_language][0]['#default_value'] = $bpi_body;
     }
+
+    // Call hooks to handle specific bpi content type.
+    drupal_alter('bpi_syndicate_form', $form, $bpi_content, $syndicated_images);
   }
 
   // Add BPI fields.
@@ -1123,4 +1136,66 @@ function bpi_preprocess_bpi_preview_item(&$variables) {
   if ($bpi_agency_id === $bpi_item['agency_id']) {
     $variables['hide_syndicate_link'] = TRUE;
   }
+}
+
+/**
+ * Set BPI mappings.
+ *
+ * @param array $bpi_mappings
+ *   The mappings.
+ */
+function bpi_set_mappings(array $bpi_mappings) {
+  variable_set('bpi_mappings', $bpi_mappings);
+}
+
+/**
+ * Get all BPI mappings.
+ *
+ * @return array
+ *   All defined mappings.
+ */
+function bpi_get_mappings() {
+  return variable_get('bpi_mappings', array());
+}
+
+/**
+ * Get mapping of a BPI node type.
+ *
+ * @param string $bpi_type
+ *   The BPI node type.
+ *
+ * @return null|array
+ *   The mapping if it exists. Otherwise null.
+ */
+function bpi_get_mapping($bpi_type) {
+  $mappings = bpi_get_mappings();
+
+  foreach ($mappings as $mapping) {
+    if ($mapping['bpi_node_type'] === $bpi_type) {
+      return $mapping;
+    }
+  }
+
+  return NULL;
+}
+
+/**
+ * Get mapping of a BPI node type by Drupal content type.
+ *
+ * @param string $content_type
+ *   The Drupal content type.
+ *
+ * @return null|array
+ *   The mapping if it exists. Otherwise null.
+ */
+function bpi_get_mapping_by_content_type($content_type) {
+  $mappings = bpi_get_mappings();
+
+  foreach ($mappings as $mapping) {
+    if (isset($mapping['bpi_content_type']) && $mapping['bpi_content_type'] === $content_type) {
+      return $mapping;
+    }
+  }
+
+  return NULL;
 }

--- a/modules/bpi/bpi.preview.inc
+++ b/modules/bpi/bpi.preview.inc
@@ -20,12 +20,6 @@ function admin_bpi_preview_ajax_callback($type, $bpi_id) {
     return _admin_bpi_preview_output($type, t('Incorrect BPI ID.'));
   }
 
-  $bpi_ctype = variable_get('bpi_content_type', '');
-  // This could lead to unexpected behavior. Just a note.
-  if (empty($bpi_ctype)) {
-    return _admin_bpi_preview_output($type, t('BPI is not mapped to any content type.'));
-  }
-
   // Load bpi.syndicate.inc for label mappers.
   module_load_include('inc', 'bpi', 'bpi.syndicate');
 
@@ -39,7 +33,10 @@ function admin_bpi_preview_ajax_callback($type, $bpi_id) {
     return _admin_bpi_preview_output($type, t('Failed to fetch the article from BPI well.'));
   }
 
-  $output = theme('bpi_preview_item', array('item' => $bpi_content));
+  $output = theme('bpi_preview_item', array(
+    'item' => $bpi_content,
+    'syndicate_url' => bpi_get_syndicate_url($bpi_content['type'], $bpi_content['id']),
+  ));
 
   return _admin_bpi_preview_output($type, $output);
 }

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -134,7 +134,7 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
   $bpi_content['title'] = $node->title;
 
   $teaser_field = isset($mapping['bpi_field_mapping']['bpi_field_teaser']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_teaser']) : NULL;
-  $body_field = isset($mapping['bpi_field_mapping']['bpi_field_body']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_body']) : '';
+  $body_field = isset($mapping['bpi_field_mapping']['bpi_field_body']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_body']) : NULL;
   $teaser = bpi_get_field_value($teaser_field);
   $body = bpi_get_field_value($body_field);
 
@@ -257,13 +257,13 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
 /**
  * Get string value from a content type field.
  *
- * @param $field
+ * @param array|NULL $field
  *   The field.
  *
  * @return string
  *   The field value.
  */
-function bpi_get_field_value($field) {
+function bpi_get_field_value(array $field = NULL) {
   $value = '';
 
   if (!empty($field)) {

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -133,45 +133,48 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
 
   $bpi_content['title'] = $node->title;
 
-  $teaser_field = isset($mapping['bpi_field_mapping']['bpi_field_teaser']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_teaser']) : NULL;
-  $body_field = isset($mapping['bpi_field_mapping']['bpi_field_body']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_body']) : NULL;
+	$field_mapping = $mapping['field_mapping'];
+  $teaser_field = isset($field_mapping['teaser']) ? field_view_field('node', $node, $field_mapping['teaser']) : NULL;
+  $body_field = isset($field_mapping['body']) ? field_view_field('node', $node, $field_mapping['body']) : NULL;
   $teaser = bpi_get_field_value($teaser_field);
   $body = bpi_get_field_value($body_field);
 
   // Find the references to the ting date well.
   $materials_drupal = array();
   if ($with_refs) {
-    // Function field_get_items returns data with 2 different structure, depending from stage when it was called.
-    $items = field_get_items('node', $node, variable_get('bpi_field_materials', ''));
-    foreach ((array) $items as $item) {
-      // First case, we have completly saved node, when it returns ding_object_id.
-      if (!empty($item['ting_object_id'])) {
-        $id = $item['ting_object_id'];
-        // Filter out id's with "katalog" PID, as they only makes sens on
-        // current site.
-        if (!preg_match('/katalog/', $id)) {
-          $materials_drupal[] = $id;
-        }
-        // Second case, we used "Save and push" button and node wasn't completly saved
-        // In this case, we have object of class Relation.
-        elseif (isset($item['value']->endpoints)) {
-          $endpoints = $item['value']->endpoints;
-          $data = array_filter($endpoints[LANGUAGE_NONE], function ($i) {
-            return $i['entity_type'] == 'ting_object';
-          });
-          if (!empty($data)) {
-            $ting_data = current($data);
-            $ting_object = entity_load_single('ting_object', $ting_data['entity_id']);
-            if ($ting_object) {
-              if (!preg_match('/katalog/', $ting_object->ding_entity_id)) {
-                $materials_drupal[] = $ting_object->ding_entity_id;
-              }
-            }
-          }
-        }
-      }
-    }
-  }
+    if (isset($field_mapping['materials'])) {
+      // Function field_get_items returns data with 2 different structure, depending from stage when it was called.
+			$items = field_get_items('node', $node, $field_mapping['materials']);
+			foreach ((array) $items as $item) {
+				// First case, we have completly saved node, when it returns ding_object_id.
+				if (!empty($item['ting_object_id'])) {
+					$id = $item['ting_object_id'];
+					// Filter out id's with "katalog" PID, as they only makes sens on
+					// current site.
+					if (!preg_match('/katalog/', $id)) {
+						$materials_drupal[] = $id;
+					}
+				}
+				// Second case, we used "Save and push" button and node wasn't completly saved
+				// In this case, we have object of class Relation.
+				elseif (isset($item['value']->endpoints)) {
+					$endpoints = $item['value']->endpoints;
+					$data = array_filter($endpoints[LANGUAGE_NONE], function ($i) {
+						return $i['entity_type'] == 'ting_object';
+					});
+					if (!empty($data)) {
+						$ting_data = current($data);
+						$ting_object = entity_load_single('ting_object', $ting_data['entity_id']);
+						if ($ting_object) {
+							if (!preg_match('/katalog/', $ting_object->ding_entity_id)) {
+								$materials_drupal[] = $ting_object->ding_entity_id;
+							}
+						}
+					}
+				}
+			}
+		}
+	}
 
   // Empty the teaser, if body and teaser are mapped to same fields
   // and the values are identical.
@@ -230,15 +233,17 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
   }
 
   $tags = array();
-  $tags_field_name = variable_get('bpi_field_tags', '');
-  if (!empty($tags_field_name)) {
-    // We use field_view_field (rather than field_get_items, say) to get the
-    // actual taxonomy term names which we need to push to bpi.
-    $tags_field = field_view_field('node', $node, $tags_field_name);
-    if ($tags_field && isset($tags_field['#items'])) {
-      foreach ($tags_field['#items'] as $item) {
-        if (isset($item['taxonomy_term'])) {
-          $tags[] = $item['taxonomy_term']->name;
+  if (isset($field_mapping['tags'])) {
+    $tags_field_name = $field_mapping['tags'];
+    if (!empty($tags_field_name)) {
+      // We use field_view_field (rather than field_get_items, say) to get the
+      // actual taxonomy term names which we need to push to bpi.
+      $tags_field = field_view_field('node', $node, $tags_field_name);
+      if ($tags_field && isset($tags_field['#items'])) {
+        foreach ($tags_field['#items'] as $item) {
+          if (isset($item['taxonomy_term'])) {
+            $tags[] = $item['taxonomy_term']->name;
+          }
         }
       }
     }

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -118,7 +118,7 @@ function bpi_http_push_action_form($nid) {
  * @todo Add a hook allowing changing the values before they are sent to BPI.
  * @todo Split this function into smaller parts (ex: images, texts).
  */
-function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $authorship = FALSE, $editable = 1, $with_refs = FALSE) {
+function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $authorship = FALSE, $editable = 1, $with_refs = FALSE, array $mapping = array()) {
   $bpi_content = array();
 
   $bpi_content['agency_id'] = variable_get('bpi_agency_id', '');
@@ -133,23 +133,10 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
 
   $bpi_content['title'] = $node->title;
 
-
-  $teaser_field = field_view_field('node', $node, variable_get('bpi_field_teaser', ''));
-  $body_field = field_view_field('node', $node, variable_get('bpi_field_body', ''));
-  $teaser = '';
-  $body = '';
-
-  // Whether the field is a text area with summary, fetch the summary, if not -
-  // fetch it's safe value.
-  if (!empty($teaser_field) && isset($teaser_field['#items'][0]['safe_summary'])) {
-    $teaser = $teaser_field['#items'][0]['safe_summary'];
-  }
-  elseif (isset($teaser_field['#items'][0]['safe_value'])) {
-    $teaser = $teaser_field['#items'][0]['safe_value'];
-  }
-  elseif (isset($teaser_field[0]['#markup'])) {
-    $teaser = $teaser_field[0]['#markup'];
-  }
+  $teaser_field = isset($mapping['bpi_field_mapping']['bpi_field_teaser']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_teaser']) : NULL;
+  $body_field = isset($mapping['bpi_field_mapping']['bpi_field_body']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_body']) : '';
+  $teaser = bpi_get_field_value($teaser_field);
+  $body = bpi_get_field_value($body_field);
 
   // Find the references to the ting date well.
   $materials_drupal = array();
@@ -165,32 +152,25 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
         if (!preg_match('/katalog/', $id)) {
           $materials_drupal[] = $id;
         }
-      }
-      // Second case, we used "Save and push" button and node wasn't completly saved
-      // In this case, we have object of class Relation.
-      elseif (isset($item['value']->endpoints)) {
-        $endpoints = $item['value']->endpoints;
-        $data = array_filter($endpoints[LANGUAGE_NONE], function ($i) {
-          return $i['entity_type'] == 'ting_object';
-        });
-        if (!empty($data)) {
-          $ting_data = current($data);
-          $ting_object = entity_load_single('ting_object', $ting_data['entity_id']);
-          if ($ting_object) {
-            if (!preg_match('/katalog/', $ting_object->ding_entity_id)) {
-              $materials_drupal[] = $ting_object->ding_entity_id;
+        // Second case, we used "Save and push" button and node wasn't completly saved
+        // In this case, we have object of class Relation.
+        elseif (isset($item['value']->endpoints)) {
+          $endpoints = $item['value']->endpoints;
+          $data = array_filter($endpoints[LANGUAGE_NONE], function ($i) {
+            return $i['entity_type'] == 'ting_object';
+          });
+          if (!empty($data)) {
+            $ting_data = current($data);
+            $ting_object = entity_load_single('ting_object', $ting_data['entity_id']);
+            if ($ting_object) {
+              if (!preg_match('/katalog/', $ting_object->ding_entity_id)) {
+                $materials_drupal[] = $ting_object->ding_entity_id;
+              }
             }
           }
         }
       }
     }
-  }
-
-  if (!empty($body_field) && isset($body_field['#items'][0]['safe_value'])) {
-    $body = $body_field['#items'][0]['safe_value'];
-  }
-  elseif (isset($body_field[0]['#markup'])) {
-    $body = $body_field[0]['#markup'];
   }
 
   // Empty the teaser, if body and teaser are mapped to same fields
@@ -204,7 +184,7 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
   $dt = new DateTime();
   $dt->setTimestamp($node->changed);
   $bpi_content['creation'] = $dt->format(DateTime::W3C);
-  $bpi_content['type'] = $node->type;
+  $bpi_content['type'] = $mapping['bpi_node_type'];
   $bpi_content['category'] = $category;
   $bpi_content['audience'] = $audience;
   $bpi_content['related_materials'] = $materials_drupal;
@@ -265,8 +245,45 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
   }
   $bpi_content['tags'] = implode(',', $tags);
 
+  drupal_alter('bpi_convert_to_bpi', $bpi_content, $node, $mapping);
+
+  if (is_array($bpi_content['data'])) {
+    $bpi_content['data'] = json_encode($bpi_content['data']);
+  }
+
   return $bpi_content;
 }
+
+/**
+ * Get string value from a content type field.
+ *
+ * @param $field
+ *   The field.
+ *
+ * @return string
+ *   The field value.
+ */
+function bpi_get_field_value($field) {
+  $value = '';
+
+  if (!empty($field)) {
+    if (isset($field['#items'][0]['safe_summary'])) {
+      $value = $field['#items'][0]['safe_summary'];
+    }
+    elseif (isset($field['#items'][0]['safe_value'])) {
+      $value = $field['#items'][0]['safe_value'];
+    }
+    elseif (isset($field['#items'][0]['value'])) {
+      $value = $field['#items'][0]['value'];
+    }
+    elseif (isset($field[0]['#markup'])) {
+      $value = $field[0]['#markup'];
+    }
+  }
+
+  return $value;
+}
+
 
 /**
  * Fetch image field types.

--- a/modules/bpi/bpi.rules.inc
+++ b/modules/bpi/bpi.rules.inc
@@ -57,6 +57,12 @@ function bpi_rules_push($node) {
     return FALSE;
   }
 
+  $bpi_mapping = bpi_get_mapping_by_content_type($node->type);
+  if (empty($bpi_mapping)) {
+    drupal_set_message(t('No BPI mapping defined for content type @type', array('@type' => $node->type)), 'error');
+    return FALSE;
+  }
+
   // Don't push to BPI if new sid (workflow state id) is the same as old sid.
   if ($node->workflow_transitions['field_bpi_workflow']->old_sid == $node->workflow_transitions['field_bpi_workflow']->new_sid) {
     return;
@@ -86,7 +92,7 @@ function bpi_rules_push($node) {
     return FALSE;
   }
 
-  $bpi_content = bpi_convert_to_bpi($node, $category, $audience, $with_images, FALSE, $editable, $with_refs);
+  $bpi_content = bpi_convert_to_bpi($node, $category, $audience, $with_images, FALSE, $editable, $with_refs, $bpi_mapping);
 
   $bpi = bpi_client_instance();
   $push_result = $bpi->push($bpi_content)->getProperties();

--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -324,6 +324,7 @@ function bpi_search_get_items() {
     // Transform \Bpi\Sdk\Document properties items into array.
     $bpi_nodes[] = array(
       'bpi_id' => isset($current_item['id']) ? $current_item['id'] : '',
+      'type' => isset($current_item['type']) ? $current_item['type'] : '',
       'title' => isset($current_item['title']) ? $current_item['title'] : '',
       'date' => isset($current_item['pushed']) ? $current_item['pushed'] : '',
       'teaser' => isset($current_item['teaser']) ? $current_item['teaser'] : '',
@@ -369,6 +370,10 @@ function bpi_preprocess_bpi_search_results(array &$variables) {
 
   $table_head = array(
     array(
+      'data' => bpi_get_sort_link(t('Type'), 'type'),
+      'class' => array('bpi-type', _bpi_get_current_sorting('type') ? 'active' : ''),
+    ),
+    array(
       'data' => bpi_get_sort_link(t('Title'), 'title'),
       'class' => array('bpi-title', _bpi_get_current_sorting('title') ? 'active' : ''),
     ),
@@ -402,6 +407,7 @@ function bpi_preprocess_bpi_search_results(array &$variables) {
 
   $rows = array();
   foreach ($items as $i => $item) {
+    $rows[$i]['type'] = $item['type'];
     $rows[$i]['title'] = sprintf(
       '<b>%s</b><br />%s',
       $item['title'],
@@ -451,10 +457,14 @@ function bpi_preprocess_bpi_search_results(array &$variables) {
     // No need to be able to syndicate own content.
     // The ownership is based on agency id.
     if ($bpi_agency_id != $item['agency_id']) {
-      $actions[] = l(
-        t('Syndicate'),
-        'admin/bpi/syndicate/' . $item['bpi_id']
-      );
+			$syndicate_url = bpi_get_syndicate_url($item['type'], $item['bpi_id']);
+			if ($syndicate_url) {
+				$actions[] = '<a href="' . check_plain($syndicate_url) . '">' . t('Syndicate') . '</a>';
+			}
+		}
+
+    if (isset($variables['actions_callback']) && is_callable($variables['actions_callback'])) {
+      $variables['actions_callback']($actions, $item, $variables);
     }
 
     $rows[$i]['actions'] = implode(' ', $actions);
@@ -680,15 +690,40 @@ function bpi_available_map() {
  * @param int $bpi_id
  *   Content ID, as as stored in BPI service.
  */
-function bpi_syndicate_action($bpi_id) {
-  $bpi_ctype = variable_get('bpi_content_type', '');
+function bpi_syndicate_action($bpi_type, $bpi_id) {
+  $mapping = bpi_get_mapping($bpi_type);
 
-  if (!empty($bpi_ctype)) {
-    drupal_goto(str_replace('_', '-', 'node/add/' . $bpi_ctype), array('query' => array('bpi_id' => $bpi_id)));
-  }
-  else {
+  if (!empty($mapping) && !empty($mapping['bpi_content_type'])) {
+    $hook = 'bpi_syndicate_action_url';
+    foreach (module_implements($hook) as $module) {
+      $url = module_invoke($module, $hook, $bpi_type, $bpi_id, $mapping);
+      if (!empty($url)) {
+        header('Location: ' . $url, TRUE, 301);
+        drupal_exit($url);
+      }
+    }
+    drupal_set_message(t('Cannot syndicate @type', array('@type' => $bpi_type)), 'warning');
     drupal_goto('admin/bpi');
   }
+  else {
+    drupal_set_message(t('Cannot find BPI mapping for @type', array('@type' => $bpi_type)), 'warning');
+    drupal_goto('admin/bpi');
+  }
+}
+
+function bpi_get_syndicate_url($bpi_type, $bpi_id) {
+  $mapping = bpi_get_mapping($bpi_type);
+  if (!empty($mapping)) {
+    $hook = 'bpi_syndicate_action_url';
+    foreach (module_implements($hook) as $module) {
+      $url = module_invoke($module, $hook, $bpi_type, $bpi_id, $mapping);
+      if (!empty($url)) {
+        return $url;
+      }
+    }
+  }
+
+  return NULL;
 }
 
 /**

--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -711,6 +711,20 @@ function bpi_syndicate_action($bpi_type, $bpi_id) {
   }
 }
 
+/**
+ * Get url for syndicating a BPI node.
+ *
+ * All modules implementing BPI syndication will be asked for the url used to
+ * syndicate the node.
+ *
+ * @param string $bpi_type
+ *   The bpi type.
+ * @param string $bpi_id
+ *   The bpi node id.
+ *
+ * @return string|NULL
+ *   The syndicate url.
+ */
 function bpi_get_syndicate_url($bpi_type, $bpi_id) {
   $mapping = bpi_get_mapping($bpi_type);
   if (!empty($mapping)) {

--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -682,36 +682,6 @@ function bpi_available_map() {
 }
 
 /**
- * Prepares data before the actual syndication occurs.
- *
- * Creates a session entry, storing the BPI content, which is lately
- * inserted into an empty corresponding node form.
- *
- * @param int $bpi_id
- *   Content ID, as as stored in BPI service.
- */
-function bpi_syndicate_action($bpi_type, $bpi_id) {
-  $mapping = bpi_get_mapping($bpi_type);
-
-  if (!empty($mapping) && !empty($mapping['content_type'])) {
-    $hook = 'bpi_syndicate_action_url';
-    foreach (module_implements($hook) as $module) {
-      $url = module_invoke($module, $hook, $bpi_type, $bpi_id, $mapping);
-      if (!empty($url)) {
-        header('Location: ' . $url, TRUE, 301);
-        drupal_exit($url);
-      }
-    }
-    drupal_set_message(t('Cannot syndicate @type', array('@type' => $bpi_type)), 'warning');
-    drupal_goto('admin/bpi');
-  }
-  else {
-    drupal_set_message(t('Cannot find BPI mapping for @type', array('@type' => $bpi_type)), 'warning');
-    drupal_goto('admin/bpi');
-  }
-}
-
-/**
  * Get url for syndicating a BPI node.
  *
  * All modules implementing BPI syndication will be asked for the url used to

--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -693,7 +693,7 @@ function bpi_available_map() {
 function bpi_syndicate_action($bpi_type, $bpi_id) {
   $mapping = bpi_get_mapping($bpi_type);
 
-  if (!empty($mapping) && !empty($mapping['bpi_content_type'])) {
+  if (!empty($mapping) && !empty($mapping['content_type'])) {
     $hook = 'bpi_syndicate_action_url';
     foreach (module_implements($hook) as $module) {
       $url = module_invoke($module, $hook, $bpi_type, $bpi_id, $mapping);

--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -459,7 +459,9 @@ function bpi_preprocess_bpi_search_results(array &$variables) {
     if ($bpi_agency_id != $item['agency_id']) {
 			$syndicate_url = bpi_get_syndicate_url($item['type'], $item['bpi_id']);
 			if ($syndicate_url) {
-				$actions[] = '<a href="' . check_plain($syndicate_url) . '">' . t('Syndicate') . '</a>';
+				// Handle the syndicate url as en external url to prevent encoding of
+				// the query string.
+				$actions[] = l(t('Syndicate'), $syndicate_url, array('external' => TRUE));
 			}
 		}
 

--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -689,24 +689,20 @@ function bpi_available_map() {
  * All modules implementing BPI syndication will be asked for the url used to
  * syndicate the node.
  *
- * @param string $bpi_type
- *   The bpi type.
+ * @param string $bpi_node_type
+ *   The bpi node type.
  * @param string $bpi_id
  *   The bpi node id.
  *
  * @return string|NULL
  *   The syndicate url.
  */
-function bpi_get_syndicate_url($bpi_type, $bpi_id) {
-  $mapping = bpi_get_mapping($bpi_type);
+function bpi_get_syndicate_url($bpi_node_type, $bpi_id) {
+  $mapping = bpi_get_mapping($bpi_node_type);
   if (!empty($mapping)) {
     $hook = 'bpi_syndicate_action_url';
-    foreach (module_implements($hook) as $module) {
-      $url = module_invoke($module, $hook, $bpi_type, $bpi_id, $mapping);
-      if (!empty($url)) {
-        return $url;
-      }
-    }
+    // Get syndicate url from first module able to handle the node type.
+    return bpi_module_invoke_one($hook, $bpi_node_type, $bpi_id, $mapping);
   }
 
   return NULL;

--- a/modules/bpi/bpi_features/bpi_features.install
+++ b/modules/bpi/bpi_features/bpi_features.install
@@ -1,0 +1,12 @@
+<?php
+/**
+ * @file
+ * Install/uninstall, database related stuff here.
+ */
+
+/**
+ * Revert BPI workflow features.
+ */
+function bpi_features_update_7001(&$sandbox) {
+  features_revert(array('bpi_features' => array('rules_config')));
+}

--- a/modules/bpi/bpi_features/bpi_features.rules_defaults.inc
+++ b/modules/bpi/bpi_features/bpi_features.rules_defaults.inc
@@ -14,8 +14,9 @@ function bpi_features_default_rules_configuration() {
       "PLUGIN" : "reaction rule",
       "OWNER" : "rules",
       "REQUIRES" : [ "rules" ],
-      "ON" : { "node_update--ding_news" : { "bundle" : "ding_news" } },
+      "ON" : { "node_update" : [] },
       "IF" : [
+        { "entity_has_field" : { "entity" : [ "node" ], "field" : "field_bpi_workflow" } },
         { "data_is" : { "data" : [ "node:field-bpi-workflow" ], "value" : "4" } }
       ],
       "DO" : [ { "bpi_rules_push" : { "entity" : [ "node" ] } } ]
@@ -26,8 +27,9 @@ function bpi_features_default_rules_configuration() {
       "PLUGIN" : "reaction rule",
       "OWNER" : "rules",
       "REQUIRES" : [ "rules" ],
-      "ON" : { "node_update--ding_news" : { "bundle" : "ding_news" } },
+      "ON" : { "node_update" : [] },
       "IF" : [
+        { "entity_has_field" : { "entity" : [ "node" ], "field" : "field_bpi_workflow" } },
         { "data_is" : { "data" : [ "node:field-bpi-workflow" ], "value" : "7" } }
       ],
       "DO" : [ { "bpi_rules_delete" : { "entity" : [ "node" ] } } ]
@@ -38,8 +40,9 @@ function bpi_features_default_rules_configuration() {
       "PLUGIN" : "reaction rule",
       "OWNER" : "rules",
       "REQUIRES" : [ "rules" ],
-      "ON" : { "node_insert--ding_news" : { "bundle" : "ding_news" } },
+      "ON" : { "node_insert" : [] },
       "IF" : [
+        { "entity_has_field" : { "entity" : [ "node" ], "field" : "field_bpi_workflow" } },
         { "data_is" : { "data" : [ "node:field-bpi-workflow" ], "value" : "3" } }
       ],
       "DO" : [ { "redirect" : { "url" : "node\\/[node:nid]\\/workflow" } } ]

--- a/modules/bpi/templates/bpi-preview-item.tpl.php
+++ b/modules/bpi/templates/bpi-preview-item.tpl.php
@@ -36,9 +36,12 @@
       </p>
     </div>
   </div>
+
   <?php if (!$hide_syndicate_link): ?>
-  <p class="item-action item-action-syndicate">
-    <?php echo l(t('Syndicate'), 'admin/bpi/syndicate/' . $item['id']); ?>
-  </p>
+    <?php if (isset($syndicate_url)): ?>
+      <p class="item-action item-action-syndicate">
+        <?php echo l(t('Syndicate'), $syndicate_url); ?>
+      </p>
+    <?php endif; ?>
   <?php endif; ?>
 </div>

--- a/modules/bpi/templates/bpi-preview-item.tpl.php
+++ b/modules/bpi/templates/bpi-preview-item.tpl.php
@@ -40,7 +40,7 @@
   <?php if (!$hide_syndicate_link): ?>
     <?php if (isset($syndicate_url)): ?>
       <p class="item-action item-action-syndicate">
-        <?php echo l(t('Syndicate'), $syndicate_url); ?>
+        <a href="<?php echo htmlspecialchars($syndicate_url); ?>"><?php echo t('Syndicate'); ?></a>
       </p>
     <?php endif; ?>
   <?php endif; ?>

--- a/modules/bpi/translations/da.po
+++ b/modules/bpi/translations/da.po
@@ -454,3 +454,36 @@ msgstr "Indhold må redigeres"
 #: bpi.push.inc:123;257
 msgid "I want be anonymous"
 msgstr "Jeg ønsker at være anonym"
+
+msgid "BPI node type"
+msgstr "BPI-indholdstype"
+
+msgid "article"
+msgstr "artikel"
+
+msgid "campaign"
+msgstr "kampagne"
+
+msgid "BPI tags"
+msgstr "Tags (BPI)"
+
+msgid "BPI materials"
+msgstr "Materialer (BPI)"
+
+msgid "Mapping (@bpi_type)"
+msgstr "Tilknytning (@bpi_type)"
+
+msgid "Enter the BPI node type, e.g. ding_news, campaign, carousel."
+msgstr "Vælg BPI-indholdstypen."
+
+msgid "If you change the content type, you have to save the form before editing the field mapping."
+msgstr "Hvis du ændrer indholdstypen, skal du gemme formularen før du redigerer felttilknytningen."
+
+msgid "Remove mapping of @bpi_type"
+msgstr "Fjern tilknytning af @bpi_type"
+
+msgid "Save to remove mapping of @bpi_type"
+msgstr "Gem for at fjerne tilknytning af @bpi_type"
+
+msgid "Add mapping"
+msgstr "Tilføj tilknytning"

--- a/modules/ding_campaign/ding_campaign.bpi.inc
+++ b/modules/ding_campaign/ding_campaign.bpi.inc
@@ -17,7 +17,7 @@ function ding_campaign_bpi_syndicate_get_bpi_types() {
  */
 function ding_campaign_bpi_syndicate_action_url($bpi_type, $bpi_id, array $mapping) {
   if (in_array($bpi_type, ding_campaign_bpi_syndicate_get_bpi_types())) {
-    return url(str_replace('_', '-', 'node/add/' . $mapping['bpi_content_type']), array('query' => array('bpi_type' => $bpi_type, 'bpi_id' => $bpi_id)));
+    return url(str_replace('_', '-', 'node/add/' . $mapping['content_type']), array('query' => array('bpi_type' => $bpi_type, 'bpi_id' => $bpi_id)));
   }
 
   return NULL;
@@ -31,7 +31,7 @@ function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, arra
     $field_options = array('' => '') + bpi_get_field_instances($content_type);
 
     return array(
-      'bpi_field_title' => array(
+      'title' => array(
         '#type' => 'select',
         '#title' => t('BPI title'),
         '#description' => t('Titles are automatically assigned.'),
@@ -40,20 +40,20 @@ function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, arra
         '#disabled' => TRUE,
       ),
 
-      'bpi_field_body' => array(
+      'body' => array(
         '#type' => 'select',
         '#title' => t('BPI body'),
         '#description' => t('Field to extract the main content from (body field).'),
         '#options' => $field_options,
-        '#default_value' => isset($field_mapping['bpi_field_body']) ? $field_mapping['bpi_field_body'] : NULL,
+        '#default_value' => isset($field_mapping['body']) ? $field_mapping['body'] : NULL,
       ),
 
-      'bpi_field_url' => array(
+      'url' => array(
         '#type' => 'select',
         '#title' => t('BPI url'),
         '#description' => t('Field to extract the url from.'),
         '#options' => $field_options,
-        '#default_value' => isset($field_mapping['bpi_field_url']) ? $field_mapping['bpi_field_url'] : NULL,
+        '#default_value' => isset($field_mapping['url']) ? $field_mapping['url'] : NULL,
       ),
     );
   }
@@ -65,8 +65,8 @@ function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, arra
  * Implements hook_bpi_convert_to_bpi_alter().
  */
 function ding_campaign_bpi_convert_to_bpi_alter(&$bpi_content, $node, $mapping) {
-  if (isset($mapping['bpi_node_type']) && in_array($mapping['bpi_node_type'], ding_campaign_bpi_syndicate_get_bpi_types())) {
-    $url_field = isset($mapping['bpi_field_mapping']['bpi_field_url']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_url']) : NULL;
+  if (in_array($mapping['bpi_node_type'], ding_campaign_bpi_syndicate_get_bpi_types())) {
+    $url_field = isset($mapping['field_mapping']['url']) ? field_view_field('node', $node, $mapping['field_mapping']['url']) : NULL;
     $url = bpi_get_field_value($url_field);
     $bpi_content['url'] = $url;
 

--- a/modules/ding_campaign/ding_campaign.bpi.inc
+++ b/modules/ding_campaign/ding_campaign.bpi.inc
@@ -55,7 +55,7 @@ function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, arra
         '#options' => $field_options,
         '#default_value' => isset($field_mapping['bpi_field_url']) ? $field_mapping['bpi_field_url'] : NULL,
       ),
-);
+    );
   }
 
   return NULL;

--- a/modules/ding_campaign/ding_campaign.bpi.inc
+++ b/modules/ding_campaign/ding_campaign.bpi.inc
@@ -82,7 +82,7 @@ function ding_campaign_bpi_convert_to_bpi_alter(&$bpi_content, $node, $mapping) 
  */
 function ding_campaign_bpi_syndicate_form_alter(&$form, $bpi_content, $syndicated_images) {
   $current_language = $form['language']['#value'];
-  $data = @json_decode($bpi_content['data'], TRUE);
+  $data = json_decode($bpi_content['data'], TRUE);
   $type = isset($data['type']) ? $data['type'] : 'plain';
 
   if (!in_array($type, array('full', 'image', 'plain'))) {

--- a/modules/ding_campaign/ding_campaign.bpi.inc
+++ b/modules/ding_campaign/ding_campaign.bpi.inc
@@ -28,7 +28,7 @@ function ding_campaign_bpi_syndicate_action_url($bpi_type, $bpi_id, array $mappi
  */
 function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
   if (in_array($bpi_type, ding_campaign_bpi_syndicate_get_bpi_types())) {
-    $field_options = array('' => '') + bpi_get_field_instances($content_type);
+    $field_options = bpi_get_field_instances($content_type);
 
     return array(
       'title' => array(
@@ -45,6 +45,7 @@ function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, arra
         '#title' => t('BPI body'),
         '#description' => t('Field to extract the main content from (body field).'),
         '#options' => $field_options,
+        '#empty_value' => '',
         '#default_value' => isset($field_mapping['body']) ? $field_mapping['body'] : NULL,
       ),
 
@@ -53,6 +54,7 @@ function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, arra
         '#title' => t('BPI url'),
         '#description' => t('Field to extract the url from.'),
         '#options' => $field_options,
+        '#empty_value' => '',
         '#default_value' => isset($field_mapping['url']) ? $field_mapping['url'] : NULL,
       ),
     );

--- a/modules/ding_campaign/ding_campaign.bpi.inc
+++ b/modules/ding_campaign/ding_campaign.bpi.inc
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * @file
+ * Implementation of BPI hooks.
+ */
+
+/**
+ * Implements hook_bpi_syndicate_get_bpi_types().
+ */
+function ding_campaign_bpi_syndicate_get_bpi_types() {
+  return array('campaign');
+}
+
+/**
+ * Implements bpi_syndicate_action_url().
+ */
+function ding_campaign_bpi_syndicate_action_url($bpi_type, $bpi_id, array $mapping) {
+  if (in_array($bpi_type, ding_campaign_bpi_syndicate_get_bpi_types())) {
+    return url(str_replace('_', '-', 'node/add/' . $mapping['bpi_content_type']), array('query' => array('bpi_type' => $bpi_type, 'bpi_id' => $bpi_id)));
+  }
+
+  return NULL;
+}
+
+/**
+ * Implements hook_bpi_get_field_mapping().
+ */
+function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, array $field_mapping) {
+  if (in_array($bpi_type, ding_campaign_bpi_syndicate_get_bpi_types())) {
+    $field_options = array('' => '') + bpi_get_field_instances($content_type);
+
+    return array(
+      'bpi_field_title' => array(
+        '#type' => 'select',
+        '#title' => t('BPI title'),
+        '#description' => t('Titles are automatically assigned.'),
+        '#options' => array('title' => t('Title')),
+        '#value' => 'title',
+        '#disabled' => TRUE,
+      ),
+
+      'bpi_field_teaser' => array(
+        '#type' => 'select',
+        '#title' => t('BPI teaser'),
+        '#description' => t('The field to extract the teaser from. If the content type have a body summary, assign it to the body field.'),
+        '#options' => $field_options,
+        '#default_value' => isset($field_mapping['bpi_field_teaser']) ? $field_mapping['bpi_field_teaser'] : NULL,
+      ),
+
+      'bpi_field_body' => array(
+        '#type' => 'select',
+        '#title' => t('BPI body'),
+        '#description' => t('Field to extract the main content from (body field).'),
+        '#options' => $field_options,
+        '#default_value' => isset($field_mapping['bpi_field_body']) ? $field_mapping['bpi_field_body'] : NULL,
+      ),
+
+      'bpi_field_url' => array(
+        '#type' => 'select',
+        '#title' => t('BPI url'),
+        '#description' => t('Field to extract the url from.'),
+        '#options' => $field_options,
+        '#default_value' => isset($field_mapping['bpi_field_url']) ? $field_mapping['bpi_field_url'] : NULL,
+      ),
+);
+  }
+
+  return NULL;
+}
+
+/**
+ * Implements hook_bpi_convert_to_bpi_alter().
+ */
+function ding_campaign_bpi_convert_to_bpi_alter(&$bpi_content, $node, $mapping) {
+  if (isset($mapping['bpi_node_type']) && in_array($mapping['bpi_node_type'], ding_campaign_bpi_syndicate_get_bpi_types())) {
+    $url_field = isset($mapping['bpi_field_mapping']['bpi_field_url']) ? field_view_field('node', $node, $mapping['bpi_field_mapping']['bpi_field_url']) : NULL;
+    $url = bpi_get_field_value($url_field);
+    $bpi_content['url'] = $url;
+
+    $campaign_type = bpi_get_field_value(field_view_field('node', $node, 'field_camp_settings'));
+    $bpi_content['data'] = array(
+      'type' => $campaign_type,
+    );
+  }
+}
+
+/**
+ * Implements hook_bpi_syndicate_form().
+ */
+function ding_campaign_bpi_syndicate_form_alter(&$form, $bpi_content, $syndicated_images) {
+  $current_language = $form['language']['#value'];
+  $data = @json_decode($bpi_content['data'], TRUE);
+  $type = isset($data['type']) ? $data['type'] : 'plain';
+
+  if (!in_array($type, array('full', 'image', 'plain'))) {
+    $type = 'plain';
+  }
+
+  $form['field_camp_settings'][$current_language]['#default_value'] = $type;
+  $form['field_camp_link'][$current_language][0]['value']['#default_value'] = isset($bpi_content['url']) ? $bpi_content['url'] : NULL;
+}
+
+/**
+ * Implements hook_bpi_get_image_type().
+ */
+function ding_campaign_bpi_get_image_type($image_field_name, $node) {
+  if ($node->type === 'ding_campaign') {
+    $pattern = '/field_camp_(?<image_type>.+)/';
+    if (preg_match($pattern, $image_field_name, $matches)) {
+      return $matches['image_type'];
+    }
+  }
+
+  return NULL;
+}

--- a/modules/ding_campaign/ding_campaign.bpi.inc
+++ b/modules/ding_campaign/ding_campaign.bpi.inc
@@ -40,14 +40,6 @@ function ding_campaign_bpi_get_field_mapping_form($bpi_type, $content_type, arra
         '#disabled' => TRUE,
       ),
 
-      'bpi_field_teaser' => array(
-        '#type' => 'select',
-        '#title' => t('BPI teaser'),
-        '#description' => t('The field to extract the teaser from. If the content type have a body summary, assign it to the body field.'),
-        '#options' => $field_options,
-        '#default_value' => isset($field_mapping['bpi_field_teaser']) ? $field_mapping['bpi_field_teaser'] : NULL,
-      ),
-
       'bpi_field_body' => array(
         '#type' => 'select',
         '#title' => t('BPI body'),

--- a/modules/ding_campaign/ding_campaign.module
+++ b/modules/ding_campaign/ding_campaign.module
@@ -5,6 +5,7 @@
  */
 
 include_once 'ding_campaign.features.inc';
+include_once 'ding_campaign.bpi.inc';
 
 /**
  * Implements hook_menu().

--- a/translations/da.po
+++ b/translations/da.po
@@ -45822,8 +45822,8 @@ msgid "Please enter a valid url."
 msgstr "Indtast venligst en korrekt URL."
 
 #: bpi.admin.inc:143
-msgid "Select a content type into which content from BPI will be syndicated."
-msgstr "Vælg den indholdstype som du ønsker at syndikere til."
+msgid "Select a content type into which content from BPI will be syndicated. If you change the content type, you have to save the form before editing the field mapping."
+msgstr "Vælg en indholdstype som du ønsker at syndikere til. Hvis du ændrer indholdstypen skal du gemme formularen før du kan redigere felttilknytningen."
 
 #: bpi.admin.inc:164
 msgid "Field mapping"


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3062

This adds handling of campaigns to BPI.

The basic idea is to add an API (hooks) that a module can use to hook into the BPI syndication/push process to add custom content types. This API is then implemented in the `ding_campaign`-module.