### PR TITLE
3729: Remove check_plain around event name

### DIFF
--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -703,7 +703,7 @@ function ding_place2book_build_xml($node, $service_settings) {
   $xml->provider->email = $service_settings['provider_mail'];
 
   // Set event name with title.
-  $xml->event->name = check_plain($node->title);
+  $xml->event->name = $node->title;
 
   // Set short description.
   $field_ding_event_lead = field_get_items('node', $node, 'field_ding_event_lead');


### PR DESCRIPTION
To maintain compatibility, and avoiding place2book showing events with ambersands and/or quotes, as `Some Concert with &quot;Peter Petersen &amp; Lars Larsen&quot;`, we need to not sanitize the field like this..

See this proof of concept:

## Old behaviour
```php
$xml = simplexml_load_string('<?xml version="1.0" encoding="UTF-8"?>
  <data>
  <el></el>
  </data>
');

// See implementation of check_plain in Drupal https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/check_plain/7.x

$xml->el = htmlspecialchars("Text & Test", ENT_QUOTES, 'UTF-8');
echo $xml->asXML();

```
*Outputs:*
```xml
<?xml version="1.0" encoding="UTF-8"?>
<data>
  <el>Text &amp;amp; Test</el>
</data>
```

## New behaviour
```php
$xml = simplexml_load_string('<?xml version="1.0" encoding="UTF-8"?>
  <data>
  <el></el>
  </data>
');

$xml->el = "Text & Test";
echo $xml->asXML();
```
*Outputs:*
```xml
<?xml version="1.0" encoding="UTF-8"?>
<data>
  <el>Text &amp; Test</el>
</data>
```

This is a proactive help, from Place2Book developers.
If any doubt, let me know here or at fst (at) place2book.com

Frederik

**Notes to GitCop Check**

I have created a profile, at Redmine awaiting approval, so that I can create an issue and get an ID to correct errors. I will amend commit afterwards, if this is an issue for GitCop, and DDB/Ding 🙂 