### PR TITLE
3191: better renewal feedback

### DIFF
--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -274,7 +274,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
             'class' => 'messages information',
           );
         }
-        // Inter library loan
+        // Inter library loan.
         elseif ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWAL_REQUESTED) {
           $item['#material_message'] = array(
             'message' => t('An inter-library loan renewal was requested'),

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -168,6 +168,8 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       $form['loans'][$gid]['title']['#prefix'] = '<a class="anchor" id="anchor-' . $group_type . '"></a>' . $form['loans'][$gid]['title']['#prefix'];
     }
 
+    $renewed_ids = ding_session_cache_get('ding_loan', 'renewed_ids', array());
+
     foreach ($group['loans'] as $loan) {
       // The default title from loan object.
       $title = $loan->display_name;
@@ -255,7 +257,14 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       }
 
       // If not renewable set message.
-      if (empty($loan->renewable)) {
+      if (in_array($loan->id, $renewed_ids)) {
+        $disabled_count++;
+        $item['#material_message'] = array(
+          'message' => t('This material was renewed'),
+          'class' => 'messages warning',
+        );
+      }
+      elseif (empty($loan->renewable)) {
         $disabled_count++;
         $item['#material_message'] = array(
           'message' => t('This material can not be renewed'),
@@ -332,7 +341,7 @@ function ding_loan_loans_form_submit($form, &$form_state) {
     DingProviderLoan::STATUS_RENEWAL_RESERVED => t('The material is reserved by another loaner'),
   );
 
-  $clear_cache = FALSE;
+  $renewed_ids = array();
 
   $result = ding_provider_invoke('loan', 'renew', $form_state['values']['account'], $ids);
   foreach ($result as $id => $status) {
@@ -362,7 +371,7 @@ function ding_loan_loans_form_submit($form, &$form_state) {
       case DingProviderLoan::STATUS_RENEWED:
       case DingProviderLoan::STATUS_RENEWAL_REQUESTED:
         drupal_set_message(t('"@title renewed"', array('@title' => $title)));
-        $clear_cache = TRUE;
+        $renewed_ids[] = $id;
         break;
 
       case DingProviderLoan::STATUS_NOT_RENEWED:
@@ -379,9 +388,11 @@ function ding_loan_loans_form_submit($form, &$form_state) {
     }
   }
 
-  // Clear session cache.
-  if ($clear_cache && module_exists('ding_session_cache')) {
+  // If any loans was succesfully renewed; clear session cache and remember
+  // these loans throughout the session.
+  if (!empty($renewed_ids) && module_exists('ding_session_cache')) {
     ding_session_cache_clear('ding_loan', 'list');
+    ding_session_cache_set('ding_loan', 'renewed_ids', $renewed_ids);
   }
 }
 

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -268,7 +268,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         // The provider may have returned some useful renewal status, perhaps
         // based on the already renewed ids in this session that we maintain in
         // this module.
-        if ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWED) {
+        if ($loan->renewal_status == DingProviderLoan::STATUS_RENEWED) {
           $item['#material_message'] = array(
             'message' => t('This material was renewed. New return date: !due_date', array(
               '!due_date' => format_date(strtotime(check_plain($loan->expiry)), 'ding_material_lists_date'),
@@ -277,7 +277,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
           );
         }
         // Inter library loan.
-        elseif ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWAL_REQUESTED) {
+        elseif ($loan->renewal_status == DingProviderLoan::STATUS_RENEWAL_REQUESTED) {
           $item['#material_message'] = array(
             'message' => t('An inter-library loan renewal was requested'),
             'class' => 'messages information',
@@ -293,7 +293,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         }
         else {
           $item['#material_message'] = array(
-            'message' => $error_messages[$loan->renewalStatus],
+            'message' => $error_messages[$loan->renewal_status],
             'class' => 'messages warning',
           );
         }

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -255,12 +255,11 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       }
 
       // This is the same array as in loan form submit further down, but we
-      // might want different feedback messages on the list and after renew
-      // submit.
+      // might want different feedback messages on the list.
       $error_messages = array(
         DingProviderLoan::STATUS_NOT_RENEWED => t('This material can not be renewed'),
-        DingProviderLoan::STATUS_RENEWAL_NUM_EXCEEDED => t('Maximum number of renewals reached'),
-        DingProviderLoan::STATUS_RENEWAL_RESERVED => t('The material is reserved by another loaner'),
+        DingProviderLoan::STATUS_RENEWAL_NUM_EXCEEDED => t('The material can not be renewed because maximum number of renewals reached'),
+        DingProviderLoan::STATUS_RENEWAL_RESERVED => t('The material is reserved by another loaner and can not be renewed'),
       );
 
       // Loan is not renewable! Inform the user the best we can.

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -256,20 +256,31 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         );
       }
 
-      // If not renewable set message.
-      if (in_array($loan->id, $renewed_ids)) {
+      // Loan is not renewable! Inform the user the best we can.
+      if (empty($loan->renewable)) {
         $disabled_count++;
-        $item['#material_message'] = array(
-          'message' => t('This material was renewed'),
-          'class' => 'messages warning',
-        );
-      }
-      elseif (empty($loan->renewable)) {
-        $disabled_count++;
-        $item['#material_message'] = array(
-          'message' => t('This material can not be renewed'),
-          'class' => 'messages warning',
-        );
+        // If already renewed this session inform the user to avoid confusion.
+        if (in_array($loan->id, $renewed_ids)) {
+          $disabled_count++;
+          $item['#material_message'] = array(
+            'message' => t('This material was renewed'),
+            'class' => 'messages warning',
+          );
+        }
+        // Material was borrowed today; show that instead.
+        if (date('Y-m-d') == date('Y-m-d', strtotime($loan->loan_date))) {
+          $item['#material_message'] = array(
+            'message' => t('This material was borrowed today'),
+            'class' => 'messages warning',
+          );
+        }
+        // As a last resort; show the not renewable warning.
+        else {
+          $item['#material_message'] = array(
+            'message' => t('This material can not be renewed'),
+            'class' => 'messages warning',
+          );
+        }
       }
 
       // Add the reservation to the form.

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -268,7 +268,9 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         // If already renewed this session inform the user to avoid confusion.
         if ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWED) {
           $item['#material_message'] = array(
-            'message' => t('This material was renewed'),
+            'message' => t('This material was renewed. New return date: !due_date', array(
+              '!due_date' => format_date(strtotime(check_plain($loan->expiry)), 'ding_material_lists_date'),
+            )),
             'class' => 'messages information',
           );
         }

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -265,7 +265,9 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       // Loan is not renewable! Inform the user the best we can.
       if (empty($loan->renewable)) {
         $disabled_count++;
-        // If already renewed this session inform the user to avoid confusion.
+        // The provider may have returned some useful renewal status, perhaps
+        // based on the already renewed ids in this session that we maintain in
+        // this module.
         if ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWED) {
           $item['#material_message'] = array(
             'message' => t('This material was renewed. New return date: !due_date', array(
@@ -368,6 +370,11 @@ function ding_loan_loans_form_submit($form, &$form_state) {
 
   $clear_cache = FALSE;
 
+  $renewed_ids = array();
+  if (module_exists('ding_session_cache')) {
+    $renewed_ids = ding_session_cache_get('ding_loan', 'renewed_ids', array());
+  }
+
   $result = ding_provider_invoke('loan', 'renew', $form_state['values']['account'], $ids);
   foreach ($result as $id => $status) {
     // Try to get entity for the item.
@@ -397,6 +404,10 @@ function ding_loan_loans_form_submit($form, &$form_state) {
       case DingProviderLoan::STATUS_RENEWAL_REQUESTED:
         drupal_set_message(t('"@title renewed"', array('@title' => $title)));
         $clear_cache = TRUE;
+
+        // This loan was succefully renewed. Remember this for the rest of the
+        // session.
+        $renewed_ids[] = $id;
         break;
 
       case DingProviderLoan::STATUS_NOT_RENEWED:
@@ -417,6 +428,7 @@ function ding_loan_loans_form_submit($form, &$form_state) {
   // these loans throughout the session.
   if ($clear_cache && module_exists('ding_session_cache')) {
     ding_session_cache_clear('ding_loan', 'list');
+    ding_session_cache_set('ding_loan', 'renewed_ids', $renewed_ids);
   }
 }
 

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -273,6 +273,13 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
             'class' => 'messages warning',
           );
         }
+        // Inter library loan
+        elseif ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWAL_REQUESTED) {
+          $item['#material_message'] = array(
+            'message' => t('An inter-library loan renewal was requested'),
+            'class' => 'messages warning',
+          );
+        }
         // This is a special case. If the material was borrowed today and is
         // not renewed/rewenable; we show this message instead.
         elseif (date('Y-m-d') == date('Y-m-d', strtotime($loan->loan_date))) {

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -265,10 +265,18 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       // Loan is not renewable! Inform the user the best we can.
       if (empty($loan->renewable)) {
         $disabled_count++;
-        // The provider may have returned some useful renewal status, perhaps
-        // based on the already renewed ids in this session that we maintain in
-        // this module.
-        if ($loan->renewal_status == DingProviderLoan::STATUS_RENEWED) {
+        // This is a special case. If the material was borrowed today and is
+        // not renewed/rewenable; we show this message instead. This is more
+        // useful information in this case.
+        if (date('Y-m-d') == date('Y-m-d', strtotime($loan->loan_date))) {
+          $item['#material_message'] = array(
+            'message' => t('This material was borrowed today'),
+            'class' => 'messages information',
+          );
+        }
+        // Otherwise, we will have a look at the renewal_status returned from
+        // the provider.
+        elseif ($loan->renewal_status == DingProviderLoan::STATUS_RENEWED) {
           $item['#material_message'] = array(
             'message' => t('This material was renewed. New return date: !due_date', array(
               '!due_date' => format_date(strtotime(check_plain($loan->expiry)), 'ding_material_lists_date'),
@@ -283,17 +291,24 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
             'class' => 'messages information',
           );
         }
-        // This is a special case. If the material was borrowed today and is
-        // not renewed/rewenable; we show this message instead.
-        elseif (date('Y-m-d') == date('Y-m-d', strtotime($loan->loan_date))) {
+        elseif ($loan->renewal_status == DingProviderLoan::STATUS_RENEWAL_NUM_EXCEEDED) {
           $item['#material_message'] = array(
-            'message' => t('This material was borrowed today'),
-            'class' => 'messages information',
+            'message' => t('The material can not be renewed because maximum number of renewals reached'),
+            'class' => 'messages warning',
           );
         }
+        elseif ($loan->renewal_status == DingProviderLoan::STATUS_RENEWAL_RESERVED) {
+          $item['#material_message'] = array(
+            'message' => t('The material is reserved by another loaner and can not be renewed'),
+            'class' => 'messages warning',
+          );
+        }
+        // If we get here, either the provider doesn't support the renewa status
+        // or the status is STATUS_NOT_RENEWED. In any case we just fallback to
+        // the generic "can not be renewed" message.
         else {
           $item['#material_message'] = array(
-            'message' => $error_messages[$loan->renewal_status],
+            'message' => t('This material can not be renewed'),
             'class' => 'messages warning',
           );
         }

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -254,14 +254,6 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         );
       }
 
-      // This is the same array as in loan form submit further down, but we
-      // might want different feedback messages on the list.
-      $error_messages = array(
-        DingProviderLoan::STATUS_NOT_RENEWED => t('This material can not be renewed'),
-        DingProviderLoan::STATUS_RENEWAL_NUM_EXCEEDED => t('The material can not be renewed because maximum number of renewals reached'),
-        DingProviderLoan::STATUS_RENEWAL_RESERVED => t('The material is reserved by another loaner and can not be renewed'),
-      );
-
       // Loan is not renewable! Inform the user the best we can.
       if (empty($loan->renewable)) {
         $disabled_count++;

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -168,8 +168,6 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       $form['loans'][$gid]['title']['#prefix'] = '<a class="anchor" id="anchor-' . $group_type . '"></a>' . $form['loans'][$gid]['title']['#prefix'];
     }
 
-    $renewed_ids = ding_session_cache_get('ding_loan', 'renewed_ids', array());
-
     foreach ($group['loans'] as $loan) {
       // The default title from loan object.
       $title = $loan->display_name;
@@ -256,28 +254,36 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         );
       }
 
+      // This is the same array as in loan form submit further down, but we
+      // might want different feedback messages on the list and after renew
+      // submit.
+      $error_messages = array(
+        DingProviderLoan::STATUS_NOT_RENEWED => t('This material can not be renewed'),
+        DingProviderLoan::STATUS_RENEWAL_NUM_EXCEEDED => t('Maximum number of renewals reached'),
+        DingProviderLoan::STATUS_RENEWAL_RESERVED => t('The material is reserved by another loaner'),
+      );
+
       // Loan is not renewable! Inform the user the best we can.
       if (empty($loan->renewable)) {
         $disabled_count++;
         // If already renewed this session inform the user to avoid confusion.
-        if (in_array($loan->id, $renewed_ids)) {
-          $disabled_count++;
+        if ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWED) {
           $item['#material_message'] = array(
             'message' => t('This material was renewed'),
             'class' => 'messages warning',
           );
         }
-        // Material was borrowed today; show that instead.
-        if (date('Y-m-d') == date('Y-m-d', strtotime($loan->loan_date))) {
+        // This is a special case. If the material was borrowed today and is
+        // not renewed/rewenable; we show this message instead.
+        elseif (date('Y-m-d') == date('Y-m-d', strtotime($loan->loan_date))) {
           $item['#material_message'] = array(
             'message' => t('This material was borrowed today'),
             'class' => 'messages warning',
           );
         }
-        // As a last resort; show the not renewable warning.
         else {
           $item['#material_message'] = array(
-            'message' => t('This material can not be renewed'),
+            'message' => $error_messages[$loan->renewalStatus],
             'class' => 'messages warning',
           );
         }
@@ -352,7 +358,7 @@ function ding_loan_loans_form_submit($form, &$form_state) {
     DingProviderLoan::STATUS_RENEWAL_RESERVED => t('The material is reserved by another loaner'),
   );
 
-  $renewed_ids = array();
+  $clear_cache = FALSE;
 
   $result = ding_provider_invoke('loan', 'renew', $form_state['values']['account'], $ids);
   foreach ($result as $id => $status) {
@@ -382,7 +388,7 @@ function ding_loan_loans_form_submit($form, &$form_state) {
       case DingProviderLoan::STATUS_RENEWED:
       case DingProviderLoan::STATUS_RENEWAL_REQUESTED:
         drupal_set_message(t('"@title renewed"', array('@title' => $title)));
-        $renewed_ids[] = $id;
+        $clear_cache = TRUE;
         break;
 
       case DingProviderLoan::STATUS_NOT_RENEWED:
@@ -401,9 +407,8 @@ function ding_loan_loans_form_submit($form, &$form_state) {
 
   // If any loans was succesfully renewed; clear session cache and remember
   // these loans throughout the session.
-  if (!empty($renewed_ids) && module_exists('ding_session_cache')) {
+  if ($clear_cache && module_exists('ding_session_cache')) {
     ding_session_cache_clear('ding_loan', 'list');
-    ding_session_cache_set('ding_loan', 'renewed_ids', $renewed_ids);
   }
 }
 

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -270,14 +270,14 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         if ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWED) {
           $item['#material_message'] = array(
             'message' => t('This material was renewed'),
-            'class' => 'messages warning',
+            'class' => 'messages information',
           );
         }
         // Inter library loan
         elseif ($loan->renewalStatus == DingProviderLoan::STATUS_RENEWAL_REQUESTED) {
           $item['#material_message'] = array(
             'message' => t('An inter-library loan renewal was requested'),
-            'class' => 'messages warning',
+            'class' => 'messages information',
           );
         }
         // This is a special case. If the material was borrowed today and is
@@ -285,7 +285,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         elseif (date('Y-m-d') == date('Y-m-d', strtotime($loan->loan_date))) {
           $item['#material_message'] = array(
             'message' => t('This material was borrowed today'),
-            'class' => 'messages warning',
+            'class' => 'messages information',
           );
         }
         else {

--- a/modules/ding_provider/ding_provider.loan.inc
+++ b/modules/ding_provider/ding_provider.loan.inc
@@ -106,6 +106,7 @@ class DingProviderLoan extends DingEntityBase {
       'loan_date',
       'expiry',
       'renewable',
+      'renewalStatus',
       'remote_loan',
       'notes',
       'author',

--- a/modules/ding_provider/ding_provider.loan.inc
+++ b/modules/ding_provider/ding_provider.loan.inc
@@ -106,7 +106,7 @@ class DingProviderLoan extends DingEntityBase {
       'loan_date',
       'expiry',
       'renewable',
-      'renewalStatus',
+      'renewal_status',
       'remote_loan',
       'notes',
       'author',

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -66,17 +66,17 @@ function fbs_loan_list($account, $reset = FALSE) {
           // this loan is here we will use it for renewal feedback.
           if (in_array($id, $renewed_ids)) {
             if ($loan->loanDetails->loanType === 'interLibraryLoan') {
-              $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWAL_REQUESTED;
+              $loan_data['renewal_status'] = DingProviderLoan::STATUS_RENEWAL_REQUESTED;
             }
             else {
-              $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWED;
+              $loan_data['renewal_status'] = DingProviderLoan::STATUS_RENEWED;
             }
           }
           // Fallback to the general error messages, which is also used when
           // renewing loans.
           else {
             $loan->renewalStatus = $loan->renewalStatusList;
-            $loan_data['renewalStatus'] = _fbs_loan_get_renewal_status($loan);
+            $loan_data['renewal_status'] = _fbs_loan_get_renewal_status($loan);
           }
         }
 

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -59,12 +59,11 @@ function fbs_loan_list($account, $reset = FALSE) {
         if (empty($loan->isRenewable)) {
           $renewed_ids = array();
           if (module_exists('ding_session_cache')) {
-            $renewed_ids = ding_session_cache_get('fbs', 'renewed_ids', array());
+            $renewed_ids = ding_session_cache_get('ding_loan', 'renewed_ids', array());
           }
 
-          // We maintain a list of renewed loans in this session, and if this
-          // loan is here we will give it the renewed status for the rest of the
-          // session.
+          // Ding loan maintains a list of renewed loans in this session, and if
+          // this loan is here we will use it for renewal feedback.
           if (in_array($id, $renewed_ids)) {
             if ($loan->loanDetails->loanType === 'interLibraryLoan') {
               $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWAL_REQUESTED;
@@ -137,11 +136,6 @@ function fbs_loan_renew($account, $loans) {
     watchdog_exception('fbs', $e);
   }
 
-  $renewed_ids = array();
-  if (module_exists('ding_session_cache')) {
-    $renewed_ids = ding_session_cache_get('fbs', 'renewed_ids', array());
-  }
-
   $result = array();
   foreach ($res as $loan) {
     // Using an array for renewalStatus is an odd choice, but we'll only
@@ -151,10 +145,6 @@ function fbs_loan_renew($account, $loans) {
         $loan->loanDetails->loanType == 'interLibraryLoan' ?
         DingProviderLoan::STATUS_RENEWAL_REQUESTED :
         DingProviderLoan::STATUS_RENEWED;
-
-      // This loan was succefully renewed. Remember this for the rest of the
-      // session.
-      $renewed_ids[] = $loan->loanDetails->loanId;
     }
     else {
       $result[$loan->loanDetails->loanId] = _fbs_loan_get_renewal_status($loan);
@@ -164,7 +154,6 @@ function fbs_loan_renew($account, $loans) {
   // Clear ding session cache.
   if (module_exists('ding_session_cache')) {
     ding_session_cache_clear('fbs', 'loans');
-    ding_session_cache_set('fbs', 'renewed_ids', $renewed_ids);
   }
 
   return $result;

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -64,7 +64,7 @@ function fbs_loan_list($account, $reset = FALSE) {
 
           // We maintain a list of renewed loans in this session, and if this
           // loan is here we will give it the renewed status for the rest of the
-          // session
+          // session.
           if (in_array($id, $renewed_ids)) {
             if ($loan->loanDetails->loanType === 'interLibraryLoan') {
               $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWAL_REQUESTED;
@@ -173,6 +173,7 @@ function fbs_loan_renew($account, $loans) {
 /**
  * Helper function to extract renewalStatus from the FBS loan and convert it to
  * to Ding provider renewal status constants.
+ *
  * Used when renewing and showing loan list.
  */
 function _fbs_loan_get_renewal_status($loan) {
@@ -183,12 +184,4 @@ function _fbs_loan_get_renewal_status($loan) {
     return DingProviderLoan::STATUS_RENEWAL_RESERVED;
   }
   return DingProviderLoan::STATUS_NOT_RENEWED;
-  // TODO: FBS returns more reasons (on both renewal and loan list). Maybe these
-  // could be integrated in the provider layer?
-  // - deniedLoanerIsBlocked
-  // - deniedMaterialIsNotLoanable
-  // - deniedMaterialIsNotFound
-  // - deniedLoanerNotFound
-  // - deniedLoaningProfileNotFound
-  // - deniedOtherReason
 }

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -160,10 +160,15 @@ function fbs_loan_renew($account, $loans) {
 }
 
 /**
- * Helper function to extract renewalStatus from the FBS loan and convert it to
- * to Ding provider renewal status constants.
+ * Helper function to extract renewal status from the FBS loan.
  *
- * Used when renewing and showing loan list.
+ * The renewal status is converted to Ding provider renewal status constants.
+ *
+ * @param object $loan
+ *   The loan to extract renewal status from.
+ *
+ * @return int
+ *   An integer representing a constant from DingProviderLoan.
  */
 function _fbs_loan_get_renewal_status($loan) {
   if (in_array('deniedMaxRenewalsReached', $loan->renewalStatus)) {

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -66,7 +66,12 @@ function fbs_loan_list($account, $reset = FALSE) {
           // loan is here we will give it the renewed status for the rest of the
           // session
           if (in_array($id, $renewed_ids)) {
-            $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWED;
+            if ($loan->loanDetails->loanType === 'interLibraryLoan') {
+              $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWAL_REQUESTED;
+            }
+            else {
+              $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWED;
+            }
           }
           // Fallback to the general error messages, which is also used when
           // renewing loans.

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -55,6 +55,27 @@ function fbs_loan_list($account, $reset = FALSE) {
           'materials_number' => $loan->loanDetails->materialItemNumber,
         );
 
+        // Try to provide some meaningful renewal feedback.
+        if (empty($loan->isRenewable)) {
+          $renewed_ids = array();
+          if (module_exists('ding_session_cache')) {
+            $renewed_ids = ding_session_cache_get('fbs', 'renewed_ids', array());
+          }
+
+          // We maintain a list of renewed loans in this session, and if this
+          // loan is here we will give it the renewed status for the rest of the
+          // session
+          if (in_array($id, $renewed_ids)) {
+            $loan_data['renewalStatus'] = DingProviderLoan::STATUS_RENEWED;
+          }
+          // Fallback to the general error messages, which is also used when
+          // renewing loans.
+          else {
+            $loan->renewalStatus = $loan->renewalStatusList;
+            $loan_data['renewalStatus'] = _fbs_loan_get_renewal_status($loan);
+          }
+        }
+
         // If this is a periodical, add in issue data.
         if (isset($loan->loanDetails->periodical)) {
           $periodical = $loan->loanDetails->periodical;
@@ -111,6 +132,11 @@ function fbs_loan_renew($account, $loans) {
     watchdog_exception('fbs', $e);
   }
 
+  $renewed_ids = array();
+  if (module_exists('ding_session_cache')) {
+    $renewed_ids = ding_session_cache_get('fbs', 'renewed_ids', array());
+  }
+
   $result = array();
   foreach ($res as $loan) {
     // Using an array for renewalStatus is an odd choice, but we'll only
@@ -120,22 +146,44 @@ function fbs_loan_renew($account, $loans) {
         $loan->loanDetails->loanType == 'interLibraryLoan' ?
         DingProviderLoan::STATUS_RENEWAL_REQUESTED :
         DingProviderLoan::STATUS_RENEWED;
+
+      // This loan was succefully renewed. Remember this for the rest of the
+      // session.
+      $renewed_ids[] = $loan->loanDetails->loanId;
     }
     else {
-      $result[$loan->loanDetails->loanId] = DingProviderLoan::STATUS_NOT_RENEWED;
-      if (in_array('deniedMaxRenewalsReached', $loan->renewalStatus)) {
-        $result[$loan->loanDetails->loanId] = DingProviderLoan::STATUS_RENEWAL_NUM_EXCEEDED;
-      }
-      if (in_array('deniedReserved', $loan->renewalStatus)) {
-        $result[$loan->loanDetails->loanId] = DingProviderLoan::STATUS_RENEWAL_RESERVED;
-      }
+      $result[$loan->loanDetails->loanId] = _fbs_loan_get_renewal_status($loan);
     }
   }
 
   // Clear ding session cache.
   if (module_exists('ding_session_cache')) {
     ding_session_cache_clear('fbs', 'loans');
+    ding_session_cache_set('fbs', 'renewed_ids', $renewed_ids);
   }
 
   return $result;
+}
+
+/**
+ * Helper function to extract renewalStatus from the FBS loan and convert it to
+ * to Ding provider renewal status constants.
+ * Used when renewing and showing loan list.
+ */
+function _fbs_loan_get_renewal_status($loan) {
+  if (in_array('deniedMaxRenewalsReached', $loan->renewalStatus)) {
+    return DingProviderLoan::STATUS_RENEWAL_NUM_EXCEEDED;
+  }
+  if (in_array('deniedReserved', $loan->renewalStatus)) {
+    return DingProviderLoan::STATUS_RENEWAL_RESERVED;
+  }
+  return DingProviderLoan::STATUS_NOT_RENEWED;
+  // TODO: FBS returns more reasons (on both renewal and loan list). Maybe these
+  // could be integrated in the provider layer?
+  // - deniedLoanerIsBlocked
+  // - deniedMaterialIsNotLoanable
+  // - deniedMaterialIsNotFound
+  // - deniedLoanerNotFound
+  // - deniedLoaningProfileNotFound
+  // - deniedOtherReason
 }

--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -141,13 +141,11 @@
     top: 16px;
     right: 0;
     width: 190px;
-    height: 28px;
-    padding: 5px 10px 0 0;
+    padding: 10px;
     margin: 0;
     background-image: none;
     color: $white;
     border: 0;
-    text-align: right;
 
     &.warning {
       background-color: $red;

--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -135,8 +135,8 @@
     }
   }
 
-  // Specific style for message warning in material item
-  .messages.warning {
+  // Specific style for messages on material item
+  .messages {
     position: absolute;
     top: 16px;
     right: 0;
@@ -144,11 +144,18 @@
     height: 28px;
     padding: 5px 10px 0 0;
     margin: 0;
-    background-color: $red;
     background-image: none;
     color: $white;
     border: 0;
     text-align: right;
+
+    &.warning {
+      background-color: $red;
+    }
+
+    &.information {
+      background-color: $green;
+    }
 
     // Mobile
     @include media($mobile) {


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3191

In this PR I try to provide some better renewal feedback on the loan list.

renewalStatus is returned from FBS API in two cases:

1. When a loan is renewed
2. When a patrons loans is fetched

Until now we have only used the renewalStatus for feedback when the patron renews a loan.

With the changes in this PR the renewalStatus will also be used to provide useful information when the user is viewing the loan list. More information about what exactly is shown on redmine (https://platform.dandigbib.org/issues/3191#note-40).

As we don't have any information about the "renewal-history" of the materials, I have also used the ding_session_cache to remember which loans was renewed in the current session. This should fix the confusing "The material can not be renewed"-message, that was show right after renewal. Instead, it now shows "The material was renewed" for the rest of the session.

I have tried my best to keep all this in the FBS-provider layer, but I have extended the "ding provider loan API" with a new renewalStatus, that providers have to set when building the loan list.