### PR TITLE
3320: P2 list covered by header

### DIFF
--- a/themes/ddbasic/sass/p2/p2-entity-buttons.scss
+++ b/themes/ddbasic/sass/p2/p2-entity-buttons.scss
@@ -33,9 +33,15 @@
     left: 0;
     height: 100%;
     width: 100%;
+    padding-top: 70px;
     opacity: 0;
     background-color: $black-overlay-dark;
     overflow-y: scroll;
+
+    .topbar-up & {
+      padding-top: 0;
+    }
+
     .wrapper {
       @include wrapper;
       position: relative;


### PR DESCRIPTION
#### Link to issue
https://platform.dandigbib.org/issues/3320

#### Description

This PR includes SCSS previously introduced in https://github.com/ding2/ding2/commit/2c94f4bdbfd151ee008fc5642d5c8ff932c8a640#diff-fc43d7933e2f5935cc2fec36d4251a9c but removed in PR https://github.com/ding2/ding2/commit/b478dea3d1a2d275d5fc51513b3d7c12e84678a9#diff-fc43d7933e2f5935cc2fec36d4251a9c

Cannot reproduce missing notification of adding already existing material to list

#### Screenshot of the result

![screen shot 2018-10-11 at 11 52 35](https://user-images.githubusercontent.com/30495061/46797059-69bdf500-cd4e-11e8-9dc0-89820d605d7b.png)
