### PR TITLE
3325: Move periodical detection to search system

### DIFF
--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -425,3 +425,18 @@ function opensearch_page_alter(&$page) {
     }
   }
 }
+
+/**
+ * Implements hook_ding_entity_is().
+ */
+function opensearch_ding_entity_is($object, $class) {
+  if ($object instanceof TingEntity) {
+    /* @var TingEntity $object */
+    switch ($class) {
+      case 'periodical':
+        // @todo make sure that availability information isn't displayed
+        // on the object.
+        return in_array(drupal_strtolower($object->getType()), array('tidsskrift', 'periodikum', 'årbog'));
+    }
+  }
+}

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -441,12 +441,6 @@ function ting_ding_entity_is($object, $class) {
       $types = variable_get('ting_reservable_types', _ting_default_reservable_types());
       return (in_array(drupal_strtolower($object->ac_source), $sources) && in_array(drupal_strtolower($object->type), $types));
 
-    case 'periodical':
-      // TODO Reduce coupling with Danish OpenSearch type names for periodicals.
-      // @todo make sure that availability information isn't displayed
-      // on the object.
-      return in_array(drupal_strtolower($object->type), array('tidsskrift', 'periodikum', 'årbog'));
-
     case 'online':
       return !empty($object->getOnline_url());
   }


### PR DESCRIPTION
The current detection of periodicals based on types is not suitable
across search providers which may use different languages.

The current values are tied to OpenSearch and the Danish municipal 
libraries. Consequently we move the detection to the opensearch module.