### PR TITLE
3582: Expire inactive provider sessions on cron run

### DIFF
--- a/modules/ding_user/ding_user.admin.inc
+++ b/modules/ding_user/ding_user.admin.inc
@@ -1,0 +1,43 @@
+<?php
+/**
+ * @file
+ * Ding user settings.
+ */
+
+/**
+ * Ding user admin.
+ */
+function ding_user_admin_setting_form($form, &$form_state) {
+  $limits = drupal_map_assoc(array(
+    0,
+    900,
+    1800,
+    3600,
+    7200,
+    18000,
+    43200,
+    86400,
+  ), 'format_interval');
+
+  $limits[0] = t('Disable');
+
+  $form['ding_user_provider_session_expire'] = array(
+    '#type' => 'select',
+    '#title' => t('Expire provider sessions'),
+    '#description' => t('Select the maximum age for provider sesssions with no activity. Sessions will be pruned on cron runs and cron must therefore be configured accordingly. Alternatively, the lightweight cron option this module provides can be used, if sessions needs to be pruned more often than is practical with core cron.'),
+    '#options' => $limits,
+    // ding_base features sets the auto-logout for providers to 900 seconds, so we use a default value corresponding to that.
+    '#default_value' => variable_get('ding_user_provider_session_expire', 900),
+  );
+
+  $form['ding_user_session_expire_cron'] = array(
+    '#markup' => '<p>' . t('This module provides a lightweight cron endpoint, which only expires provider sessions. Use to following endpoint to run it: %path', array(
+      '%path' => '/ding_user/expire_sessions/cron/' . variable_get('cron_key'),
+    )) . '</p>',
+  );
+
+  return system_settings_form($form);
+}
+
+
+

--- a/modules/ding_user/ding_user.admin.inc
+++ b/modules/ding_user/ding_user.admin.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Ding user settings.
@@ -38,6 +39,3 @@ function ding_user_admin_setting_form($form, &$form_state) {
 
   return system_settings_form($form);
 }
