### PR TITLE
3352: Fix notice when search string does not contain query

### DIFF
--- a/modules/ting/ting.field.inc
+++ b/modules/ting/ting.field.inc
@@ -571,7 +571,8 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
  *   An HTML string containing a link to the search result.
  */
 function ting_field_search_link($text, $search_string, array $replacements = [], array $options = []) {
-  list($path_suffix, $query_string) = preg_split('/\?/', $search_string, 2);
+  $search_string_parts = preg_split('/\?/', $search_string, 2);
+  list($path_suffix, $query_string) = array_pad($search_string_parts, 2, '');
   $path = 'search/ting/' . strtr($path_suffix, $replacements);
   $query_string = strtr($query_string, $replacements);
   parse_str($query_string, $query);


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3352

preg_split will only return a single entry causing list to issue a
notice.