### PR TITLE
2193: Don't disable admin_views node view on BPI install

### DIFF
--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -55,14 +55,6 @@ function bpi_schema() {
 }
 
 /**
- * Implements hook_install().
- */
-function bpi_install() {
-  // Disable view 'admin_views_node' (cf. bpi_update_7003).
-  bpi_update_7003();
-}
-
-/**
  * Add BPI data blob to db table.
  */
 function bpi_update_7001() {


### PR DESCRIPTION
I missed this one in the last in the PR.

As a result the admin_views node view isn't activated on fresh installs.

https://platform.dandigbib.org/issues/2193