### PR TITLE
2685: Enable opensearch module as search provider on existing sites

### DIFF
--- a/modules/ting/ting.install
+++ b/modules/ting/ting.install
@@ -299,3 +299,12 @@ function ting_update_7013() {
   );
   variable_set('ting_language_type_title_suffix', $language_suffix_types);
 }
+
+/**
+ * Enable OpenSearch module if no other search provider is active.
+ */
+function ting_update_7014() {
+  if (!ding_provider_implements('search', 'search')) {
+    module_enable(['opensearch']);
+  }
+}


### PR DESCRIPTION
https://platform.dandigbib.org/issues/2685

The current codebase enables the new opensearch module as the default
search provider on new sites during installation. However nothing is
done to ensure that a search provider is active on existing sites.

Consequently we implement an update hook which enables the opensearch
module if no other search provider is active.