### PR TITLE
2175: Support for information about entity buttons

### DIFF
--- a/modules/ding_entity/ding_entity.module
+++ b/modules/ding_entity/ding_entity.module
@@ -245,6 +245,10 @@ function ding_entity_field_formatter_view($entity_type, $entity, $field, $instan
     }
   }
 
+  // Allow other modules to alter the content of the entity buttons. This is
+  // e.g. used by digital article service (gold button).
+  drupal_alter('ding_entity_buttons', $element, $entity, $display['type']);
+
   return $element;
 }
 


### PR DESCRIPTION
In the "guldknap" projekt we need to know which buttons have already been added via hook_ding_entity_buttons. This is need to not add the new button if e.g. the "See online" button have already been added to the entity.

So this PR adds the previous results form the hook to the next module.

Please not that #1075 changes entity_button_parameters, so this PR is dependent on that PR.