### PR TITLE
3432: Update Drupal Core to 7.58

### DIFF
--- a/drupal.make
+++ b/drupal.make
@@ -3,7 +3,7 @@ api = 2
 
 ; Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.57
+projects[drupal][version] = 7.58
 projects[drupal][patch][] = "http://drupal.org/files/issues/menu-get-item-rebuild-1232346-45.patch"
 projects[drupal][patch][] = "http://drupal.org/files/ssl-socket-transports-1879970-13.patch"
 projects[drupal][patch][] = "http://www.drupal.org/files/issues/1232416-autocomplete-for-drupal7x53.patch"


### PR DESCRIPTION
This protects against the SA-CORE-2018-002 security vulnerability.
https://www.drupal.org/sa-core-2018-002