### PR TITLE
3742: BUGFIX: Cache local files by creating a copy into the covers cache.

### DIFF
--- a/modules/ting_covers/ting_covers.module
+++ b/modules/ting_covers/ting_covers.module
@@ -209,7 +209,7 @@ function _ting_covers_get_file($id, $uri) {
     case 'public':
     case 'private':
     case 'file':
-      if (file_unmanaged_mv($uri, $path)) {
+      if (file_unmanaged_copy($uri, $path)) {
         return $path;
       }
   }


### PR DESCRIPTION
Fixes an undefined function error if a local file path is encountered, and makes a copy for the cache instead of a move in order to not delete managed/unmanaged files that have other dependencies.