### PR TITLE
3829 by Inlead: Make Event Target vocabulary mandatory.

### DIFF
--- a/modules/ding_event/ding_event.features.field_instance.inc
+++ b/modules/ding_event/ding_event.features.field_instance.inc
@@ -972,7 +972,7 @@ function ding_event_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_ding_event_target',
     'label' => 'Target',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'user_register_form' => FALSE,
     ),


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3829