### PR TITLE
3162: Fix titles on status lists

### DIFF
--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -469,7 +469,7 @@ function ting_ding_entity_buttons($type, $entity) {
     }
 
     $collection = ting_collection_load($entity->id);
-    if (count($collection->types) > 1) {
+    if (is_a($collection, 'TingCollection') && count($collection->types) > 1) {
       $buttons[] = array(
         '#theme' => 'link',
         '#text' => t('Other formats'),


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3162 

**Problem**
Some materials on user's statuslists will show "Title not available". This primarily occurs when:

1. Libraries makes reservation for users on bibliographic posts before they get the actual materials delivered.
2. When users have materials on the debt lists, they will often be discarded in the system and therefor not searchable anymore for the library.

There are other causes (for example sometimes for ILL-loans) but I believe these to be the primary reasons for this error.

**Solution**
First I was trying to make a solution, where the materials on the statuslists would be searched with out filtering on the libraries holdings (holdingsitem.agencyid). This involved implementing a mechanism for temporarily disabling the filter. A bit "hacky".

Then i discovered the work being done in https://platform.dandigbib.org/issues/2223. Here we go from using a rec.id-search to getObject, when fetching multiple materials. getObject request aren't subject to holdings filtering, so with this method we're able to fetch all materials from the well. This will fix the missing titles in almost all cases. (in cases were the material is completely gone from the well, there's not much to do anyway).

After merging the PR from 2223 and testing, this seems to work very well!

The only problem is that we will get an error when users try to click on the (non-searchable) materials in status-lists. This is because of the code that tries to add the "Other material types" button: it tries to load the associated collection, but since we still need to use a search to get collections (work match), this will not work and currently results in an error, because the code tries to call a method on a boolean.

The solution must be to simple check if it's was possible to load a collection based on the ding_entity_id from the status-lists. Hence no "Other materials" button is shown, and I believe this to be a non-issue, since the library will not have this material anyway. It's only shown for informational purposes, when a user wants to know more about a material on their lists.