### PR TITLE
3356: Return null if OpenSearch cannot retrieve collection for id

### DIFF
--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -85,15 +85,20 @@ function opensearch_search_object_load(array $ids) {
  * @param string $id
  *   Id of material to load as a collection.
  *
- * @return Ting\TingObjectCollectionInterface
- *   The collection.
+ * @return Ting\TingObjectCollectionInterface|NULL
+ *   The collection or NULL if there is no collection for the id.
  */
 function opensearch_search_collection_load($id) {
   // Ensure we have OpenSearch client.
   module_load_include('inc', 'opensearch', 'opensearch.client');
 
   $reply = opensearch_get_object($id, TRUE);
-  return new OpenSearchTingObjectCollection($reply);
+  if ($reply instanceof TingClientObjectCollection) {
+    return new OpenSearchTingObjectCollection($reply);
+  }
+  else {
+    return NULL;
+  }
 }
 
 /**

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -25,9 +25,9 @@ define('OPENSEARCH_CACHE_EMPTY_ENTRY', '8e4f3ef1784c020bf7afa5b6dd69b421');
  *
  * @todo Should use getObject, but the ting-client lib doesn't implement that.
  *
- * @return \TingClientObject|\TingClientObjectCollection
+ * @return \TingClientObject|\TingClientObjectCollection|NULL
  *   Ting object or object collection if $collection is TRUE and a collection
- *   was found.
+ *   was found. NULL is returned if no object or collection could be retrieved.
  */
 function opensearch_get_object($object_id, $collection = FALSE, $with_relations = FALSE) {
   if (!empty($object_id)) {

--- a/modules/ting/ting.controllers.inc
+++ b/modules/ting/ting.controllers.inc
@@ -253,18 +253,14 @@ class TingCollectionController implements DrupalEntityControllerInterface {
         }
         else {
           // Use the search provider to load the collection.
-          /** @var \Ting\TingObjectCollectionInterface $object_collection */
+          /* @var \Ting\TingObjectCollectionInterface|NULL $object_collection */
           $object_collection = ding_provider_invoke('search', 'collection_load', $ding_entity_id);
 
           if (empty($object_collection) || empty($object_collection->getPrimaryObject())) {
             watchdog('ting', 'Loaded empty collection with ID @id, this could be an error. ', ['@id' => $ding_entity_id], WATCHDOG_WARNING);
+            continue;
           }
           $object = new TingCollection($ding_entity_id, $object_collection);
-          // Attach search provider object.
-          $ting_object_collection = ding_provider_invoke('search', 'collection_load', $ding_entity_id);
-          if ($ting_object_collection) {
-            $object->setTingObjectCollection($ting_object_collection);
-          }
           $queried_entities[$ding_entity_id] = $object;
 
           if (isset($object)) {


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3356

This prevents fatal errors opensearch_get_object can return multiple
types including NULL. OpenSearchTingObjectCollection only accepts a
TingClientObjectCollection.

Returning NULL from the search provider collection_load method should
not cause problems. Callers already check for empty results.

Update DocBlocks accordingly.