### PR TITLE
3069: Refactor ding_user external access plugin

### DIFF
--- a/modules/ding_user/ding_user.install
+++ b/modules/ding_user/ding_user.install
@@ -145,3 +145,11 @@ function ding_user_update_7009(&$sandbox) {
 function ding_user_update_7010(&$sandbox) {
   ding_user_create_private_key();
 }
+
+/**
+ * Ensure init and authname are equal for provider users.
+ */
+function ding_user_update_7011() {
+  db_query("UPDATE users a INNER JOIN authmap b ON a.uid=b.uid SET a.init=b.authname WHERE a.init<>b.authname;")
+    ->execute();
+}

--- a/modules/ding_user/plugins/access/external_user.inc
+++ b/modules/ding_user/plugins/access/external_user.inc
@@ -26,12 +26,7 @@ function ding_user_external_user_access_check($conf, $context) {
   if (empty($context) || empty($context[0]->data) || !user_is_logged_in()) {
     return FALSE;
   }
-  // Ensure that the user has been externally authenticated by ding_user.
-  $query = db_select('authmap', 'a')
-    ->condition('uid', $context[0]->data->uid, '=')
-    ->condition('module', 'ding_user', '=');
-
-  return $query->countQuery()->execute()->fetchField();
+  return (user_get_authmaps($context[0]->data->init) xor $conf);
 }
 
 /**

--- a/modules/ding_user/plugins/access/external_user.inc
+++ b/modules/ding_user/plugins/access/external_user.inc
@@ -26,7 +26,12 @@ function ding_user_external_user_access_check($conf, $context) {
   if (empty($context) || empty($context[0]->data) || !user_is_logged_in()) {
     return FALSE;
   }
-  return (user_get_authmaps($context[0]->data->init) xor $conf);
+  // Ensure that the user has been externally authenticated by ding_user.
+  $query = db_select('authmap', 'a')
+    ->condition('uid', $context[0]->data->uid, '=')
+    ->condition('module', 'ding_user', '=');
+
+  return $query->countQuery()->execute()->fetchField();
 }
 
 /**


### PR DESCRIPTION
Instead of relying on init on user table and authname on authmap to be equal, this change just verifies
that the user is externally authenticated by ding_user instead. 

This should be more robust, since there has been cases where init and authname for some reason wasn't  synchronized properly.

More info the description: https://platform.dandigbib.org/issues/3069