-
-
-

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -78,6 +78,24 @@ function ding_user_ctools_plugin_api($module, $api) {
 }
 
 /**
+ * Implements hook_menu().
+ */
+function ding_user_menu() {
+  $items = array();
+
+  $items['ding_user/expire_sessions/cron'] = array(
+    'title' => 'Lightweight expire session cron',
+    'description' => 'Run the lightweight expire inacitve provider sessions cron job',
+    'page callback' => '_ding_user_expire_sessions_cron',
+    'access callback' => '_ding_user_expire_sessions_cron_access',
+    'access arguments' => array(3),
+    'type' => MENU_CALLBACK,
+  );
+
+  return $items;
+}
+
+/**
  * Implements hook_permission().
  */
 function ding_user_permission() {
@@ -1187,6 +1205,28 @@ function ding_user_ding_user_block_reasons() {
  * Implements hook_cron()
  */
 function ding_user_cron() {
+  _ding_user_expire_sessions();
+}
+
+/**
+ *	Access callback for expires sessions cron endpoint.
+ */
+function _ding_user_expire_sessions_cron_access($cron_key) {
+  return variable_get('cron_key') === $cron_key;
+}
+
+/**
+ * Page callback for expires sessions lightweight cron endpoint.
+ */
+function _ding_user_expire_sessions_cron() {
+  _ding_user_expire_sessions();
+  drupal_exit();
+}
+
+/**
+ * Deletes inactive provider sessions in the database.
+ */
+function _ding_user_expire_sessions() {
   if (!$limit = variable_get('ding_user_provider_session_expire', 900)) {
     // Return now if the session expire functionality is disabled.
     return;
@@ -1215,3 +1255,5 @@ function ding_user_cron() {
     ));
   }
 }
+
+

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -86,8 +86,8 @@ function ding_user_menu() {
   $items['ding_user/expire_sessions/cron'] = array(
     'title' => 'Lightweight expire session cron',
     'description' => 'Run the lightweight expire inacitve provider sessions cron job',
-    'page callback' => '_ding_user_expire_sessions_cron',
-    'access callback' => '_ding_user_expire_sessions_cron_access',
+    'page callback' => 'ding_user_expire_sessions_cron',
+    'access callback' => 'ding_user_expire_sessions_cron_access',
     'access arguments' => array(3),
     'type' => MENU_CALLBACK,
   );
@@ -1202,31 +1202,31 @@ function ding_user_ding_user_block_reasons() {
 }
 
 /**
- * Implements hook_cron()
+ * Implements hook_cron().
  */
 function ding_user_cron() {
-  _ding_user_expire_sessions();
+  ding_user_expire_sessions();
 }
 
 /**
- *	Access callback for expires sessions cron endpoint.
+ * Access callback for expires sessions cron endpoint.
  */
-function _ding_user_expire_sessions_cron_access($cron_key) {
+function ding_user_expire_sessions_cron_access($cron_key) {
   return variable_get('cron_key') === $cron_key;
 }
 
 /**
  * Page callback for expires sessions lightweight cron endpoint.
  */
-function _ding_user_expire_sessions_cron() {
-  _ding_user_expire_sessions();
+function ding_user_expire_sessions_cron() {
+  ding_user_expire_sessions();
   drupal_exit();
 }
 
 /**
  * Deletes inactive provider sessions in the database.
  */
-function _ding_user_expire_sessions() {
+function ding_user_expire_sessions() {
   if (!$limit = variable_get('ding_user_provider_session_expire', 900)) {
     // Return now if the session expire functionality is disabled.
     return;
@@ -1255,5 +1255,3 @@ function _ding_user_expire_sessions() {
     ));
   }
 }
-
-

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -83,6 +83,15 @@ function ding_user_ctools_plugin_api($module, $api) {
 function ding_user_menu() {
   $items = array();
 
+  $items['admin/config/ding/user'] = array(
+    'title' => 'Ding user settings',
+    'description' => 'Administer ding_user settings.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ding_user_admin_setting_form'),
+    'access arguments' => array('administer user settings'),
+    'file' => 'ding_user.admin.inc',
+  );
+
   $items['ding_user/expire_sessions/cron'] = array(
     'title' => 'Lightweight expire session cron',
     'description' => 'Run the lightweight expire inacitve provider sessions cron job',

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -1182,3 +1182,36 @@ function ding_user_ding_user_block_reasons() {
     'ding_user_blocked_excluded' => t('You have been excluded. Please contact your library for more information.'),
   );
 }
+
+/**
+ * Implements hook_cron()
+ */
+function ding_user_cron() {
+  if (!$limit = variable_get('ding_user_provider_session_expire', 900)) {
+    // Return now if the session expire functionality is disabled.
+    return;
+  }
+
+  // Delete sessions with no activity since $limit seconds.
+  $timestamp = REQUEST_TIME - $limit;
+
+  // Construct subquere with uids for provider users.
+  $roles = user_roles(TRUE);
+  $rid = array_search('provider', $roles);
+  $subquery = db_select('users_roles', 'ur')
+    ->fields('ur', array('uid'))
+    ->condition('rid', $rid);
+
+  $query = db_delete('sessions')
+    ->condition('timestamp', $timestamp, '<')
+    ->condition('uid', $subquery, 'IN');
+
+  $num_updated = $query->execute();
+
+  // Log a notice if we succesfully deleted any inacitve provider sessions.
+  if ($num_updated) {
+    watchdog('ding_user', 'Deleted %num_updated inactive provider sessions', array(
+      '%num_updated' => $num_updated,
+    ));
+  }
+}

--- a/modules/ding_user_form/includes/ding_user_form.admin.inc
+++ b/modules/ding_user_form/includes/ding_user_form.admin.inc
@@ -21,13 +21,17 @@ function ding_user_form_admin_setting_form($form, &$form_state) {
   $form['ding_user_provider_session_expire'] = array(
     '#type' => 'select',
     '#title' => t('Expire provider sessions'),
-    '#description' => t('Select the maximum age for provider sesssions with no activity. Sessions will be pruned on cron runs and cron must therefore be configured accordingly.'),
+    '#description' => t('Select the maximum age for provider sesssions with no activity. Sessions will be pruned on cron runs and cron must therefore be configured accordingly. Alternatively, the lightweight cron option this module provides can be used, if sessions needs to be pruned more often than is practical with core cron.'),
     '#options' => $limits,
     // ding_base features sets the auto-logout for providers to 900 seconds, so we use a default value corresponding to that.
     '#default_value' => variable_get('ding_user_provider_session_expire', 900),
   );
 
-
+  $form['ding_user_session_expire_cron'] = array(
+    '#markup' => '<p>' . t('This module provides a lightweight cron endpoint, which only expires provider sessions. Use to following endpoint to run it: %path', array(
+      '%path' => '/ding_user/expire_sessions/cron/' . variable_get('cron_key'),
+    )) . '</p>',
+  );
 
   return system_settings_form($form);
 }

--- a/modules/ding_user_form/includes/ding_user_form.admin.inc
+++ b/modules/ding_user_form/includes/ding_user_form.admin.inc
@@ -15,7 +15,17 @@ function ding_user_form_admin_setting_form($form, &$form_state) {
     '#description' => t('The link is used in the text next to the log-in form'),
   );
 
-  $limits = drupal_map_assoc(array(0, 900, 1800, 3600, 7200, 18000, 43200, 86400), 'format_interval');
+  $limits = drupal_map_assoc(array(
+    0,
+    900,
+    1800,
+    3600,
+    7200,
+    18000,
+    43200,
+    86400,
+  ), 'format_interval');
+
   $limits[0] = t('Disable');
 
   $form['ding_user_provider_session_expire'] = array(

--- a/modules/ding_user_form/includes/ding_user_form.admin.inc
+++ b/modules/ding_user_form/includes/ding_user_form.admin.inc
@@ -15,6 +15,20 @@ function ding_user_form_admin_setting_form($form, &$form_state) {
     '#description' => t('The link is used in the text next to the log-in form'),
   );
 
+  $limits = drupal_map_assoc(array(0, 900, 1800, 3600, 7200, 18000, 43200, 86400), 'format_interval');
+  $limits[0] = t('Disable');
+
+  $form['ding_user_provider_session_expire'] = array(
+    '#type' => 'select',
+    '#title' => t('Expire provider sessions'),
+    '#description' => t('Select the maximum age for provider sesssions with no activity. Sessions will be pruned on cron runs and cron must therefore be configured accordingly.'),
+    '#options' => $limits,
+    // ding_base features sets the auto-logout for providers to 900 seconds, so we use a default value corresponding to that.
+    '#default_value' => variable_get('ding_user_provider_session_expire', 900),
+  );
+
+
+
   return system_settings_form($form);
 }
 

--- a/modules/ding_user_form/includes/ding_user_form.admin.inc
+++ b/modules/ding_user_form/includes/ding_user_form.admin.inc
@@ -15,34 +15,6 @@ function ding_user_form_admin_setting_form($form, &$form_state) {
     '#description' => t('The link is used in the text next to the log-in form'),
   );
 
-  $limits = drupal_map_assoc(array(
-    0,
-    900,
-    1800,
-    3600,
-    7200,
-    18000,
-    43200,
-    86400,
-  ), 'format_interval');
-
-  $limits[0] = t('Disable');
-
-  $form['ding_user_provider_session_expire'] = array(
-    '#type' => 'select',
-    '#title' => t('Expire provider sessions'),
-    '#description' => t('Select the maximum age for provider sesssions with no activity. Sessions will be pruned on cron runs and cron must therefore be configured accordingly. Alternatively, the lightweight cron option this module provides can be used, if sessions needs to be pruned more often than is practical with core cron.'),
-    '#options' => $limits,
-    // ding_base features sets the auto-logout for providers to 900 seconds, so we use a default value corresponding to that.
-    '#default_value' => variable_get('ding_user_provider_session_expire', 900),
-  );
-
-  $form['ding_user_session_expire_cron'] = array(
-    '#markup' => '<p>' . t('This module provides a lightweight cron endpoint, which only expires provider sessions. Use to following endpoint to run it: %path', array(
-      '%path' => '/ding_user/expire_sessions/cron/' . variable_get('cron_key'),
-    )) . '</p>',
-  );
-
   return system_settings_form($form);
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3583

#### Description

Ensure that rows in the session table for providers users is removed if they are older than the value set in `ding_user_provider_session_expire` variable.

These rows contains sensitive information about library users so it's important that the session is cleaned up periodically. Especially now where the autologout module has been removed the probability for stagnant rows session has increased.

##### IMPORTANT
The module will clear session on cron runs as default. If a more frequent cleaning is needed, a lightweight cron endpoint is provided which only clears sessions. It might not be appropriate to use the normal cron for this if it's too frequent since it performs a lot of other operations.  

An alternative approach would be to implement a drush-command and have a cron job call that instead.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

`ding_user_provider_session_expire`  is set to 15 min as default, since this was the old autologout value for provider users. Maybe a different value is more appropiate now? 