### PR TITLE
3841: Disable customerror redirect

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -632,33 +632,5 @@ function ding2_update_7051() {
  */
 function ding2_update_7052() {
   module_enable(array('customerror', 'customerroralt'));
-
-  if (module_exists('customerror')) {
-    // Set the 403 page.
-    $content_403 = array(
-      'value' => '<h3>Adgang nægtet</h3><p>Du har ikke adgang til at tilgå siden.</p>',
-      'format' => 'ding_wysiwyg',
-    );
-    variable_set('customerror_403_title', 'Adgang nægtet');
-    variable_set('customerror_403', $content_403);
-    variable_set('site_403', 'customerror/403');
-
-    // Set the 403 for authenticated users.
-    $content_403_authenticated = array(
-      'value' => '<h3>' . t('access denied: insufficient permissions') . '</h3><p>' . t('access denied: insufficient permissions') . '</p>',
-      'format' => 'plain_text',
-    );
-    variable_set('customerror_403_authenticated_title',
-      t('access denied: insufficient permissions'));
-    variable_set('customerror_403_authenticated', $content_403_authenticated);
-
-    // Set the 404 page.
-    $content_404 = array(
-      'value' => '<h3 class="field-teaser">UPS! Vi kan ikke finde den side du søger.</h3><p><strong>Hvad gik galt?</strong><br />Der kan være flere årsager til, at vi ikke kan finde det du leder efter:</p><p>- Stavefejl: Måske har du stavet forkert, da du skrev søgeordet. Eller der er en stavefejl i det link, du har fulgt.</p><p>- Siden er flyttet/slettet: Måske findes siden ikke længere eller den er blevet flyttet.</p><p><br /><strong>Bibliotek.dk</strong><br />Prøv den landsdækkende base <a href="http://bibliotek.dk/" target="_blank" title="Bibliotek.dk">bibliotek.dk</a>. Bibliotek.dk er en gratis service, hvor du kan se, hvad der er blevet udgivet i Danmark, og hvad der findes på danske biblioteker. Databasen opdateres dagligt.<br />Du kan bestille materialer til afhentning på dit lokale bibliotek. Du skal være registreret bruger på biblioteket.</p><p><br /><strong>Kom videre - kontakt dit bibliotek</strong><br />Find kontakt oplysninger på <a href="/biblioteker">\'den ønskede afdeling\'</a>.</p>',
-      'format' => 'ding_wysiwyg',
-    );
-    variable_set('customerror_404_title', 'Siden blev ikke fundet');
-    variable_set('customerror_404', $content_404);
-    variable_set('site_404', 'customerror/404');
-  }
+  ding2_set_customerror_pages();
 }

--- a/ding2.make
+++ b/ding2.make
@@ -49,6 +49,7 @@ projects[ctools][patch][] = "https://www.drupal.org/files/issues/ctools-uniform-
 projects[customerror][subdir] = "contrib"
 projects[customerror][version] = "1.4"
 projects[customerror][patch][] = "https://www.drupal.org/files/issues/customerror-2836107-switch_between_text_formats.patch"
+projects[customerror][patch][] = "patches/customerror-disable_auto_redirect.ding2.patch"
 
 projects[date][subdir] = "contrib"
 projects[date][version] = "2.8"

--- a/ding2.profile
+++ b/ding2.profile
@@ -717,42 +717,6 @@ function ding2_add_administrators_role($uid) {
 }
 
 /**
- * Adds a new static page to the site and set it as the default 404 page.
- */
-function ding2_set_page_not_found() {
-  $node = new stdClass();
-  $node->uid = 1;
-
-  $node->title = 'Siden blev ikke fundet';
-  $node->type = 'ding_page';
-  $node->language = 'und';
-  $node->field_ding_page_body = array(
-    'und' => array(
-      array(
-        'value' => '<div class="field-teaser">UPS! Vi kan ikke finde den side du søger.</div><p><strong>Hvad gik galt?</strong><br />Der kan være flere årsager til, at vi ikke kan finde det du leder efter:</p><p>- Stavefejl: Måske har du stavet forkert, da du skrev søgeordet. Eller der er en stavefejl i det link, du har fulgt.</p><p>- Siden er flyttet/slettet: Måske findes siden ikke længere eller den er blevet&nbsp;flyttet.</p><p><br /><strong>Bibliotek.dk</strong><br />Prøv den landsdækkende base <a href="http://bibliotek.dk/" target="_blank" title="Bibliotek.dk">bibliotek.dk</a>. Bibliotek.dk er en gratis service, hvor du kan se, hvad der er blevet udgivet i Danmark, og hvad der findes på danske biblioteker. Databasen opdateres dagligt.<br />Du kan bestille materialer til afhentning på dit lokale bibliotek. Du skal være registreret bruger på Odense Centralbibliotek.</p><p><br /><strong>Kom videre -&nbsp;kontakt&nbsp;dit bibliotek</strong><br />Vælg <a href="http://oc.fynbib.dk/biblioteker">&#39;Biblioteker&#39;</a> i menuen ovenfor og find kontakt oplysninger på den ønskede afdeling.</p>',
-        'format' => 'ding_wysiwyg',
-        'safe_value' => '<div class="field-teaser">UPS! Vi kan ikke finde den side du søger.</div><p><strong>Hvad gik galt?</strong><br />Der kan være flere årsager til, at vi ikke kan finde det du leder efter:</p><p>- Stavefejl: Måske har du stavet forkert, da du skrev søgeordet. Eller der er en stavefejl i det link, du har fulgt.</p><p>- Siden er flyttet/slettet: Måske findes siden ikke længere eller den er blevet flyttet.</p><p><br /><strong>Bibliotek.dk</strong><br />Prøv den landsdækkende base <a href="http://bibliotek.dk/" target="_blank" title="Bibliotek.dk">bibliotek.dk</a>. Bibliotek.dk er en gratis service, hvor du kan se, hvad der er blevet udgivet i Danmark, og hvad der findes på danske biblioteker. Databasen opdateres dagligt.<br />Du kan bestille materialer til afhentning på dit lokale bibliotek. Du skal være registreret bruger på Odense Centralbibliotek.</p><p><br /><strong>Kom videre - kontakt dit bibliotek</strong><br />Vælg <a href="http://oc.fynbib.dk/biblioteker">\'Biblioteker\'</a> i menuen ovenfor og find kontakt oplysninger på den ønskede afdeling.</p>',
-      ),
-    ),
-  );
-  $node->field_ding_page_lead = array(
-    'und' => array(
-      array(
-        'value' => '- men denne side kan måske hjælpe dig videre',
-        'format' => NULL,
-        'safe_value' => '- men denne side kan måske hjælpe dig videre',
-      ),
-    ),
-  );
-  $node->path = array(
-    'alias' => 'siden-ikke-fundet',
-    'language' => 'und',
-  );
-
-  node_save($node);
-}
-
-/**
  * Add page with std. cookie information.
  */
 function ding2_set_cookie_page() {

--- a/ding2.profile
+++ b/ding2.profile
@@ -184,6 +184,9 @@ function ding2_import_ding2_translations(&$install_state) {
  * Reverts features and adds some basic pages.
  */
 function ding2_add_settings(&$install_state) {
+  // Add customerror pages.
+  ding2_set_customerror_pages();
+
   // Set cookie page.
   ding2_set_cookie_page();
 
@@ -823,4 +826,36 @@ function ding2_set_cookie_page() {
   // Permissions, see: ding_permissions module
   // display EU Cookie Compliance popup: anonymous user, authenticated user
   // administer EU Cookie Compliance popup: administrators, local administrator
+}
+
+/**
+ * Setup customerror pages for 403 and 404 status codes.
+ */
+function ding2_set_customerror_pages() {
+  // Set the 403 page.
+  $content_403 = array(
+    'value' => '<h3>Adgang nægtet</h3><p>Du har ikke adgang til at tilgå siden.</p>',
+    'format' => 'ding_wysiwyg',
+  );
+  variable_set('customerror_403_title', 'Adgang nægtet');
+  variable_set('customerror_403', $content_403);
+  variable_set('site_403', 'customerror/403');
+
+  // Set the 403 for authenticated users.
+  $content_403_authenticated = array(
+    'value' => '<h3>' . t('access denied: insufficient permissions') . '</h3><p>' . t('access denied: insufficient permissions') . '</p>',
+    'format' => 'plain_text',
+  );
+  variable_set('customerror_403_authenticated_title',
+    t('access denied: insufficient permissions'));
+  variable_set('customerror_403_authenticated', $content_403_authenticated);
+
+  // Set the 404 page.
+  $content_404 = array(
+    'value' => '<h3 class="field-teaser">UPS! Vi kan ikke finde den side du søger.</h3><p><strong>Hvad gik galt?</strong><br />Der kan være flere årsager til, at vi ikke kan finde det du leder efter:</p><p>- Stavefejl: Måske har du stavet forkert, da du skrev søgeordet. Eller der er en stavefejl i det link, du har fulgt.</p><p>- Siden er flyttet/slettet: Måske findes siden ikke længere eller den er blevet flyttet.</p><p><br /><strong>Bibliotek.dk</strong><br />Prøv den landsdækkende base <a href="http://bibliotek.dk/" target="_blank" title="Bibliotek.dk">bibliotek.dk</a>. Bibliotek.dk er en gratis service, hvor du kan se, hvad der er blevet udgivet i Danmark, og hvad der findes på danske biblioteker. Databasen opdateres dagligt.<br />Du kan bestille materialer til afhentning på dit lokale bibliotek. Du skal være registreret bruger på biblioteket.</p><p><br /><strong>Kom videre - kontakt dit bibliotek</strong><br />Find kontakt oplysninger på <a href="/biblioteker">\'den ønskede afdeling\'</a>.</p>',
+    'format' => 'ding_wysiwyg',
+  );
+  variable_set('customerror_404_title', 'Siden blev ikke fundet');
+  variable_set('customerror_404', $content_404);
+  variable_set('site_404', 'customerror/404');
 }

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -29,6 +29,44 @@ function ding_base_menu() {
 }
 
 /**
+ * Implements hook_menu_alter().
+ */
+function ding_base_menu_alter(&$items) {
+  $items['customerror/%']['page callback'] = 'ding_base_customerror_page';
+}
+
+/**
+ * Page callback for our customerror page wrapper.
+ *
+ * We use the customerror module to show special pages for 403 og 404. If an
+ * anonymous user tries to visit any page without permission, the module will
+ * try to redirect to this page, if the user logs in later. In our setup, this
+ * has some unfortunate effects:
+ *
+ * 1. Since we use AJAX in our log in process, the redirect is never triggered
+ * when the user logs in, but rather on a subsequent form submission. This can
+ * be very confusing, if the user is redirected to a seemingly unrelated after,
+ * for example, renewing a loan.
+ * 2. The session variable will cause a session cookie to be saved in the user's
+ * browser and following requests will circumvent our Varnish cache.
+ * 3. When this error manifests it will, appearently, often be because of an
+ * AJAX-request that recieved 403, adding to the user's confusing (the page
+ * is completely unrelated).
+ *
+ * We therefore use this wrapper around customerror's page callback, to ensure
+ * this functionality is disabled.
+ */
+function ding_base_customerror_page($code) {
+  // Let customerror module do it's thing.
+  $output = customerror_page($code);
+
+  // Ensure the problematic session variable is removed.
+  unset($_SESSION['customerror_destination']);
+
+  return $output;
+}
+
+/**
  * Implements hook_theme().
  */
 function ding_base_theme() {

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -29,44 +29,6 @@ function ding_base_menu() {
 }
 
 /**
- * Implements hook_menu_alter().
- */
-function ding_base_menu_alter(&$items) {
-  $items['customerror/%']['page callback'] = 'ding_base_customerror_page';
-}
-
-/**
- * Page callback for our customerror page wrapper.
- *
- * We use the customerror module to show special pages for 403 og 404. If an
- * anonymous user tries to visit any page without permission, the module will
- * try to redirect to this page, if the user logs in later. In our setup, this
- * has some unfortunate effects:
- *
- * 1. Since we use AJAX in our log in process, the redirect is never triggered
- * when the user logs in, but rather on a subsequent form submission. This can
- * be very confusing, if the user is redirected to a seemingly unrelated after,
- * for example, renewing a loan.
- * 2. The session variable will cause a session cookie to be saved in the user's
- * browser and following requests will circumvent our Varnish cache.
- * 3. When this error manifests it will, appearently, often be because of an
- * AJAX-request that recieved 403, adding to the user's confusing (the page
- * is completely unrelated).
- *
- * We therefore use this wrapper around customerror's page callback, to ensure
- * this functionality is disabled.
- */
-function ding_base_customerror_page($code) {
-  // Let customerror module do it's thing.
-  $output = customerror_page($code);
-
-  // Ensure the problematic session variable is removed.
-  unset($_SESSION['customerror_destination']);
-
-  return $output;
-}
-
-/**
  * Implements hook_theme().
  */
 function ding_base_theme() {

--- a/patches/customerror-disable_auto_redirect.ding2.patch
+++ b/patches/customerror-disable_auto_redirect.ding2.patch
@@ -1,0 +1,42 @@
+diff --git a/customerror.module b/customerror.module
+index e515a0a..df496e0 100644
+--- a/customerror.module
++++ b/customerror.module
+@@ -210,10 +210,6 @@ function customerror_page($code) {
+       else {
+         $_GET['destination'] = variable_get('site_frontpage', 'node');
+       }
+-      // If the user is not logged in, save destination to redirect if they do.
+-      if (!$GLOBALS['user']->uid) {
+-        $_SESSION['customerror_destination'] = $_GET['destination'];
+-      }
+     case 404:
+     default:
+       // Treat an unknown method as a 404.
+@@ -287,26 +283,6 @@ function theme_customerror(array $variables) {
+   return $content;
+ }
+ 
+-/**
+- * Implements hook_drupal_goto_alter().
+- */
+-function customerror_drupal_goto_alter(&$path, &$options, &$http_response_code) {
+-  if (!user_is_logged_in() || !isset($_SESSION['customerror_destination'])) {
+-    return;
+-  }
+-  $dest = drupal_parse_url($_SESSION['customerror_destination']);
+-  // If the password reset token is set: user needs a chance to change password.
+-  if (isset($options['query']['pass-reset-token'])) {
+-    $options['query']['destination'] = $dest['path'];
+-  }
+-  else {
+-    $path = $dest['path'];
+-    unset($dest['path']);
+-    $options += $dest;
+-  }
+-  unset($_SESSION['customerror_destination']);
+-}
+-
+ /**
+  * Check list of redirects.
+  */


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3841

#### Description

We use the customerror module to show special pages for 403 og 404. If an anonymous user tries to visit any page without permission, the module will try to redirect to this page, if the user logs in later. In our setup, this has some unfortunate effects:

1. Since we use AJAX in our log in process, the redirect is never triggered when the user logs in, but rather on a subsequent form submission. This can be very confusing, if the user is redirected to a seemingly unrelated page after, for example, renewing a loan.
2. The session variable will cause a session cookie to be saved in the user's browser and following requests will circumvent our Varnish cache.
3. When this error manifests it will, appearently, often be because of an AJAX-request that recieved 403, adding to the user's confusing (the page is completely unrelated).

In this PR i try to disable that behavior.

I also discovered that customerror, while being enabled correctly, wasn't setup properly on fresh installs. This made it problematic to debug this issue. I have also corrected this in this PR.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
