### PR TITLE
3346: Initialize OpenSearch relations to empty list

### DIFF
--- a/modules/opensearch/src/OpenSearchTingObject.php
+++ b/modules/opensearch/src/OpenSearchTingObject.php
@@ -44,7 +44,7 @@ class OpenSearchTingObject implements TingObjectInterface {
    *
    * @var TingRelation[] list of materials related to this material.
    */
-  protected $relations;
+  protected $relations = [];
 
   /**
    * OpenSearchObject constructor.


### PR DESCRIPTION
[Relations for the object will only be set if they can be retrieved](https://github.com/ding2/ding2/compare/master...reload:feature/3346-fix-relation-notice?expand=1#diff-cd656e119bf1220b60ff65335fffe0feL69).
Consequently we have to initialize the property to an empty array to
avoid returning NULL if relations cannot be retrieved.