### PR TITLE
3339: Only use trailing wildcard for reference queries

### DIFF
--- a/modules/ding_provider/connie_search/includes/connie_search.search.inc
+++ b/modules/ding_provider/connie_search/includes/connie_search.search.inc
@@ -153,8 +153,7 @@ function connie_search_search_prepare_reference_query($query_string) {
     $query->setRawQuery($query_string);
   }
   else {
-    // Just perform a general fuzzy search.
-    $query->setFuzzy(TRUE);
+    // Just perform a general full text search.
     $query->setFullTextQuery($query_string);
   }
   return $query;

--- a/modules/ding_provider/tests/ding_provider_implementation.test
+++ b/modules/ding_provider/tests/ding_provider_implementation.test
@@ -568,16 +568,13 @@ abstract class DingSearchProviderImplementationTestCase extends DingProviderImpl
 
     /* @var \Ting\Search\TingSearchRequest $query */
     $query = ding_provider_invoke('search', 'prepare_reference_query', $test_query_1);
-    // Plain search should be a fuzzy text-search.
-    $this->assertTrue($query->isFuzzy());
+    // Plain search should be a full text-search.
     $this->assertEqual($query->getFullTextQuery(), $test_query_1);
 
     $query = ding_provider_invoke('search', 'prepare_reference_query', $test_query_2);
-    $this->assertFalse($query->isFuzzy());
     $this->assertEqual($query->getRawQuery(), $test_query_2);
 
     $query = ding_provider_invoke('search', 'prepare_reference_query', $test_query_3);
-    $this->assertFalse($query->isFuzzy());
     $this->assertEqual($query->getMaterialFilter(), [$test_query_3]);
   }
 

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -513,9 +513,9 @@ function opensearch_search_prepare_reference_query($query_string) {
     $query->setRawQuery($query_string);
   }
   else {
-    // Do a full-text search.
-    $query->setFuzzy(TRUE);
-    $query->setFullTextQuery($query_string);
+    // Do a full-text search with the wildcard character appended to expand
+    // search results until we have a hit.
+    $query->setFullTextQuery($query_string . '*');
   }
 
   return $query;

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -120,9 +120,6 @@ function opensearch_search_search(TingSearchRequest $ting_query) {
   // Add a general quoted free text search.
   if (!empty($free_text_query = $ting_query->getFullTextQuery())) {
     $free_text_query = _ting_search_quote($ting_query->getFullTextQuery());
-    if ($ting_query->isFuzzy()) {
-      $free_text_query = '*' . $free_text_query . '*';
-    }
     $query_parts[] = $free_text_query;
   }
 

--- a/modules/ting/src/Search/TingSearchRequest.php
+++ b/modules/ting/src/Search/TingSearchRequest.php
@@ -121,13 +121,6 @@ class TingSearchRequest {
   protected $fullTextQuery;
 
   /**
-   * Whether in particular fulltext searches are fuzzy.
-   *
-   * @var bool
-   */
-  protected $fuzzy = FALSE;
-
-  /**
    * Specifies whether collections in the search-result should be fully
    * populated. Eg. the returned collection may contain materials that does not
    * match the search-query, but shares collection with a material that does.
@@ -213,33 +206,6 @@ class TingSearchRequest {
    */
   public function setFullTextQuery($full_text_query) {
     $this->fullTextQuery = $full_text_query;
-    return $this;
-  }
-
-  /**
-   * Returns whether searches should be fuzzy.
-   *
-   * @return bool
-   *   Whether the search should be fuzzy.
-   */
-  public function isFuzzy() {
-    return $this->fuzzy;
-  }
-
-  /**
-   * Sets whether searches should be fuzzy.
-   *
-   * This will in particular affect full-text queries specified via
-   * setFullTextQuery()
-   *
-   * @param bool $fuzzy
-   *   The flag.
-   *
-   * @return TingSearchRequest
-   *   the current query object.
-   */
-  public function setFuzzy($fuzzy) {
-    $this->fuzzy = $fuzzy;
     return $this;
   }
 


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3339

Fuzzy search with add wildcards characters before and after the search
string. This makes opensearch reply much slower and requests time out.

Do not use fuzzy search and instead add a trailing wildcard. This
also matches previous behavior.

Reference queries where the only place where this functionality was
used. Remove it entirely to simplify things a bit before usage and
confusion whether it should be used or not spreads.