### PR TITLE
3745: Fix misspelling of $account

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -1114,7 +1114,7 @@ function ding_user_provider_id($account = NULL) {
   global $user;
 
   if ($account === NULL) {
-    $accout = $user;
+    $account = $user;
   }
 
   if (ding_provider_implements('user', 'get_provider_id')) {


### PR DESCRIPTION
Fixes an error where global variable $user is
not assigned to $account if no arguments where
provided.