### PR TITLE
3338: Move infomedia administration fields to new opensearch form

### DIFF
--- a/modules/ting_infomedia/ting_infomedia.info
+++ b/modules/ting_infomedia/ting_infomedia.info
@@ -6,5 +6,6 @@ core = 7.x
 
 dependencies[] = virtual_field
 dependencies[] = ctools
+dependencies[] = opensearch
 dependencies[] = panels
 dependencies[] = page_manager

--- a/modules/ting_infomedia/ting_infomedia.module
+++ b/modules/ting_infomedia/ting_infomedia.module
@@ -160,8 +160,8 @@ function ting_infomedia_ding_anchor_info() {
  *
  * Adding infomedia url form field to ting configuration form.
  */
-function ting_infomedia_form_ting_admin_ting_settings_alter(&$form, &$form_state) {
-  $form['ting']['ting_infomedia_url'] = array(
+function ting_infomedia_form_opensearch_admin_settings_alter(&$form, &$form_state) {
+  $form['opensearch']['ting_infomedia_url'] = array(
     '#type' => 'textfield',
     '#title' => t('Infomedia web service URL'),
     '#description' => t('URL to the infomedia webservice (access to infomedia article base) , e.g. http://useraccessinfomedia.addi.dk/1.1/'),


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3338

The module is called ting_infomedia but requests to the infomedia
service uses the client library also used to access Opensearch.

Consequently we update the form alter for the module to target the
opensearch admininistration form.

We also solidify the dependency on Opensearch by adding the module as
a dependency for ting_infomedia. In theory it should be possible to 
decouple the two services down the line if needed.