### PR TITLE
3727: Make webtrekk SAL compatible

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -60,11 +60,11 @@ function ding_webtrekk_page_alter(&$page) {
   // search_data() function from core search module. Since this is not tied to
   // any path, we also check current_path().
   if (strpos(current_path(), 'search/ting') === 0) {
-    if ($search_result = drupal_static('ting_search_results', FALSE)) {
+    if ($search_result = ting_search_current_results()) {
       $params = [
         'pageTitle' => 'Search ting',
-        'OSS' => $search_result->search_key,
-        'OSSr' => $search_result->numTotalObjects,
+        'OSS' => $search_result->getSearchRequest()->getFullTextQuery(),
+        'OSSr' => $search_result->getNumTotalObjects(),
       ];
       _ding_webtrekk_set_data_layer_values($params);
     }


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3727

Webtrekk was failing to track well search. Needs a little update after SAL.

After testing https://silkeborgbib.dk/search/node/test it looks like the node search is tracking properly.
