### PR TITLE
2685: Fix retrieval of primary object for collection in Connie

### DIFF
--- a/modules/ding_provider/connie_search/src/ConnieTingObjectCollection.php
+++ b/modules/ding_provider/connie_search/src/ConnieTingObjectCollection.php
@@ -43,7 +43,7 @@ class ConnieTingObjectCollection implements TingObjectCollectionInterface {
   public function getPrimaryObject() {
     // Get the first array-entry (without modifying the array).
     $objects = array_values($this->objects);
-    return empty($this->tingObjects) ? NULL : array_shift($objects);
+    return empty($objects) ? NULL : array_shift($objects);
   }
 
   /**


### PR DESCRIPTION
An invalid property will always be empty.

This should also fix the tests.