### PR TITLE
3408: Make search requests immutable

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -928,9 +928,9 @@ function bpi_workflow_by_machine_names($machine_names) {
  */
 function bpi_validate_material($id) {
   $result = ting_start_query()
-    ->setFullTextQuery($id)
-    ->setCount(1)
-    ->setPopulateCollections(FALSE)
+    ->withFullTextQuery($id)
+    ->withCount(1)
+    ->withPopulateCollections(FALSE)
     ->execute();
 
   $primary_objects = array_map(function (TingCollection $collection) {

--- a/modules/ding_ekurser/ding_ekurser.module
+++ b/modules/ding_ekurser/ding_ekurser.module
@@ -93,10 +93,10 @@ function ding_ekurser_form_alter(&$form, &$form_state, $form_id) {
  */
 function _ding_ekurser_get_subject_terms() {
   $search_result = ting_start_query()
-    ->setFullTextQuery('ekurser.nu')
-    ->setCount(1)
-    ->addSort('acquisitionDate_descending')
-    ->setTermsPrFacet(20)
+    ->withFullTextQuery('ekurser.nu')
+    ->withCount(1)
+    ->withSort('acquisitionDate_descending')
+    ->withTermsPrFacet(20)
     ->execute();
 
   // Extract subject facets.

--- a/modules/ding_provider/connie_search/includes/connie_search.search.inc
+++ b/modules/ding_provider/connie_search/includes/connie_search.search.inc
@@ -146,15 +146,15 @@ function connie_search_search_prepare_reference_query($query_string) {
   $query = ting_start_query();
 
   if (is_numeric($query_string)) {
-    $query->setMaterialFilter($query_string);
+    $query = $query->withMaterialFilter($query_string);
   }
   elseif (strpos($query_string, '=') !== FALSE) {
     // The query seems to contain something advanced, process it as a raw query.
-    $query->setRawQuery($query_string);
+    $query = $query->withRawQuery($query_string);
   }
   else {
     // Just perform a general full text search.
-    $query->setFullTextQuery($query_string);
+    $query = $query->withFullTextQuery($query_string);
   }
   return $query;
 }

--- a/modules/ding_provider/tests/ding_provider_implementation.test
+++ b/modules/ding_provider/tests/ding_provider_implementation.test
@@ -595,17 +595,13 @@ abstract class DingSearchProviderImplementationTestCase extends DingProviderImpl
    * Test TingSearchRequest can include and exclude materials.
    */
   public function testMaterialFilter() {
-    $query_include = ting_start_query();
-    // We do not run this, so the ID doesn't matter.
-    $query_include->setMaterialFilter('123');
+    $query_include = ting_start_query()->withMaterialFilter('123');
 
     // Check the filter is being set to include.
     $this->assertEqual($query_include->getMaterialFilter(), ['123']);
     $this->assertTrue($query_include->isMaterialFilterInclude());
 
-    $query_exclude = ting_start_query();
-    // We do not run this, so the ID doesn't matter.
-    $query_exclude->setMaterialFilter('123', FALSE);
+    $query_exclude = ting_start_query()->withMaterialFilter('123', FALSE);
 
     // Check the filter is being set to exclude.
     $this->assertEqual($query_exclude->getMaterialFilter(), ['123']);

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -232,13 +232,12 @@ function opensearch_search_search(TingSearchRequest $ting_query) {
   if (empty($search_result)) {
     throw new SearchProviderException("Unable to execute search, inspect logs for details");
   }
-  $result = new OpenSearchTingSearchResult($search_result, $ting_query);
 
-  // Handle the situation where opensearch sets a default sort.
-  if (empty($result->getSearchRequest()->getSorts()) && !empty($result->openSearchResult->sortUsed)) {
-    $sort_used = $result->openSearchResult->sortUsed;
+  // Handle the situation where OpenSearch sets a default sort.
+  if (empty($ting_query->getSorts()) && !empty($search_result->sortUsed)) {
+    $sort_used = $search_result->sortUsed;
     // In situations where we're configured to default to sort by "rank_general"
-    // opensearch may choose to use rank_main_title for the actual sort. Instead
+    // OpenSearch may choose to use rank_main_title for the actual sort. Instead
     // of introducing two different ways of ranking by title, we instead
     // interpret it as "rank_title".
     if ($sort_used === 'rank_main_title') {
@@ -250,11 +249,11 @@ function opensearch_search_search(TingSearchRequest $ting_query) {
     $provider_sorts = opensearch_search_sort_options();
     if (array_key_exists($sort_used, $provider_sorts)) {
       $sort_instance = $provider_sorts[$sort_used]['sort'];
-      $result->getSearchRequest()->addSorts($sort_instance);
+      $ting_query = $ting_query->withSorts($sort_instance);
     }
   }
 
-  return $result;
+  return new OpenSearchTingSearchResult($search_result, $ting_query);
 }
 
 /**
@@ -533,12 +532,12 @@ function opensearch_search_prepare_reference_query($query_string) {
   if (preg_match('/(^\d+$)|(^\d+:\d+$)|(=)/', $query_string)) {
     // The query is either ISBN, tid or CQL search expression.
     // Add as raw (eg non-escaped) string.
-    $query->setRawQuery($query_string);
+    $query = $query->withRawQuery($query_string);
   }
   else {
     // Do a full-text search with the wildcard character appended to expand
     // search results until we have a hit.
-    $query->setFullTextQuery($query_string . '*');
+    $query = $query->withFullTextQuery($query_string . '*');
   }
 
   return $query;

--- a/modules/p2/ding_entity_rating/ding_entity_rating.serendipity.inc
+++ b/modules/p2/ding_entity_rating/ding_entity_rating.serendipity.inc
@@ -71,7 +71,7 @@ function ding_entity_rating_materials_by_rating_serendipity_add(array $context) 
     }
 
     // Perform a search for materials with any of the subjects or authors.
-    $query = ting_start_query()->addFilters($field_filters, BooleanStatementInterface::OP_OR);
+    $query = ting_start_query()->withFilters($field_filters, BooleanStatementInterface::OP_OR);
 
     if (empty($query)) {
       return array();

--- a/modules/p2/ding_message/ding_message.module
+++ b/modules/p2/ding_message/ding_message.module
@@ -298,8 +298,8 @@ function ding_message_check_list_for_updates($uid, $element_id, $mid, $debug = F
       // Taxonomy terms updates are a ting search
       // for materials with the subject = term->name.
       $result = ting_start_query()
-        ->addFieldFilter(TingSearchCommonFields::SUBJECT, check_plain($term->name))
-        ->setCount(50)
+        ->withFieldFilter(TingSearchCommonFields::SUBJECT, check_plain($term->name))
+        ->withCount(50)
         ->execute();
       if ($result->getNumTotalCollections() > 0) {
         // Get the first element in the search result set.
@@ -352,7 +352,7 @@ function ding_message_check_list_for_updates($uid, $element_id, $mid, $debug = F
         // match the query accepted by ting_do_search.
         $query = ding_message_build_query($value);
         // TODO Port to search abstraction layer.
-        $result = $query->setCount(50)->execute();
+        $result = $query->withCount(50)->execute();
         if ($result->getNumTotalCollections() > 0) {
           // Get the first element in the search result set.
           $collections = $result->getTingEntityCollections();
@@ -737,13 +737,13 @@ function ding_message_build_query($query_string) {
   parse_str($query, $query_data);
 
   if (!empty($path)) {
-    $search_query->setFullTextQuery($path);
+    $search_query = $search_query->withFullTextQuery($path);
   }
 
   if (!empty($query_data['facets']) && is_array($query_data['facets'])) {
     foreach ($query_data['facets'] as $facet) {
       list($facet_name, $facet_value) = explode(':', $facet, 2);
-      $search_query->addFieldFilter($facet_name, $facet_value);
+      $search_query = $search_query->withFieldFilter($facet_name, $facet_value);
     }
   }
 

--- a/modules/p2/ding_serendipity/ding_serendipity.module
+++ b/modules/p2/ding_serendipity/ding_serendipity.module
@@ -383,12 +383,12 @@ function ding_serendipity_validate_materials(array $keys) {
   $sanitized = array();
 
   // Lookup the materials to filter out local missing materials.
-  $query = ting_start_query()->setMaterialFilter($keys);
+  $query = ting_start_query()->withMaterialFilter($keys);
 
   // Also add the audience to the query, if the user has a clear audience.
   $audience = ding_serendipity_user_audience();
   if ($audience !== FALSE) {
-    $query->addFieldFilter(TingSearchCommonFields::CATEGORY, $audience);
+    $query = $query->withFieldFilter(TingSearchCommonFields::CATEGORY, $audience);
   }
   $result = [];
   try {
@@ -457,7 +457,7 @@ function ding_serendipity_user_audience($account = NULL) {
     }
   }
 
-  $query = ting_start_query()->setMaterialFilter($ids);
+  $query = ting_start_query()->withMaterialFilter($ids);
   if (!empty($ids)) {
     foreach (ding_serendipity_do_search($query, count($ids)) as $collection) {
       $entity = $collection['object']->getPrimary_object();
@@ -942,7 +942,7 @@ function ding_serendipity_do_search(TingSearchRequest $query, $limit = 4, $shuff
 
   // Set sensible defaults for the query if the plugin did not do it.
   if ($query->getCount() === NULL) {
-    $query->setCount(20);
+    $query = $query->withCount(20);
   }
 
   $search_result = $query->execute();
@@ -1141,7 +1141,7 @@ function ding_serendipity_test_query_callback($form, &$form_state) {
     '#items' => array(),
   );
 
-  $results = ting_start_query()->setRawQuery($query)->setCount(10)->execute();
+  $results = ting_start_query()->withRawQuery($query)->withCount(10)->execute();
 
   if ($results->getNumTotalObjects()) {
     $list['#items'][] = t('Total results: @count', array('@count' => $results->getNumTotalObjects()));

--- a/modules/p2/ding_serendipity_fallback/ding_serendipity_fallback.module
+++ b/modules/p2/ding_serendipity_fallback/ding_serendipity_fallback.module
@@ -44,7 +44,7 @@ function ding_serendipity_fallback_ting_object_serendipity_add($context) {
 
   if (!empty($query)) {
     try {
-      $sal_query = ting_start_query()->setRawQuery($query)->setCount(8);
+      $sal_query = ting_start_query()->withRawQuery($query)->withCount(8);
       $results = ding_serendipity_do_search($sal_query);
     }
     catch (Exception $e) {

--- a/modules/p2/ding_serendipity_lists/ding_serendipity_lists.module
+++ b/modules/p2/ding_serendipity_lists/ding_serendipity_lists.module
@@ -221,7 +221,7 @@ function ding_serendipity_lists_frontpage_search_serendipity_add($context) {
   $results = array();
   if ($query_string = variable_get('ding_serendipity_lists_frontpage_search_string', '')) {
     // Fetch search results.
-    $query = ting_start_query()->setRawQuery($query_string);
+    $query = ting_start_query()->withRawQuery($query_string);
     $results = ding_serendipity_do_search($query);
     if ($results) {
       // Append info.
@@ -382,7 +382,7 @@ function ding_serendipity_lists_author_from_lists_serendipity_add($context) {
     if (!empty($lang) && $lang !== "Flere sprog") {
       $field_filters[] = new TingSearchFieldFilter(TingSearchCommonFields::LANGUAGE, $ting_entity->getLanguage());
     }
-    $query = ting_start_query()->addFilters($field_filters);
+    $query = ting_start_query()->withFilters($field_filters);
 
     // Fetch search results.
     $results = ding_serendipity_do_search($query);

--- a/modules/p2/ding_serendipity_taxonomy_term/ding_serendipity_taxonomy_term.module
+++ b/modules/p2/ding_serendipity_taxonomy_term/ding_serendipity_taxonomy_term.module
@@ -80,10 +80,10 @@ function ding_serendipity_taxonomy_term_recent_serendipity_add($context) {
   $query = _ding_serendipity_taxonomy_term_query_from_term($term_array);
   // Select content from this year.
   $limit = (is_numeric($context['max'])) ? $context['max'] : 16;
-  $query->setCount($limit);
+  $query = $query->withCount($limit);
 
   // Order by date.
-  $query->addSort(TingSearchCommonFields::ACQUISITION_DATE, TingSearchSort::DIRECTION_DESCENDING);
+  $query = $query->withSort(TingSearchCommonFields::ACQUISITION_DATE, TingSearchSort::DIRECTION_DESCENDING);
   return ding_serendipity_do_search($query);
 }
 
@@ -100,11 +100,11 @@ function _ding_serendipity_taxonomy_term_query_from_term(array $term_array) {
   $query = ting_start_query();
   if ($term_array['has_query']) {
     // The term has a query attached, use it.
-    $query->setRawQuery(ding_list_convert_cql($term_array['query']));
+    $query = $query->withRawQuery(ding_list_convert_cql($term_array['query']));
   }
   else {
     // Just add the term name itself as a full text search.
-    $query->setFullTextQuery($term_array['term']->name);
+    $query = $query->withFullTextQuery($term_array['term']->name);
   }
 
   return $query;
@@ -129,7 +129,7 @@ function ding_serendipity_taxonomy_term_related_by_term_serendipity_add($context
   $results = array();
   if ($context['bundle'] == 'ting_object') {
     $query = _ding_serendipity_taxonomy_term_query_from_term($term_array);
-    $query->setCount($context['min']);
+    $query = $query->withCount($context['min']);
     $results = ding_serendipity_do_search($query);
 
     // Frontpage could be a taxonomy term.

--- a/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
+++ b/modules/p2/ding_serendipity_ting_entity/ding_serendipity_ting_entity.module
@@ -112,12 +112,12 @@ function ding_serendipity_ting_entity_ting_object_author_serendipity_add($contex
   $field_filters = array_map(function($creator) {
     return new TingSearchFieldFilter(TingSearchCommonFields::AUTHOR, $creator);
   }, $creators);
-  $query = ting_start_query()->addFilters($field_filters, BooleanStatementInterface::OP_OR);
+  $query = ting_start_query()->withFilters($field_filters, BooleanStatementInterface::OP_OR);
 
   // Limit to same language to reduce signal to noise.
   $lang = $obj->getLanguage();
   if (!empty($lang) && $lang !== "Flere sprog") {
-    $query->addFieldFilter(TingSearchCommonFields::LANGUAGE, $lang);
+    $query = $query->withFieldFilter(TingSearchCommonFields::LANGUAGE, $lang);
   }
 
   $results = ding_serendipity_do_search($query);
@@ -157,7 +157,7 @@ function ding_serendipity_ting_entity_ting_object_subject_serendipity_add($conte
     return new TingSearchFieldFilter(TingSearchCommonFields::SUBJECT, $subject);
   }, $subjects);
 
-  $query = ting_start_query()->addFilters($field_filters, BooleanStatementInterface::OP_OR);
+  $query = ting_start_query()->withFilters($field_filters, BooleanStatementInterface::OP_OR);
   $results = ding_serendipity_do_search($query);
   ding_serendipity_exclude($results, $context['ting_object_id']);
 
@@ -195,7 +195,7 @@ function ding_serendipity_ting_entity_ting_object_type_serendipity_add($context)
 
   if ($type) {
     // Find related content that matches the type.
-    $query = ting_start_query()->addFieldFilter(TingSearchCommonFields::MATERIAL_TYPE, $type);
+    $query = ting_start_query()->withFieldFilter(TingSearchCommonFields::MATERIAL_TYPE, $type);
     $results = ding_serendipity_do_search($query);
     ding_serendipity_exclude($results, $context['ting_object_id']);
 

--- a/modules/ting/src/Search/TingSearchRequest.php
+++ b/modules/ting/src/Search/TingSearchRequest.php
@@ -8,9 +8,12 @@
 namespace Ting\Search;
 
 /**
- * Class TingSearchRequest
+ * A search request using a search provider.
  *
- * A request for a search using a search provider.
+ * This class is intetionally immutable. Calls to modify the state of a search
+ * request will result in a new object. This avoids unnecessary side effects
+ * to existing request objects if a request object is used as a basis for new
+ * searches.
  *
  * @package Ting\Search
  */
@@ -73,7 +76,7 @@ class TingSearchRequest {
   /**
    * Raw provider-specific query string.
    *
-   * @see setRawQuery()
+   * @see withRawQuery()
    *
    * @var string
    */
@@ -155,11 +158,12 @@ class TingSearchRequest {
    *   The maximum value.
    *
    * @return \Ting\Search\TingSearchRequest
-   *   Current search query object.
+   *   Updated search query object.
    */
-  public function setCount($max) {
-    $this->numResults = $max;
-    return $this;
+  public function withCount($max) {
+    $clone = clone $this;
+    $clone->numResults = $max;
+    return $clone;
   }
 
   /**
@@ -202,11 +206,12 @@ class TingSearchRequest {
    *   Any string.
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    */
-  public function setFullTextQuery($full_text_query) {
-    $this->fullTextQuery = $full_text_query;
-    return $this;
+  public function withFullTextQuery($full_text_query) {
+    $clone = clone $this;
+    $clone->fullTextQuery = $full_text_query;
+    return $clone;
   }
 
   /**
@@ -226,11 +231,12 @@ class TingSearchRequest {
    *   The maximum number of terms to return pr facet.
    *
    * @return TingSearchRequest
-   *   The current query object.
+   *   Updated search request object.
    */
-  public function setTermsPrFacet($terms_per_facet) {
-    $this->termsPerFacet = $terms_per_facet;
-    return $this;
+  public function withTermsPrFacet($terms_per_facet) {
+    $clone = clone $this;
+    $clone->termsPerFacet = $terms_per_facet;
+    return $clone;
   }
 
   /**
@@ -261,11 +267,12 @@ class TingSearchRequest {
    *    The facets used for the search.
    *
    * @return TingSearchRequest
-   *   The current query object.
+   *   Updated search request object.
    */
-  public function setFacets(array $facets) {
-    $this->facets = $facets;
-    return $this;
+  public function withFacets(array $facets) {
+    $clone = clone $this;
+    $clone->facets = $facets;
+    return $clone;
   }
 
   /**
@@ -285,11 +292,12 @@ class TingSearchRequest {
    *   The page-number, defaults to 1.
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    */
-  public function setPage($page) {
-    $this->page = $page;
-    return $this;
+  public function withPage($page) {
+    $clone = clone $this;
+    $clone->page = $page;
+    return $clone;
   }
 
   /**
@@ -312,11 +320,12 @@ class TingSearchRequest {
    *   The direction, see TingSearchSort::DIRECTION_*
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    */
-  public function addSort($field, $direction = TingSearchSort::DIRECTION_NONE) {
-    $this->sorts[] = new TingSearchSort($field, $direction);
-    return $this;
+  public function withSort($field, $direction = TingSearchSort::DIRECTION_NONE) {
+    $clone = clone $this;
+    $clone->sorts[] = new TingSearchSort($field, $direction);
+    return $clone;
   }
 
   /**
@@ -326,14 +335,15 @@ class TingSearchRequest {
    *   List of TingSearchSort instances.
    *
    * @return TingSearchRequest
-   *   The current query object.
+   *   Updated search request object.
    */
-  public function addSorts($sorts) {
+  public function withSorts($sorts) {
     if (!is_array($sorts)) {
       $sorts = [$sorts];
     }
-    $this->sorts += $sorts;
-    return $this;
+    $clone = clone $this;
+    $clone->sorts += $sorts;
+    return $clone;
   }
 
   /**
@@ -361,11 +371,12 @@ class TingSearchRequest {
    *   The query.
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    */
-  public function setRawQuery($query) {
-    $this->rawQuery = $query;
-    return $this;
+  public function withRawQuery($query) {
+    $clone = clone $this;
+    $clone->rawQuery = $query;
+    return $clone;
   }
 
   /**
@@ -400,16 +411,17 @@ class TingSearchRequest {
    *   Includes the materials if true and excludes them if false.
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    */
-  public function setMaterialFilter($material_ids, $include = TRUE) {
+  public function withMaterialFilter($material_ids, $include = TRUE) {
     if (!is_array($material_ids)) {
       $material_ids = [$material_ids];
     }
 
-    $this->materialFilterIds = $material_ids;
-    $this->materialFilterInclude = $include;
-    return $this;
+    $clone = clone $this;
+    $clone->materialFilterIds = $material_ids;
+    $clone->materialFilterInclude = $include;
+    return $clone;
   }
 
   /**
@@ -429,11 +441,12 @@ class TingSearchRequest {
    *   The flag.
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    */
-  public function setPopulateCollections($populate_collections) {
-    $this->populateCollections = $populate_collections;
-    return $this;
+  public function withPopulateCollections($populate_collections) {
+    $clone = clone $this;
+    $clone->populateCollections = $populate_collections;
+    return $clone;
   }
 
   /**
@@ -457,11 +470,12 @@ class TingSearchRequest {
    *   The collection type.
    *
    * @return TingSearchRequest
-   *   The current query object.
+   *   Updated search request object.
    */
-  public function setCollectionType($collectionType) {
-    $this->collectionType = $collectionType;
-    return $this;
+  public function withCollectionType($collectionType) {
+    $clone = clone $this;
+    $clone->collectionType = $collectionType;
+    return $clone;
   }
 
   /**
@@ -490,11 +504,11 @@ class TingSearchRequest {
    *   more than one filter. See BooleanStatementInterface::OP_*.
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    *
    * @throws \Ting\Search\UnsupportedSearchQueryException
    */
-  public function addFilters($filters, $logic_operator = BooleanStatementInterface::OP_AND) {
+  public function withFilters($filters, $logic_operator = BooleanStatementInterface::OP_AND) {
     // First off, protect against silly code.
     if (empty($filters)) {
       return $this;
@@ -530,8 +544,9 @@ class TingSearchRequest {
       $filters = new BooleanStatementGroup($filters, $logic_operator);
     }
 
-    $this->filters[] = $filters;
-    return $this;
+    $clone = clone $this;
+    $clone->filters[] = $filters;
+    return $clone;
   }
 
   /**
@@ -547,11 +562,10 @@ class TingSearchRequest {
    *   Expected field-value.
    *
    * @return TingSearchRequest
-   *   the current query object.
+   *   Updated search request object.
    */
-  public function addFieldFilter($name, $value) {
-    $this->addFilters([new TingSearchFieldFilter($name, $value)]);
-    return $this;
+  public function withFieldFilter($name, $value) {
+    return $this->withFilters([new TingSearchFieldFilter($name, $value)]);
   }
 
 }

--- a/modules/ting_new_materials/ting_new_materials.module
+++ b/modules/ting_new_materials/ting_new_materials.module
@@ -159,11 +159,11 @@ function ting_new_materials_make_limit_query($limit = 0) {
 function ting_new_materials_do_search($query, $page = 0, $num_per_page = 10) {
   // Build search options and ensure that they are sorted correctly.
   $query = ting_start_query()
-    ->setRawQuery($query)
-    ->setCollectionType(TingSearchRequest::COLLECTION_TYPE_SINGLE_OBJECT)
-    ->addSort('date_descending')
-    ->setPage($page + 1)
-    ->setCount($num_per_page);
+    ->withRawQuery($query)
+    ->withCollectionType(TingSearchRequest::COLLECTION_TYPE_SINGLE_OBJECT)
+    ->withSort('date_descending')
+    ->withPage($page + 1)
+    ->withCount($num_per_page);
   return $query->execute();
 }
 

--- a/modules/ting_reference/ting_reference.module
+++ b/modules/ting_reference/ting_reference.module
@@ -615,11 +615,11 @@ function _ting_reference_autocomplete($string) {
     }
     else {
       // Else fall back to a standard freetext search.
-      $query = ting_start_query()->setFullTextQuery($string);
+      $query = ting_start_query()->withFullTextQuery($string);
     }
 
     // Set limit and execute.
-    $result = $query->setCount(10)->execute();
+    $result = $query->withCount(10)->execute();
 
     // If there is no usable result, exit immediately, providing no reply.
     if ($result && $result->getNumTotalObjects()) {

--- a/modules/ting_search/plugins/content_types/search_backends.inc
+++ b/modules/ting_search/plugins/content_types/search_backends.inc
@@ -63,7 +63,7 @@ function ting_search_backend_engines_content_type_render($subtype, $conf, $panel
         // on /search/ting/%key% page.
         if (empty($results)) {
           // Prepare keys.
-          $results = ting_start_query()->setFullTextQuery($keys)->execute();
+          $results = ting_start_query()->withFullTextQuery($keys)->execute();
           ting_search_current_results($results);
         }
         // Get count of total results from ting.

--- a/modules/ting_search/tests/ting_search_unit.test
+++ b/modules/ting_search/tests/ting_search_unit.test
@@ -81,12 +81,12 @@ class DingSearchUnitTest extends DingUnitTestBase {
       new TingSearchFieldFilter('field3', 'value'),
     ], BooleanStatementInterface::OP_OR);
 
-    $query->addFilters($_1_filter_list);
-    $query->addFilters($_2_single_filter);
-    $query->addFilters($_3_filter_group);
+    $query->withFilters($_1_filter_list);
+    $query->withFilters($_2_single_filter);
+    $query->withFilters($_3_filter_group);
     // Use the shorthand for testing 4). This is basically a shorthand for 2)
     // so we use the same field-name to be able to test it in a moment.
-    $query->addFieldFilter('field2', 'value');
+    $query->withFieldFilter('field2', 'value');
 
     // This should have added four boolean statement groups.
     $resulting_filters = $query->getFilters();
@@ -122,7 +122,7 @@ class DingSearchUnitTest extends DingUnitTestBase {
 
     // Test that the filter is rejected.
     try {
-      $query->addFilters($invalid);
+      $query->withFilters($invalid);
     }
     catch (UnsupportedSearchQueryException $e) {
       // All is ok.

--- a/modules/ting_search/ting_search.module
+++ b/modules/ting_search/ting_search.module
@@ -350,18 +350,19 @@ function ting_search_search_execute($keys = NULL, $conditions = NULL) {
   $results = &drupal_static(__FUNCTION__);
   if (!isset($results)) {
     $results = array();
-    $query = ting_start_query()->setFullTextQuery($keys);
-    $query->setTermsPrFacet(variable_get('ting_search_number_of_facets', 25));
+    $query = ting_start_query()
+      ->withFullTextQuery($keys)
+      ->withTermsPrFacet(variable_get('ting_search_number_of_facets', 25));
 
     // Extend query with filters.
     if (!empty($conditions['filters'])) {
       foreach ($conditions['filters'] as $name => $filter) {
         // If no name is provided for a filter then it is a raw filter.
         if (is_int($name)) {
-          $query->addFilters(array(new TingSearchRawFilter($filter)));
+          $query = $query->withFilters(array(new TingSearchRawFilter($filter)));
         }
         else {
-          $query->addFieldFilter($name, $filter);
+          $query = $query->withFieldFilter($name, $filter);
         }
       }
     }
@@ -372,7 +373,7 @@ function ting_search_search_execute($keys = NULL, $conditions = NULL) {
       foreach ($facets as $facet) {
         $facet = explode(':', $facet, 2);
         if ($facet[0]) {
-          $query->addFieldFilter($facet[0], rawurldecode($facet[1]));
+          $query = $query->withFieldFilter($facet[0], rawurldecode($facet[1]));
         }
       }
     }
@@ -386,7 +387,6 @@ function ting_search_search_execute($keys = NULL, $conditions = NULL) {
       if (!empty($conditions['size'])) {
         $results_per_page = $conditions['size'];
       }
-
       // Set sort order.
       if (!empty($conditions['sort'])) {
         // Get all sort-options available from the provider.
@@ -396,11 +396,11 @@ function ting_search_search_execute($keys = NULL, $conditions = NULL) {
         // TingSearchSort instance specified by the provider and add it to the
         // query.
         if (!empty($available_sort_options[$conditions['sort']]['sort'])) {
-          $query->addSorts($available_sort_options[$conditions['sort']]['sort']);
+          $query = $query->withSorts($available_sort_options[$conditions['sort']]['sort']);
         }
       }
 
-      $query->setPage($page + 1)->setCount($results_per_page);
+      $query = $query->withPage($page + 1)->withCount($results_per_page);
       $search_result = $query->execute();
 
       if ($search_result->getNumTotalCollections() > 0) {

--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -295,11 +295,11 @@ function _ting_search_carousel_find_entities_with_covers($query, $start, $size, 
   $page = floor($start / $size) + 1;
 
   $sal_query = ting_start_query()
-    ->setRawQuery($query)
-    ->setPage($page)
-    ->setCount($size)
-    ->setPopulateCollections(FALSE)
-    ->setMaterialFilter($ignore, FALSE);
+    ->withRawQuery($query)
+    ->withPage($page)
+    ->withCount($size)
+    ->withPopulateCollections(FALSE)
+    ->withMaterialFilter($ignore, FALSE);
 
   $results = $sal_query->execute();
 


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3408

This change ensure that a new search object is generated and passed
along each time it is changed. This way we avoid unintentional changes
to existing search requests when we reuse an object to generate a new
search.

This is an alternate approach to the issue being tackled in #1056. This makes cloning and additional arguments unnecessary.

The approach taken using `withX` instead of `setX` is inspired by the [PSR-7 implementation](https://www.php-fig.org/psr/psr-7/) where messages are also immutable. [See the Guzzle implementation for example code](https://github.com/guzzle/psr7/blob/master/src/ServerRequest.php#L245).