### PR TITLE
3269 by Inlead: Add ting carousel to list of IPE menu options.

### DIFF
--- a/modules/ding_ipe_filter/ding_ipe_filter.install
+++ b/modules/ding_ipe_filter/ding_ipe_filter.install
@@ -63,3 +63,14 @@ function ding_ipe_filter_update_7101(&$sandbox) {
     variable_set('ding_ipe_filter_panes_selected', $selected);
   }
 }
+
+/**
+ * Select ting carousel.
+ */
+function ding_ipe_filter_update_7102(&$sandbox) {
+  $selected = _ding_ipe_filter_selected_panes();
+  if (!isset($selected['ting:carousel'])) {
+    $selected['ting:carousel'] = 'ting:carousel';
+    variable_set('ding_ipe_filter_panes_selected', $selected);
+  }
+}

--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -233,6 +233,7 @@ function _ding_ipe_filter_selected_panes() {
     'event-panes:ding_event-ding_event_simple_list' => 'event-panes:ding_event-ding_event_simple_list',
     'groups-panes:ding_groups-ding_group_overview_simple' => 'groups-panes:ding_groups-ding_group_overview_simple',
     'news-panes:ding_news-ding_news_frontpage_list' => 'news-panes:ding_news-ding_news_frontpage_list',
+    'ting:carousel' => 'ting:carousel',
   );
 
   $selected = variable_get('ding_ipe_filter_panes_selected', $default);

--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -239,3 +239,11 @@ function _ding_ipe_filter_selected_panes() {
   $selected = variable_get('ding_ipe_filter_panes_selected', $default);
   return array_filter($selected);
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function ding_ipe_filter_preprocess_panels_ipe_pane_wrapper(&$variables) {
+  unset($variables['links']['style']);
+  unset($variables['links']['css']);
+}

--- a/modules/ding_ipe_filter/js/ding_ipe_filter.js
+++ b/modules/ding_ipe_filter/js/ding_ipe_filter.js
@@ -54,6 +54,9 @@
 
         return false;
       });
+
+      // Display ipe controllers only relative to container.
+      $('body').removeClass('panels-ipe-editing');
     }
   };
 })(jQuery);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3269

#### Description

Added ting carousel back into the IPE menu options, so localadmins can insert it on the frontpage when using IPE. 

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Furthermore did som small improvements to the display of the menu and its affects.