### PR TITLE
3473 update ckeditor

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -454,12 +454,8 @@ projects[workflow][patch][] = "http://www.drupal.org/files/issues/features_impor
 ; Prevent fatal errors on cron when using Scheduler, https://www.drupal.org/node/2499193.
 projects[workflow][patch][] = "https://www.drupal.org/files/issues/workflow-php_fatal_error_call-2499193-7-2.5.patch"
 
-; This revision support the CKEditor 4.x, and can be used until a new version is tagged.
-projects[wysiwyg][type] = "module"
 projects[wysiwyg][subdir] = "contrib"
-projects[wysiwyg][download][type] = "git"
-projects[wysiwyg][download][url] = "http://git.drupal.org/project/wysiwyg.git"
-projects[wysiwyg][download][revision] = "7981731f4f3db2f932419499d2ec13a073e9b88f"
+projects[wysiwyg][version] = "2.5"
 
 projects[ask_vopros][type] = "module"
 projects[ask_vopros][subdir] = "contrib"
@@ -477,7 +473,7 @@ libraries[bpi-client][download][url] = "http://github.com/ding2/bpi-client.git"
 libraries[bpi-client][download][branch] = "master"
 
 libraries[ckeditor][download][type] = "get"
-libraries[ckeditor][download][url] = http://download.cksource.com/CKEditor/CKEditor/CKEditor%204.4.7/ckeditor_4.4.7_full.zip
+libraries[ckeditor][download][url] = https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.9.2/ckeditor_4.9.2_standard.zip
 libraries[ckeditor][directory_name] = "ckeditor"
 libraries[ckeditor][destination] = "libraries"
 

--- a/modules/ding_content/ding_content.features.wysiwyg.inc
+++ b/modules/ding_content/ding_content.features.wysiwyg.inc
@@ -10,15 +10,11 @@
 function ding_content_wysiwyg_default_profiles() {
   $profiles = array();
 
-  // Exported profile: ding_wysiwyg
+  // Exported profile: ding_wysiwyg.
   $profiles['ding_wysiwyg'] = array(
     'format' => 'ding_wysiwyg',
     'editor' => 'ckeditor',
     'settings' => array(
-      'default' => 1,
-      'user_choose' => 0,
-      'show_toggle' => 1,
-      'add_to_summaries' => 1,
       'theme' => 'advanced',
       'language' => 'da',
       'buttons' => array(
@@ -66,6 +62,14 @@ function ding_content_wysiwyg_default_profiles() {
       'advanced__active_tab' => 'edit-css',
       'forcePasteAsPlainText' => 0,
     ),
+    'preferences' => array(
+      'add_to_summaries' => TRUE,
+      'default' => 1,
+      'show_toggle' => 1,
+      'user_choose' => 0,
+      'version' => '4.9.2.95e5d83',
+    ),
+    'name' => 'formatding_wysiwyg',
   );
 
   return $profiles;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3473

#### Description

Security update of ckeditor library: https://www.drupal.org/sa-core-2018-003 

I had to update the wysiwyg module also. Refer to this editor support matrix: https://www.drupal.org/docs/7/modules/wysiwyg/supported-editors-matrix 

I also did re-export of our Wysiwyg profile config after running the updates from the updated wysiwyg-module.

The version we used before was from may 2015 (ref: 7981731f4f3db2f932419499d2ec13a073e9b88f), There's a lot of changes from 2.2 to 2.5. Looks like editor preferences is separated from profile settings and editor version is now exported in features.

The available options appear to be largely the same, apart from a view additions to the paste plugin (I have informed about this in the case) and that now you can set editor language (which ofc just will be the site's default danish)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
