### PR TITLE
1460: Reservation buttons overhaul

### DIFF
--- a/modules/alma/alma.module
+++ b/modules/alma/alma.module
@@ -780,3 +780,20 @@ function alma_ding_session_cache_defaults() {
     'expire' => 3600,
   );
 }
+
+/**
+ * Implements hook_ding_entity_is().
+ */
+function alma_ding_entity_is($object, $class) {
+  if (!$object instanceof TingEntity) {
+    return NULL;
+  }
+
+  switch ($class) {
+    case 'reservable':
+      $local_id = $object->getLocalId();
+      $result = ding_provider_invoke('availability', 'holdings', $local_id)[$local_id];
+
+      return ($result['reservable'] && !$result['is_periodical']);
+  }
+}

--- a/modules/alma/alma.module
+++ b/modules/alma/alma.module
@@ -792,7 +792,7 @@ function alma_ding_entity_is($object, $class) {
   switch ($class) {
     case 'reservable':
       $local_id = $object->getLocalId();
-      $result = ding_provider_invoke('availability', 'holdings', $local_id)[$local_id];
+      $result = ding_provider_invoke('availability', 'holdings', array($local_id))[$local_id];
 
       return ($result['reservable'] && !$result['is_periodical']);
   }

--- a/modules/ding_availability/ding_availability.field.inc
+++ b/modules/ding_availability/ding_availability.field.inc
@@ -87,7 +87,6 @@ function ding_availability_field_formatter_info() {
 function ding_availability_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
   $element = array();
   $online_types = array_filter(variable_get('ting_online_types', _ting_default_online_types()));
-  $reservable_sources = array_filter(variable_get('ting_reservable_sources', _ting_default_reservable_sources()));
 
   // Attach front-end style and JS to the element.
   foreach ($items as $delta => $item) {
@@ -115,8 +114,7 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
 
         // If item is of type 'library materials' (where we can lookup holding
         // data), prepare to check holding on the item.
-        $holding_types = variable_get('ding_availability_holdings_types', _ding_availability_holdings_default_types());
-        if (in_array(drupal_strtolower($ac_source), $reservable_sources) && in_array(drupal_strtolower($entity->type), $holding_types)) {
+        if ($entity->is('library_material')) {
           $attached['js'][] = array(
             'data' => array(
               'ding_availability_mode' => 'holdings',
@@ -162,7 +160,7 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
 
         // If item is of type 'library materials' (where we can lookup holding
         // data), prepare to check holding on the item.
-        if (in_array(strtolower($ac_source), $reservable_sources)) {
+        if ($entity->is('library_material')) {
           $attached['js'][1] = array(
             'data' => array(
               'ding_availability' => array(
@@ -285,7 +283,7 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
           // If item is of type 'library materials' (where we can lookup
           // availability data), map the HTML id to the list of entity ids.
           // This is for the current material type group (book, cd, etc.).
-          if (in_array(drupal_strtolower($ac_source), $reservable_sources) && !in_array(drupal_strtolower($type), $online_types)) {
+          if ($entities[0]->is('library_material')) {
             foreach ($entities as $object_entity) {
               $id_mapping[$id][] = $object_entity->localId;
             }

--- a/modules/ding_availability/js/ding_availability.js
+++ b/modules/ding_availability/js/ding_availability.js
@@ -29,18 +29,6 @@
         });
       }
 
-      // If there's any reservation buttons, switch to holdings. We have
-      // periodicals that's a bit off an odd one in that they can both
-      // have issues, which means that the reservation button for the
-      // main object should be disabled, or not have any issues, which
-      // means that it should be left alone. So we need to fetch full
-      // holdings in order to determine whether the material is a
-      // periodical. This is a bit of a hack, but it's the quickest way
-      // of fixing the problem right now.
-      if ($('.reserve-button').length > 0) {
-        settings.ding_availability_mode = 'holdings';
-      }
-
       $.each(html_ids, function (index, id) {
         $('#' + id).addClass('pending');
       });
@@ -103,40 +91,9 @@
     element.removeClass('pending').addClass('processed');
 
     $.each(entity_ids, function (index, entity_id) {
-      // Reserve button.
-      var reserve_button = element.parents('.ting-object:first, .material-item:first').find('a[id$=' + entity_id + '].reserve-button');
-
       if (Drupal.DADB[entity_id]) {
         var available = available || Drupal.DADB[entity_id]['available'];
-        var reservable = reservable || Drupal.DADB[entity_id]['reservable'];
-
-        // Special handling for periodicals.
-        if (typeof Drupal.DADB[entity_id]['is_periodical'] !== 'undefined' &&
-            Drupal.DADB[entity_id]['is_periodical']) {
-          // The main object of a periodical is neither available nor
-          // reservable, the individual issues is.
-          available = reservable = false;
-        }
-        var classes = [];
-
-        classes.push(available ? 'available' : 'unavailable');
-        classes.push(reservable ? 'reservable' : 'not-reservable');
-
-        $.each(classes, function (i, class_name) {
-          element.addClass(class_name);
-
-          // Add class to reserve button.
-          if (reserve_button.length) {
-            reserve_button.addClass(class_name);
-          }
-        });
-
-        if (available && !reservable) {
-          reserve_button.removeClass('available').addClass('unavailable');
-        }
-      }
-      else {
-        reserve_button.addClass('not-reservable');
+        element.addClass(available ? 'available' : 'unavailable');
       }
     });
   }

--- a/modules/ding_carousel/js/ding_carousel.js
+++ b/modules/ding_carousel/js/ding_carousel.js
@@ -177,25 +177,6 @@
         item.tab.data('offset', data.offset);
         item.tab.data('updating', false);
 
-        // This ensures that ting objects loaded via ajax in the carousel's gets
-        // reservations buttons displayed if available. So basically it finds
-        // the material ids and coverts them into ding_availability format and
-        // updates the settings, which is then used when behaviors are attached
-        // below. This is a hack, but the alternative was to re-write
-        // ding_availability.
-        var matches = data.content.match(/reservation-\d+-\w+:\d+/gm);
-        if (matches instanceof Array) {
-          if (!Drupal.settings.hasOwnProperty('ding_availability')) {
-            Drupal.settings.ding_availability = {};
-          }
-          for (var i in matches) {
-            var match = matches[i];
-            var id = match.substring(match.indexOf(':') + 1);
-            match = match.replace('reservation', 'availability').replace(':', '');
-            Drupal.settings.ding_availability[match] = [ id ];
-          }
-        }
-
         // Ensure that behaviors are attached to the new content.
         Drupal.attachBehaviors($('.ding-carousel-item'));
 

--- a/modules/ding_provider/connie/connie.module
+++ b/modules/ding_provider/connie/connie.module
@@ -198,3 +198,14 @@ function connie_availability_periodical($provider_ids) {
   }
   return $res;
 }
+
+/**
+ * Implements hook_ding_entity_is()
+ */
+function connie_ding_entity_is($object, $class) {
+  switch ($class) {
+    case 'reservable':
+    case 'library_material':
+      return TRUE;
+  }
+}

--- a/modules/ding_provider/connie/connie.module
+++ b/modules/ding_provider/connie/connie.module
@@ -200,7 +200,7 @@ function connie_availability_periodical($provider_ids) {
 }
 
 /**
- * Implements hook_ding_entity_is()
+ * Implements hook_ding_entity_is().
  */
 function connie_ding_entity_is($object, $class) {
   switch ($class) {

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -67,6 +67,14 @@ function ding_reservation_menu() {
     'access arguments' => array('perform reservation'),
   );
 
+  $items['ding_reservation/%ding_entity/is_reservable'] = array(
+    'title' => 'Check ding entity reservability',
+    'page callback' => 'ding_reservation_is_reservable_ajax_callback',
+    'page arguments' => array(1),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -105,16 +113,26 @@ function ding_reservation_ding_entity_menu(&$items, $type, $path, $index) {
 }
 
 /**
+ * Check the reservability of the passed entity. Used as AJAX callback for the
+ * reservation button.
+ */
+function ding_reservation_is_reservable_ajax_callback($entity) {
+  drupal_json_output(array('reservable' => $entity->is('reservable')));
+}
+
+/**
  * Implements hook_ding_entity_buttons().
  */
 function ding_reservation_ding_entity_buttons($type, $entity, $view_mode, $widget = 'default') {
   $button = '';
 
-  if ($type == 'ding_entity' && $entity->is('reservable')) {
+  if ($type == 'ding_entity') {
     switch ($widget) {
       case 'ajax':
         drupal_add_library('system', 'drupal.ajax');
 
+        // The AJAX-widget will use AJAX-request for checking reservability and
+        // also when performing the reservation.
         $button = array(
           array(
             '#theme' => 'link',
@@ -128,8 +146,17 @@ function ding_reservation_ding_entity_buttons($type, $entity, $view_mode, $widge
                   'use-ajax',
                 ),
                 'id' => 'reservation-' . $entity->id,
+                'data-entity-id' => $entity->id,
               ),
               'html' => FALSE,
+            ),
+            '#attached' => array(
+              'js' => array(
+                array(
+                  'type' => 'file',
+                  'data' => drupal_get_path('module', 'ding_reservation') . '/js/ding_reservation_reservability.js',
+                ),
+              ),
             ),
           ),
         );
@@ -138,7 +165,13 @@ function ding_reservation_ding_entity_buttons($type, $entity, $view_mode, $widge
       default:
         // The last parameter to the form below (TRUE) hides the provider
         // options in the form (interest period and branch).
-        $button = array(ding_provider_get_form('ding_reservation_reserve_form', new DingReservationReservableEntity($entity), TRUE));
+        if ($entity->is('reservable')) {
+          $button = array(ding_provider_get_form(
+            'ding_reservation_reserve_form',
+            new DingReservationReservableEntity($entity),
+            TRUE
+          ));
+        }
         break;
     }
   }

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -126,7 +126,7 @@ function ding_reservation_is_reservable_ajax_callback($entity) {
 function ding_reservation_ding_entity_buttons($type, $entity, $view_mode, $widget = 'default') {
   $button = '';
 
-  if ($type == 'ding_entity') {
+  if ($type == 'ding_entity' && $entity->is('library_material')) {
     switch ($widget) {
       case 'ajax':
         drupal_add_library('system', 'drupal.ajax');

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -113,8 +113,7 @@ function ding_reservation_ding_entity_menu(&$items, $type, $path, $index) {
 }
 
 /**
- * Check the reservability of the passed entity. Used as AJAX callback for the
- * reservation button.
+ * AJAX callback used to check the reservability of the passed entity.
  */
 function ding_reservation_is_reservable_ajax_callback($entity) {
   drupal_json_output(array('reservable' => $entity->is('reservable')));
@@ -166,11 +165,9 @@ function ding_reservation_ding_entity_buttons($type, $entity, $view_mode, $widge
         // The last parameter to the form below (TRUE) hides the provider
         // options in the form (interest period and branch).
         if ($entity->is('reservable')) {
-          $button = array(ding_provider_get_form(
-            'ding_reservation_reserve_form',
-            new DingReservationReservableEntity($entity),
-            TRUE
-          ));
+          $button = array(
+            ding_provider_get_form('ding_reservation_reserve_form', new DingReservationReservableEntity($entity), TRUE),
+          );
         }
         break;
     }

--- a/modules/ding_reservation/js/ding_reservation_reservability.js
+++ b/modules/ding_reservation/js/ding_reservation_reservability.js
@@ -13,7 +13,7 @@
         var entityId = reserveButton.data("entity-id");
         $.ajax({
           dataType: "json",
-          url: "/ding_reservation/" + entityId + "/reservable",
+          url: "/ding_reservation/" + entityId + "/is_reservable",
           success: function(result) {
             if (result['reservable']) {
               reserveButton.addClass('reservable');

--- a/modules/ding_reservation/js/ding_reservation_reservability.js
+++ b/modules/ding_reservation/js/ding_reservation_reservability.js
@@ -1,0 +1,27 @@
+/**
+ * Checks reservability for materials before activating the reserve button.
+ */
+
+(function($) {
+
+  "use strict";
+
+  Drupal.behaviors.ding_reservation = {
+    attach: function(context) {
+      $(".ting-object .reserve-button", context).once('check-reservability', function() {
+        var reserveButton = $(this);
+        var entityId = reserveButton.data("entity-id");
+        $.ajax({
+          dataType: "json",
+          url: "/ding_reservation/" + entityId + "/reservable",
+          success: function(result) {
+            if (result['reservable']) {
+              reserveButton.addClass('reservable');
+            }
+          }
+        });
+      })
+    }
+  }
+
+})(jQuery);

--- a/modules/ding_reservation/js/ding_reservation_reservability.js
+++ b/modules/ding_reservation/js/ding_reservation_reservability.js
@@ -15,13 +15,13 @@
           dataType: "json",
           url: "/ding_reservation/" + entityId + "/is_reservable",
           success: function(result) {
-            if (result['reservable']) {
+            if (result.reservable) {
               reserveButton.addClass('reservable');
             }
           }
         });
-      })
+      });
     }
-  }
+  };
 
 })(jQuery);

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -83,7 +83,7 @@ function fbs_ding_provider() {
 }
 
 /**
- * Implements hook_ding_entity_is()
+ * Implements hook_ding_entity_is().
  */
 function fbs_ding_entity_is($object, $class) {
   if (!$object instanceof TingEntity) {

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -83,6 +83,28 @@ function fbs_ding_provider() {
 }
 
 /**
+ * Implements hook_ding_entity_is()
+ */
+function fbs_ding_entity_is($object, $class) {
+  switch ($class) {
+    case 'reservable':
+      // Only materials from this source can be reservable in FBS, so there's
+      // no need to do any lookup if object is not from that source.
+      if (mb_strtolower($object->ac_source) !== 'bibliotekskatalog') {
+        return FALSE;
+      }
+
+      // We get the full holdings since we both need to check reservability and
+      // whether FBS considers the object a periodical. If the item is
+      // periodical, the main item is not reservable.
+      $local_id = $object->localId;
+      $holdings = ding_provider_invoke('availability', 'holdings', $local_id)[$local_id];
+
+      return ($holdings['reservable'] && !$holdings['is_periodical']);
+  }
+}
+
+/**
  * Get info for patron.
  *
  * Wrapper around ding_user_get_creds() to facilitate testing.

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -95,12 +95,23 @@ function fbs_ding_entity_is($object, $class) {
       }
 
       // We get the full holdings since we both need to check reservability and
-      // whether FBS considers the object a periodical. If the item is
-      // periodical, the main item is not reservable.
-      $local_id = $object->localId;
-      $holdings = ding_provider_invoke('availability', 'holdings', $local_id)[$local_id];
+      // whether FBS considers the object a periodical.
+      // Invoke the call to FBS API directly, as using fbs_availability_holdings
+      // (or going through ding_provider) sets up render array for holdings
+      // display and has a chance of calling opensearch to get marc record. We
+      // need none of this and only want to know if the material is reservable
+      // and if it has any periodical information.
+      $result = reset(fbs_service()->Catalog->getHoldings(
+        fbs_service()->agencyId,
+        $object->localId
+      ));
 
-      return ($holdings['reservable'] && !$holdings['is_periodical']);
+      // Use the first material to find out if this is a periodical.
+      $holdings = reset($result->holdings);
+      $material = reset($holdings->materials);
+
+      // If the object is periodical, the main object should not be reservable.
+      return ($result->reservable && empty($material->periodical));
   }
 }
 

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -86,6 +86,10 @@ function fbs_ding_provider() {
  * Implements hook_ding_entity_is()
  */
 function fbs_ding_entity_is($object, $class) {
+  if (!$object instanceof TingEntity) {
+    return NULL;
+  }
+
   switch ($class) {
     case 'reservable':
       // Only materials from this source can be reservable in FBS, so there's

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -104,9 +104,17 @@ function fbs_ding_entity_is($object, $class) {
         $object->localId
       );
       $result = reset($result);
-
-      // Use the first material to find out if this is a periodical.
       $holdings = reset($result->holdings);
+
+      // If the record doesn't have any materials there's nothing to reserve and
+      // we can return FALSE early. This can happen for online posts from the
+      // library catalog.
+      if (empty($holdings->materials)) {
+        return FALSE;
+      }
+
+      // To determine if this is a periodical we extract the first material and
+      // look for periodical information.
       $material = reset($holdings->materials);
 
       // If the object is periodical, the main object should not be reservable.

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -99,10 +99,11 @@ function fbs_ding_entity_is($object, $class) {
       // display and has a chance of calling opensearch to get marc record. We
       // need none of this and only want to know if the material is reservable
       // and if it has any periodical information.
-      $result = reset(fbs_service()->Catalog->getHoldings(
+      $result = fbs_service()->Catalog->getHoldings(
         fbs_service()->agencyId,
         $object->localId
-      ));
+      );
+      $result = reset($result);
 
       // Use the first material to find out if this is a periodical.
       $holdings = reset($result->holdings);

--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -92,12 +92,6 @@ function fbs_ding_entity_is($object, $class) {
 
   switch ($class) {
     case 'reservable':
-      // Only materials from this source can be reservable in FBS, so there's
-      // no need to do any lookup if object is not from that source.
-      if (mb_strtolower($object->ac_source) !== 'bibliotekskatalog') {
-        return FALSE;
-      }
-
       // We get the full holdings since we both need to check reservability and
       // whether FBS considers the object a periodical.
       // Invoke the call to FBS API directly, as using fbs_availability_holdings

--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -423,9 +423,8 @@ function _opensearch_search_relation_render_online_url(\TingRelation $relation) 
         break;
       }
 
-      // Reservable sources is library material.
-      $reservable_sources = variable_get('ting_reservable_sources', _ting_default_reservable_sources());
-      if (in_array(strtolower($object->getAc_source()), $reservable_sources)) {
+      // If library material show the entity with availability, holdings, etc.
+      if ($object->is('library_material')) {
         $title = t('Read more about the material');
         $url = '/ting/object/' . $object->id;
       }

--- a/modules/opensearch/opensearch.install
+++ b/modules/opensearch/opensearch.install
@@ -10,6 +10,7 @@
  */
 function opensearch_install() {
   opensearch_migrate_settings();
+  variable_set('ting_library_material_sources', _opensearch_default_library_material_sources());
 }
 
 /**
@@ -73,4 +74,11 @@ function opensearch_update_7002() {
 function opensearch_update_7003() {
   $schema['cache_opensearch'] = drupal_get_schema_unprocessed('system', 'cache');
   db_create_table('cache_opensearch', $schema['cache_opensearch']);
+}
+
+/**
+ * Ensure the default library material source for opensearch is set.
+ */
+function opensearch_update_7004() {
+  variable_set('ting_library_material_sources', _opensearch_default_library_material_sources());
 }

--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -433,3 +433,24 @@ function opensearch_ding_entity_is($object, $class) {
     }
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function opensearch_form_ting_admin_reservable_settings_alter(&$form, &$form_state) {
+  $form['ting_library_material_sources']['#default_value'] = variable_get(
+    'ting_reservable_sources',
+    _opensearch_default_library_material_sources()
+  );
+}
+
+/**
+ * Default library material sources.
+ *
+ * Defined as a function as a define can only be scalars.
+ */
+function _opensearch_default_library_material_sources() {
+  return array(
+    'bibliotekskatalog',
+  );
+}

--- a/modules/ting/ting.admin.inc
+++ b/modules/ting/ting.admin.inc
@@ -166,6 +166,14 @@ function ting_admin_reservable_settings($form_state) {
   $types = variable_get('ting_well_types', _ting_fetch_well_types());
   $sources = variable_get('ting_well_sources', _ting_fetch_well_sources());
 
+  $form['ting_library_material_sources'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('Sources'),
+    '#description' => t('Select which sources should be considered as library material. For library materials the system will ask the library provider for reservability, availability and holdings. So for performance reasons, only check those sources where this behaviour is needed.')
+    '#options' => drupal_map_assoc($sources),
+    '#default_value' => variable_get('ting_library_material_sources', array()),
+  );
+
   $form['ting_reservable'] = array(
     '#type' => 'fieldset',
     '#title' => t('Reservation buttons'),

--- a/modules/ting/ting.admin.inc
+++ b/modules/ting/ting.admin.inc
@@ -163,7 +163,6 @@ function ting_admin_reservable_settings($form_state) {
     '#description' => t('Time before an reservation expires that a message should be shown to the user.'),
   );
 
-  $types = variable_get('ting_well_types', _ting_fetch_well_types());
   $sources = variable_get('ting_well_sources', _ting_fetch_well_sources());
 
   $form['ting_library_material_sources'] = array(
@@ -174,26 +173,6 @@ function ting_admin_reservable_settings($form_state) {
     '#default_value' => variable_get('ting_library_material_sources', array()),
   );
 
-  $form['ting_reservable'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Reservation buttons'),
-    '#tree' => FALSE,
-    '#description' => t("A Ting object will get a reservation button, if it's source and type is <em>both</em> selected."),
-  );
-
-  $form['ting_reservable']['ting_reservable_sources'] = array(
-    '#type' => 'checkboxes',
-    '#title' => t('Sources'),
-    '#options' => drupal_map_assoc($sources),
-    '#default_value' => variable_get('ting_reservable_sources', _ting_default_reservable_sources()),
-  );
-
-  $form['ting_reservable']['ting_reservable_types'] = array(
-    '#type' => 'checkboxes',
-    '#title' => t('Types'),
-    '#options' => drupal_map_assoc($types),
-    '#default_value' => variable_get('ting_reservable_types', _ting_default_reservable_types()),
-  );
   // Save us the trouble of running array_filter.
   $form['array_filter'] = array('#type' => 'value', '#value' => TRUE);
 

--- a/modules/ting/ting.admin.inc
+++ b/modules/ting/ting.admin.inc
@@ -136,7 +136,7 @@ function ting_admin_reservable_settings($form_state) {
   $form['reservation_settings'] = array(
     '#type' => 'fieldset',
     '#title' => t('Reservation settings'),
-    '#tree' => FALSE,
+
   );
 
   $options = array();
@@ -166,9 +166,14 @@ function ting_admin_reservable_settings($form_state) {
   $sources = variable_get('ting_well_sources', _ting_fetch_well_sources());
 
   $form['ting_library_material_sources'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Library material sources'),
+    '#tree' => FALSE,
+    '#description' => t('Select which sources should be considered as library material. For library materials the system will ask the library provider for reservability, availability and holdings. So for performance reasons, only check those sources where this behaviour is needed.'),
+  );
+
+  $form['ting_library_material_sources']['ting_library_material_sources'] = array(
     '#type' => 'checkboxes',
-    '#title' => t('Sources'),
-    '#description' => t('Select which sources should be considered as library material. For library materials the system will ask the library provider for reservability, availability and holdings. So for performance reasons, only check those sources where this behaviour is needed.')
     '#options' => drupal_map_assoc($sources),
     '#default_value' => variable_get('ting_library_material_sources', array()),
   );

--- a/modules/ting/ting.install
+++ b/modules/ting/ting.install
@@ -312,3 +312,11 @@ function ting_update_7014() {
 function ting_update_7015() {
   db_drop_table('cache_ting');
 }
+
+/**
+ * Delete now unused variables (because of reservable changes).
+ */
+function ting_update_7016() {
+  variable_del('ting_reservable_sources');
+  variable_del('ting_reservable_types');
+}

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -680,61 +680,6 @@ function _ting_default_online_types() {
 }
 
 /**
- * Default reservable sources.
- *
- * Defined as a function as a define can only be scalars.
- */
-function _ting_default_reservable_sources() {
-  return array(
-    'bibliotekskatalog',
-  );
-}
-
-/**
- * Default reservable types.
- *
- * Defined as a function as a define can only be scalars.
- */
-function _ting_default_reservable_types() {
-  return array(
-    'bog',
-    'node',
-    'dvd',
-    'billedbog',
-    'cd (musik)',
-    'lydbog (cd)',
-    'lydbog (bånd)',
-    'tegneserie',
-    'lydbog (cd-mp3)',
-    'sammensat materiale',
-    'cd',
-    'bog stor skrift',
-    'video',
-    'blu-ray',
-    'cd-rom',
-    'pc-spil',
-    'playstation 3',
-    'xbox 360',
-    'wii',
-    'playstation 2',
-    'playstation 4',
-    'graphic novel',
-    'nintendo ds',
-    'dvd-rom',
-    'kort',
-    'xbox',
-    'gameboy advance',
-    'wii u',
-    'grammofonplade',
-    'playstation',
-    'lydbog',
-    'spil',
-    'puslespil',
-    'diskette',
-  );
-}
-
-/**
  * Fetch known types from the datawell.
  *
  * @return array

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -377,6 +377,7 @@ function ting_ding_entity_is($object, $class) {
         return TRUE;
       }
       return NULL;
+
     case 'library_material':
       $sources = variable_get('ting_library_material_sources', array());
 

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -365,9 +365,16 @@ function ting_entity_info() {
  * Implements hook_ding_entity_is().
  */
 function ting_ding_entity_is($object, $class) {
+  if (!$object instanceof TingEntity) {
+    return NULL;
+  }
+
   switch ($class) {
     case 'online':
       return !empty($object->getOnline_url());
+    case 'library_material':
+      $sources = variable_get('ting_library_material_sources', array());
+      return in_array(drupal_strtolower($object->getAc_source()), $sources);
   }
 }
 

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -369,12 +369,21 @@ function ting_ding_entity_is($object, $class) {
     return NULL;
   }
 
+  // By not returning FALSE if the object doesn't meet the requirement, we give
+  // more flexibilty to other modules.
   switch ($class) {
     case 'online':
-      return !empty($object->getOnline_url());
+      if (!empty($object->getOnline_url())) {
+        return TRUE;
+      }
+      return NULL;
     case 'library_material':
       $sources = variable_get('ting_library_material_sources', array());
-      return in_array(drupal_strtolower($object->getAc_source()), $sources);
+
+      if (in_array(drupal_strtolower($object->getAc_source()), $sources)) {
+        return TRUE;
+      }
+      return NULL;
   }
 }
 

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -366,12 +366,6 @@ function ting_entity_info() {
  */
 function ting_ding_entity_is($object, $class) {
   switch ($class) {
-    case 'reservable':
-    case 'cartable':
-      $sources = variable_get('ting_reservable_sources', _ting_default_reservable_sources());
-      $types = variable_get('ting_reservable_types', _ting_default_reservable_types());
-      return (in_array(drupal_strtolower($object->ac_source), $sources) && in_array(drupal_strtolower($object->type), $types));
-
     case 'online':
       return !empty($object->getOnline_url());
   }

--- a/modules/ting_reference/js/ting_reference_ajax.js
+++ b/modules/ting_reference/js/ting_reference_ajax.js
@@ -17,25 +17,6 @@
           dataType : 'json',
           success : function (data) {
             elm.html(data.content);
-
-            // This ensures that ting objects loaded via ajax gets reservations buttons
-            // displayed if available. So basically it finds the material ids and coverts
-            // them into ding_availability format and updates the settings, which is
-            // this used when behaviors are attached below. This is a hack, but the
-            // alternative was to re-write ding_availability.
-            var matches = data.content.match(/reservation-\d+-\w+:\d+/gm);
-            if (matches instanceof Array) {
-              if (!Drupal.settings.hasOwnProperty('ding_availability')) {
-                Drupal.settings.ding_availability = {};
-              }
-              for (var i in matches) {
-                var match = matches[i];
-                var id = match.substring(match.indexOf(':') + 1);
-                match = match.replace('reservation', 'availability').replace(':', '');
-                Drupal.settings.ding_availability[match] = [ id ];
-              }
-            }
-
             // Ensure that behaviors are attached to the new content.
             Drupal.attachBehaviors(elm);
           }


### PR DESCRIPTION
https://platform.dandigbib.org/issues/1460

**Motivation**
The primary motivation for the changes in this PR, is to move the responsibility of checking reservability of materials from the ting module to the library provider layer

**Issues with current implementaion**
I have listed several issues with the current situation, where ting module decides reservability based on material types from the well, here: https://platform.dandigbib.org/issues/1460#note-48

**Disadvantage with the approach in this PR**
We need to do and additional look-up to check reservability, but we still need to make this look-ups anyway to check holdings/availability. (therefore, this could be solved with caching as explained below). To somewhat combat this, I have implemented the reservability check with AJAX-request, when the reserve action button is shown with AJAX-widget (this does delay the display of the reservation-button a bit though).

**Removal of reservation button hacks**
I have been able to remove all the reservation button hacks from ding_carousel and ding_availbility as they are not needed anymore. Ding reservation module is purely responsible for showing the reservation button now.

**Removal of ting_reservable_sources and ting_reservable_types configuration**
It also means that I have removed the ting_reservable_sources and ting_reservable_types configuration from the ting module. Some other modules was using this information (the reservable sources) to decide whether or not to check availability for materials. I think we still need this functionality to avoid looking up availbility information for materials, where it's not needed. I have therefore introduced a new ding_entity pseudo class: "library_material" which serves this purpose. It's basically the same configuration as reservable_sources, just renamed to better describe what it actually does.
The ting module now makes no assumptions about which material types from the search provider, should be set as default. It's up to the library provider to supply these defaults now.

**Suggestions for improvements**
Some suggestions for improvements (that I have not implemented):
1. Maybe use POST AJAX-request to bypass Varnish cache. Availability information should be up-to-date. This could be done in both ding_availability.js and ding_reservation_reservability.js.
2. Implement caching of availability and holdings from FBS. This seems to already be implemented in ALMA with a short expire of 10 min. This will prevent several look-ups of the same information when viewing a material, but we still have up-to-date availability and holdings.
3. Look up reservability of several materials at once (can't use $entity->is() then).
4. When determining whether a bibliographic post (ting object) is a periodical, we only require one of the materials to have periodical information. This is unfortunate in some cases because of the problem described in: https://platform.dandigbib.org/issues/3247. In short: Some materials can have misplaced periodical-information, which the libraries can't fix/see themselves. Therefore, this approach will sometimes wrongfully label bibliographic posts as periodicals, making them unreservable.
Maybe a more precise approach would be to require that more materials have periodical information. This could be a problematic approach though and I don't think that we can just require that all materials should have periodical information, as this would probably wrongfully label posts as non-periodical in some cases (if the post is actually a periodical, but one of the materials is missing periodical-information).
5. If the AJAX-widget is used for the reservation-button, we could provide some better feedback when checking reservability instead of just not showing the button.

**Further improvements out of scope of this PR**
Currently we also need to configure which materials should have holdings display. There's also some problems with that: 
- Libraries forget to set it when new sources are introduced 
- Some material types need normal holdings in some cases and periodical holdings in other cases, resulting in the confusing display of 2 holdings for some materials.

The ding_availability module currently handles a bit of availability and also show holdings for non-periodical materials (before this PR, it also handled a bit of reservation). And then we have a periodical module, which handles holdings only for periodical, but we don't even have a dedicated module to handle holdings.

I believe an approach with a much more cleaner separation of concerns would be:

- Make new ding_holdings module which merges the holding functionality from ding_availability and ding_periodical into one. This module could define one field, which just shows the holdings, if any, returned from the library provider. The field could handle both periodical and non-periodical holdings, ensuring that we never get the confusing display of two types of holdings.
- Remove all holdings functionality from ding_availability, such that the module is only concerned with availability and relevant fields.
- Remove the ding_periodical module entirely. All holdings display is now handled by the dedicated ding_holdings module. It also contains some handling of periodical reservation, which could be moved to ding_reservation.
