### PR TITLE
3534: Fix default values during install

### DIFF
--- a/ding2.profile
+++ b/ding2.profile
@@ -47,12 +47,12 @@ function ding2_form_alter(&$form, &$form_state, $form_id) {
 
     // Set default values in ting search form to help aegir/bulk installations.
     if ($form_id == 'opensearch_admin_settings') {
-      $form['ting']['opensearch_url']['#default_value'] = 'https://opensearch.addi.dk/b3.5_5.0/';
-      $form['ting']['opensearch_recommendation_url']['#default_value'] = 'http://openadhl.addi.dk/1.1/';
+      $form['opensearch']['opensearch_url']['#default_value'] = 'https://opensearch.addi.dk/b3.5_5.0/';
+      $form['opensearch']['opensearch_recommendation_url']['#default_value'] = 'http://openadhl.addi.dk/1.1/';
     }
 
-    if ($form_id == 'ting_covers_admin_addi_settings_form') {
-      $form['addi']['addi_wsdl_url']['#default_value'] = 'http://moreinfo.addi.dk/2.11';
+    if ($form_id == 'ting_covers_addi_admin_settings_form') {
+      $form['addi']['ting_covers_addi_wsdl_url']['#default_value'] = 'http://moreinfo.addi.dk/2.11';
     }
   }
 }

--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -256,7 +256,7 @@ function opensearch_admin_settings($form_state) {
   $form['opensearch']['opensearch_url'] = array(
     '#type' => 'textfield',
     '#title' => t('Search service URL'),
-    '#description' => t('URL to the Ting search webservice, e.g. https://opensearch.addi.dk/b3.5_5.0/),
+    '#description' => t('URL to the Ting search webservice, e.g. https://opensearch.addi.dk/b3.5_5.0/'),
     '#required' => TRUE,
     '#default_value' => variable_get('opensearch_url', ''),
   );


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3534

We try to set some defaults for opensearch and moreinfo service during install. Appearently this wasn't happening because of some typos.

I tested that it works with drush site-install and manual install via browser.

Just can't find a reason why these are not just placed on the form itself, but I have not changed it.