### PR TITLE
3703: Fix fatal php error when viewing /ekurser.

### DIFF
--- a/modules/ding_ekurser/ding_ekurser.module
+++ b/modules/ding_ekurser/ding_ekurser.module
@@ -97,6 +97,7 @@ function _ding_ekurser_get_subject_terms() {
     ->withCount(1)
     ->withSort('acquisitionDate_descending')
     ->withTermsPrFacet(20)
+    ->withFacets(array('facet.subject'))
     ->execute();
 
   // Extract subject facet terms.

--- a/modules/ding_ekurser/ding_ekurser.module
+++ b/modules/ding_ekurser/ding_ekurser.module
@@ -99,15 +99,8 @@ function _ding_ekurser_get_subject_terms() {
     ->withTermsPrFacet(20)
     ->execute();
 
-  // Extract subject facets.
-  $facets = $search_result->getFacets();
-  $subject_facets = array_filter($facets, function (TingSearchFacet $facet) {
-    return $facet->getName() == 'facet.subject';
-  });
-  $subject_term_groups = array_map(function (TingSearchFacet $facet) {
-    return $facet->getTerms();
-  }, $subject_facets);
-  $subject_terms = array_merge(...$subject_term_groups);
+  // Extract subject facet terms.
+  $subject_terms = $search_result->getFacets()['facet.subject']->getTerms();
 
   // Remove terms that covers more than 80% of the resultset.
   $frequent_subject_terms = array_filter(


### PR DESCRIPTION
And also ensure the search query is using facet.subject.

https://platform.dandigbib.org/issues/3703

Regarding simplification of facet.subject terms extraction. As mentioned in commit message:

As documented in \Ting\Search\TingSearchResultInterface, the getFacets() method returns a list of facets keyed by facet name. Hence there can only be one entry for the facet with name facet.subject and there's no need to do any filtering. 
This simplification also fixes the fatal PHP error, since it remove the need to use the splat-operator (which where failing before because of associative array)