### PR TITLE
3388: Added agency to fulltext request

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -376,7 +376,7 @@ function opensearch_execute_cache($request) {
 
   // Handle fulltext vs. dkabm caching of object.
   $type = OPENSEARCH_CACHE_TING_OBJECT;
-  if ($parms['format'] == 'docbook') {
+  if ($parms['objectFormat'] == 'docbook') {
     $type = OPENSEARCH_CACHE_TING_OBJECT_FULLTEXT;
   }
 

--- a/modules/ting_fulltext/ting_fulltext.module
+++ b/modules/ting_fulltext/ting_fulltext.module
@@ -48,7 +48,9 @@ function ting_fulltext_object_load($object_id) {
     $request = opensearch_get_request_factory()->getObjectRequest();
     $request->setObjectId($object_id);
     $request->setProfile(variable_get('opensearch_search_profile', ''));
-    $request->setFormat('docbook');
+    if ($agency = variable_get('ting_agency', FALSE)) {
+      $request->setAgency($agency);
+    }
     $request->setObjectFormat('docbook');
     $request->setOutputType('xml');
     $xml = opensearch_execute_cache($request);


### PR DESCRIPTION
When switching to datawell 5.0 the agency is required to make search and the format is obsolete.

See https://platform.dandigbib.org/issues/3388  