### PR TITLE
3875: Create database docker image as a part of build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
         command: |
           drush site-install ding2 \
           --db-url=mysql://root@127.0.0.1/circle_test -y --debug \
+          --site-name=Ding2 --account-name=admin --account-pass=admin \
           install_configure_form.update_status_module='array(FALSE,FALSE)' \
           ding2_module_selection_form.providers_selection=connie \
           opensearch_admin_settings.opensearch_url=https://opensearch.addi.dk/b3.5_5.0/ \
@@ -279,6 +280,38 @@ jobs:
           mv ding2-$CIRCLE_SHA1.tar.gz ding2-$CIRCLE_TAG.tar.gz
           ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${PRERELEASE} ${CIRCLE_TAG} ding2-$CIRCLE_TAG.tar.gz
 
+  docker_db_image:
+    docker:
+    - image: docker:stable-git
+    working_directory: ~/db
+    steps:
+    - checkout:
+        path: ~/project
+    - attach_workspace:
+        at: ~/
+    - setup_remote_docker
+    - run:
+        name: Build Docker database image
+        command: |
+          docker build -t mysql . -f-<<EOF
+          FROM mysql:5.7.23
+          COPY db.sql /docker-entrypoint-initdb.d/db.sql
+          EOF
+    - run:
+        name: Push image to Docker Hub
+        command: |
+          if [ -n "${DOCKER_USER}" ] && [ -n "${DOCKER_PASS}" ]
+          then
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
+            CIRCLE_TAG="$(cd ~/project && git tag -l --points-at HEAD)"
+            DOCKER_TAG=$([[ $CIRCLE_BRANCH == 'master' ]] && echo 'master' || echo 'latest')
+            DOCKER_TAG=$([[ -n $CIRCLE_TAG ]] && echo $CIRCLE_TAG || echo $DOCKER_TAG)
+            docker tag mysql $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-mysql:$DOCKER_TAG
+            docker push $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME-mysql:$DOCKER_TAG
+          else
+            echo "Not pushing Docker image to Docker Hub. Environment variables DOCKER_USER and/or DOCKER_PASS are not set."
+          fi
+
 workflows:
   version: 2
   build-test-package:
@@ -311,3 +344,12 @@ workflows:
             only: /^7\.x\-.+/
           branches:
             ignore: /.*/
+    - docker_db_image:
+        requires:
+          - site_install
+        filters:
+          branches:
+            only:
+              - master
+          tags:
+            only: /^7\.x\-.+/

--- a/README.md
+++ b/README.md
@@ -107,9 +107,34 @@ will not delete these.
 ```sh
   ~$ drush make --no-core --working-copy --contrib-destination=. ding2.make
 ```
-
-Next goto your sites URL and run the ding2 installation profile and fill out
+### Site installation 
+Go to the url for your site, run the ding2 installation profile and fill out
 all the questions.
+
+If you use [Docker](https://docs.docker.com/get-started/) you can also start a container with database server for an already installed site using the latest version of the Ding2 `master` branch:
+
+```sh
+   ~$ docker run -e MYSQL_USER=db -e MYSQL_PASSWORD=db -e MYSQL_DATABASE=db -e MYSQL_ROOT_PASSWORD=root -p 3306:3306 -d ding2/ding2-mysql:master
+``` 
+
+In this case you should insert the following in your `settings.php` file:
+
+```php
+$databases = array(
+  'default' => array(
+    'default' => array(
+      'driver' => 'mysql',
+      'database' => 'db',
+      'username' => 'db',
+      'password' => 'db',
+      'host' => 'db',
+      'prefix' => '',
+    ),
+  ),
+);
+```
+
+Username/password for logging into the site is `admin`/`admin`.
 
 ## Alternative installation method
 If you are using an deployment system you may not want to patch Drupal core


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3875

#### Description

This PR depends on #1205. Key commit is f640cfc.

This is orchestrated by CircleCI.

A database Docker images will allow developers to spin up a site without
going through the installation process which can be slow and tedious.

The image is based on MySQL 5.7.23 as that is the closest version to 
what we are using for the rest of our CI process.

The image gets the database dump from the workspace copied into a 
specific folder which the database image is configured to load SQL
files from on startup.

To provide a stable starting point we set a fixed username and password.

The Dockerfile is not included in the project as we are not providing a
Full Docker setup at this point in time. Instead we generate it during
the build.

Once the image is built it can be pushed to Docker Hub. However this 
only occurs if the CircleCI project is configured with the required 
username and password. This way we allow forks to utilize our workflow
if they want to but do not force them into anything to avoid breaking 
the build.

Tags are used to handle typical use cases:
1. If the codebase has a tag then the image is tagged accordingly.
2. The master branch is latest official development version of the code.
The corresponding database image is tagged master.
3. For all other situations latest is used.

Update documentation accordingly.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Note: For this to work the `DOCKER_USER` and `DOCKER_PASS` has to be set on CircleCI - preferably with a shared Ding2 Core Docker Hub user.