### PR TITLE
2158: Add core patch to disallow gatewayf in robots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,8 @@ circle-setup:
 	cp -R ./* $(DRUPAL_SITE_PATH)/profiles/ding2/
 	# Install the site using the ding2 profile
 	cd $(DRUPAL_SITE_PATH) && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test -y ding2_module_selection_form.providers_selection=connie
-  # Apply Drupal core patches
-  git apply -v profiles/ding2/patches/drupal_core.robots.txt.ding2.patch
+	# Apply Drupal core patches
+	cd $(DRUPAL_SITE_PATH) && git apply -v $(DRUPAL_SITE_PATH)/profiles/ding2/patches/drupal_core.robots.txt.ding2.patch
 	# Notices and warnings are seen as an error from simpletests point of view
 	# and is added to the xml-output as such. Idealy we would not have any
 	# notices or warnings, but in the current state of affairs we see quite a

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ circle-setup:
 	cp -R ./* $(DRUPAL_SITE_PATH)/profiles/ding2/
 	# Install the site using the ding2 profile
 	cd $(DRUPAL_SITE_PATH) && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test -y ding2_module_selection_form.providers_selection=connie
+  # Apply Drupal core patches
+  git apply -v profiles/ding2/patches/drupal_core.robots.txt.ding2.patch
 	# Notices and warnings are seen as an error from simpletests point of view
 	# and is added to the xml-output as such. Idealy we would not have any
 	# notices or warnings, but in the current state of affairs we see quite a

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,6 @@ circle-setup:
 	cp -R ./* $(DRUPAL_SITE_PATH)/profiles/ding2/
 	# Install the site using the ding2 profile
 	cd $(DRUPAL_SITE_PATH) && drush site-install ding2 --db-url=mysql://ubuntu@127.0.0.1/circle_test -y ding2_module_selection_form.providers_selection=connie
-	# Apply Drupal core patches
-	cd $(DRUPAL_SITE_PATH) && git apply -v $(DRUPAL_SITE_PATH)/profiles/ding2/patches/drupal_core.robots.txt.ding2.patch
 	# Notices and warnings are seen as an error from simpletests point of view
 	# and is added to the xml-output as such. Idealy we would not have any
 	# notices or warnings, but in the current state of affairs we see quite a

--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ __Optional, but recommended patches__
 Ensures that Ajax errors only are displayed when not in readystate 4. So when
 the user presses enter to perform a search before auto-complete Ajax is call is
 completed an error will not be displayed.
->>>>>>> 2158: Update README.md with info about new patch
 ```sh
   ~$ wget -qO- http://www.drupal.org/files/issues/autocomplete-1232416-205-7x.patch | patch -p1
 ```

--- a/README.md
+++ b/README.md
@@ -58,10 +58,18 @@ web-services that runs OpenSSL v1.0.x or newer works.
   ~$ wget -qO- http://drupal.org/files/ssl-socket-transports-1879970-13.patch | patch -p1
 ```
 
+<<<<<<< HEAD
 __Optional__, but recommended patch that ensures that Ajax errors only are
 displayed when not in readystate 4. So when the user presses enter to perform a
 search before auto-complete Ajax is call is completed an error will not be
 displayed.
+=======
+__Optional, but recommended patches__
+
+Ensures that Ajax errors only are displayed when not in readystate 4. So when
+the user presses enter to perform a search before auto-complete Ajax is call is
+completed an error will not be displayed.
+>>>>>>> 2158: Update README.md with info about new patch
 ```sh
   ~$ wget -qO- http://www.drupal.org/files/issues/autocomplete-1232416-205-7x.patch | patch -p1
 ```
@@ -70,6 +78,11 @@ __Optional__, but recommended patch that fixes the problem with scrolls
 when dragging items within tables in the backend.
 ```sh
   ~$ wget -qO- http://www.drupal.org/files/issues/drupal-tabledrag-scroll-2843240-36.patch | patch -p1
+
+Modification to Drupal core's robots.txt that disallows gatewayf urls. So if
+you're using this module, apply this patch too.
+```sh
+  patch -p1 < profiles/ding2/patches/drupal_core.robots.txt.ding2.patch
 ```
 
 ## Build Ding2 installation profile
@@ -111,6 +124,13 @@ manually in a production environment.
 ```sh
   ~$ wget https://raw.github.com/ding2/ding2/release/drupal.make
   ~$ drush make --working-copy --contrib-destination=profiles/ding2/ drupal.make htdocs
+```
+
+If you want to apply our custom Drupal core robots.txt patch, you still need to
+do that manually, as it's not possible to add it to the standalone drupal.make
+file
+```sh
+  patch -p1 < profiles/ding2/patches/drupal_core.robots.txt.ding2.patch
 ```
 
 # Post installation

--- a/README.md
+++ b/README.md
@@ -122,15 +122,10 @@ all the questions.
 If you are using an deployment system you may not want to patch Drupal core
 manually in a production environment.
 ```sh
-  ~$ wget https://raw.github.com/ding2/ding2/release/drupal.make
-  ~$ drush make --working-copy --contrib-destination=profiles/ding2/ drupal.make htdocs
-```
-
-If you want to apply our custom Drupal core robots.txt patch, you still need to
-do that manually, as it's not possible to add it to the standalone drupal.make
-file
-```sh
-  patch -p1 < profiles/ding2/patches/drupal_core.robots.txt.ding2.patch
+  ~$ git clone git@github.com:ding2/ding2.git ding2
+  ~$ drush make --working-copy --contrib-destination=profiles/ding2 ding2/drupal.make drupal
+  ~$ mv drupal/* drupal/.[^.]* .
+  ~$ rm -rf drupal ding2
 ```
 
 # Post installation

--- a/README.md
+++ b/README.md
@@ -58,12 +58,6 @@ web-services that runs OpenSSL v1.0.x or newer works.
   ~$ wget -qO- http://drupal.org/files/ssl-socket-transports-1879970-13.patch | patch -p1
 ```
 
-<<<<<<< HEAD
-__Optional__, but recommended patch that ensures that Ajax errors only are
-displayed when not in readystate 4. So when the user presses enter to perform a
-search before auto-complete Ajax is call is completed an error will not be
-displayed.
-=======
 __Optional, but recommended patches__
 
 Ensures that Ajax errors only are displayed when not in readystate 4. So when
@@ -74,10 +68,10 @@ completed an error will not be displayed.
   ~$ wget -qO- http://www.drupal.org/files/issues/autocomplete-1232416-205-7x.patch | patch -p1
 ```
 
-__Optional__, but recommended patch that fixes the problem with scrolls
-when dragging items within tables in the backend.
+Fixes the problem with scrolls when dragging items within tables in the backend.
 ```sh
   ~$ wget -qO- http://www.drupal.org/files/issues/drupal-tabledrag-scroll-2843240-36.patch | patch -p1
+```
 
 Modification to Drupal core's robots.txt that disallows gatewayf urls. So if
 you're using this module, apply this patch too.

--- a/README.md
+++ b/README.md
@@ -117,9 +117,8 @@ If you are using an deployment system you may not want to patch Drupal core
 manually in a production environment.
 ```sh
   ~$ git clone git@github.com:ding2/ding2.git ding2
-  ~$ drush make --working-copy --contrib-destination=profiles/ding2 ding2/drupal.make drupal
-  ~$ mv drupal/* drupal/.[^.]* .
-  ~$ rm -rf drupal ding2
+  ~$ drush make --working-copy --contrib-destination=profiles/ding2 ding2/drupal.make .
+  ~$ rm -rf ding2
 ```
 
 # Post installation

--- a/drupal.make
+++ b/drupal.make
@@ -9,6 +9,7 @@ projects[drupal][patch][] = "http://drupal.org/files/ssl-socket-transports-18799
 projects[drupal][patch][] = "http://www.drupal.org/files/issues/1232416-autocomplete-for-drupal7x53.patch"
 projects[drupal][patch][] = "http://drupal.org/files/issues/translate_role_names-2205581-1.patch"
 projects[drupal][patch][] = "http://www.drupal.org/files/issues/drupal-tabledrag-scroll-2843240-36.patch"
+projects[drupal][patch][] = "patches/drupal_core.robots.txt.ding2.patch"
 
 ; Get the profile, which will contain the next makefile.
 projects[ding2][type] = "profile"

--- a/patches/drupal_core.robots.txt.ding2.patch
+++ b/patches/drupal_core.robots.txt.ding2.patch
@@ -1,0 +1,10 @@
+diff --git a/robots.txt b/robots.txt
+index a2ee32ec39..6672652e52 100644
+--- a/robots.txt
++++ b/robots.txt
+@@ -88,3 +88,5 @@ Disallow: /?q=user/password/
+ Disallow: /?q=user/register/
+ Disallow: /?q=user/login/
+ Disallow: /?q=user/logout/
++# Ding2 specific paths
++Disallow: /gatewayf/


### PR DESCRIPTION
https://platform.dandigbib.org/issues/2158

Had a lot of issues with the Makefile, since it needs tabs to separate lines. My editor is set to use spaces when working with ding2 and Drupal in general.
And sublime text was not helping. Had to use this plugin: https://packagecontrol.io/packages/TabNukerNuker 

Anyway, I think I got those tabs inserted after some hard work hehe :)

I was wondering: Are there any particular reason why we use a MakeFile for circleci? I can't seem to find any documentation about that.