### PR TITLE
3572: Enable ding_app_variables on existing Opensearch sites

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -615,3 +615,12 @@ function ding2_update_7050() {
   ding2_remove_module('ding_mobilesearch');
 }
 
+/**
+ * Enable ding_app_variables module.
+ */
+function ding2_update_7051() {
+  // Rerun the update hook. Some sites may already have run 7048 but without
+  // ding2_update_dependencies and thus without ting_update_7014 and
+  // Opensearch.
+  ding2_update_7048();
+}


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3572

Previous changes were made to an update hook which has already been
run on production and thus did not have any effect. Consequently we
rerun the hook.