### PR TITLE
3600: Re-add search message prefix/suffix hooks

### DIFF
--- a/modules/ting_search/plugins/content_types/search_result.inc
+++ b/modules/ting_search/plugins/content_types/search_result.inc
@@ -73,6 +73,8 @@ function ting_search_search_result_content_type_render($subtype, $conf, $panel_a
     // Collect the search results.
     $results = search_data($keys, $info['module'], $conditions);
     $search_result = ting_search_current_results();
+    $prefix = implode(module_invoke_all('ting_search_results_prefix', $keys, $conditions, $search_result));
+    $suffix = implode(module_invoke_all('ting_search_results_suffix', $keys, $conditions, $search_result));
   }
 
   if (!empty($conf['log'])) {


### PR DESCRIPTION
When SAL was introduced into core the hooks need to sub-search modules was removed.

This re-introduce the hooks.

Used by: "Mente du" and "Maskinebare oversættelser"

See https://platform.dandigbib.org/issues/3600