### PR TITLE
3192: Prevent notices for invalid categories

### DIFF
--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -183,9 +183,11 @@ function _ding_ipe_filter_get_pane_info($category, $subtype_name) {
     $categories = $panel_editor->get_categories($content_types);
   }
 
-  foreach ($categories[$category]['content'] as $pane) {
-    if ($pane['subtype_name'] == $subtype_name) {
-      return $pane;
+  if (!empty($categories[$category]['content'])) {
+    foreach ($categories[$category]['content'] as $pane) {
+      if ($pane['subtype_name'] == $subtype_name) {
+        return $pane;
+      }
     }
   }
 


### PR DESCRIPTION
If the provided category argument is included in the available
categories we should not check for panes. Doing this will result in
notices and warnings