### PR TITLE
3388: Changed fulltext XML check from format to objectFormat

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -376,7 +376,7 @@ function opensearch_execute_cache($request) {
 
   // Handle fulltext vs. dkabm caching of object.
   $type = OPENSEARCH_CACHE_TING_OBJECT;
-  if ($parms['objectFormat'] == 'docbook') {
+  if (isset($parms['objectFormat']) && $parms['objectFormat'] == 'docbook') {
     $type = OPENSEARCH_CACHE_TING_OBJECT_FULLTEXT;
   }
 
@@ -709,7 +709,7 @@ function opensearch_execute($request) {
     // next part expect JSON only formatted input. So this hack simply return
     // the XML for now as later on we have to work with open format and XML
     // parsing. So for now simply return the result to fulltext.
-    if ($request instanceof TingClientObjectRequest && $request->getOutputType() == 'xml' && $request->getFormat() == 'docbook') {
+    if ($request instanceof TingClientObjectRequest && $request->getOutputType() == 'xml' && $request->getObjectFormat() == 'docbook') {
       return $res;
     }
 


### PR DESCRIPTION
The detection of the format for response from the datawell has changed to be objectFormat from format, which did break the fulltext module.

See https://platform.dandigbib.org/issues/3388