### PR TITLE
Core: Amend changes to release commits

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -48,7 +48,7 @@ An example name could be `7.x-3.4.2-rc1`.
 
 7. In `ding2.info` set `version = 7.x-3.4.2-rc1`
 
-8. Commit your changes `git add ding2.info ding2.make drupal.make && git commit -m "Core: Bumped version to 7.x-3.4.2-rc1"`
+8. Commit your changes `git add ding2.info ding2.make drupal.make && git commit --amend -m "Core: Bumped version to 7.x-3.4.2-rc1"`
 
 9. In the git repository tag the commit with the release name og push it `git tag 7.x-3.4.2-rc1 && git push origin 7.x-3.4.2-rc1`
 


### PR DESCRIPTION
There is no reason to keep a history of commits on the release branch
hanging around. Their position in relation to the master branch is not
correct anyway.

Consequently we should amend changes to any existing release commit and
thus in practice overriding it. We already rebase the branch on the
master branch. This ensures that each release commit is only a single
commit away from master.