### PR TITLE
3892: Use moreinfo externURL

### DIFF
--- a/modules/ting_covers/ting_covers.module
+++ b/modules/ting_covers/ting_covers.module
@@ -230,7 +230,7 @@ function _ting_covers_get_file($id, $uri) {
  *   URL for the source image file.
  *
  * @return mixed
- *   A file object or FALSE on error.
+ *   A string with the path of the image or FALSE on error.
  *
  * @see image_style_create_derivative()
  */
@@ -253,22 +253,19 @@ function ting_covers_fetch_image($filename, $image_url) {
 
   $file = file_unmanaged_save_data($result->data, $filename, FILE_EXISTS_REPLACE);
 
-  // Check that the file is an image. If not we'll remove again and return FALSE
-  // to avoid broken images in frontend.
-  if ($file) {
-    if (!exif_imagetype($file)) {
-      file_unmanaged_delete($file);
-      $file = FALSE;
-    }
-  }
-
-  // Sometimes we get images in print quality, which makes imagecache run out
-  // of memory in the attempt to resize it. So we check the image size and
-  // scale it down to a more manageable size using the Imagemagick shell
-  // command which gets around the memory limit.
   if ($file) {
     $realpath = drupal_realpath($filename);
-    $size = getimagesize($realpath);
+    // Check that the file is an image. If not we'll remove again and return
+    // FALSE to avoid broken images in frontend.
+    if (!$size = getimagesize($realpath)) {
+      file_unmanaged_delete($file);
+      return FALSE;
+    }
+
+    // Sometimes we get images in print quality, which makes imagecache run out
+    // of memory in the attempt to resize it. So we check the image size and
+    // scale it down to a more manageable size using the Imagemagick shell
+    // command which gets around the memory limit.
     if ($size[0] > TING_COVERS_MAX_SIZE || $size[1] > TING_COVERS_MAX_SIZE) {
       exec('convert ' . $realpath . ' -resize ' . TING_COVERS_MAX_SIZE . 'x ' .
            $realpath . '.tmp', $output, $rc);

--- a/modules/ting_covers/ting_covers.module
+++ b/modules/ting_covers/ting_covers.module
@@ -259,6 +259,7 @@ function ting_covers_fetch_image($filename, $image_url) {
     // FALSE to avoid broken images in frontend.
     if (!$size = getimagesize($realpath)) {
       file_unmanaged_delete($file);
+      watchdog('ting_covers', 'Discarded invalid cover file from %url', array('%url' => $image_url), WATCHDOG_ERROR);
       return FALSE;
     }
 

--- a/modules/ting_covers/ting_covers.module
+++ b/modules/ting_covers/ting_covers.module
@@ -252,6 +252,16 @@ function ting_covers_fetch_image($filename, $image_url) {
   }
 
   $file = file_unmanaged_save_data($result->data, $filename, FILE_EXISTS_REPLACE);
+
+  // Check that the file is an image. If not we'll remove again and return FALSE
+  // to avoid broken images in frontend.
+  if ($file) {
+    if (!exif_imagetype($file)) {
+      file_unmanaged_delete($file);
+      $file = FALSE;
+    }
+  }
+
   // Sometimes we get images in print quality, which makes imagecache run out
   // of memory in the attempt to resize it. So we check the image size and
   // scale it down to a more manageable size using the Imagemagick shell

--- a/modules/ting_covers_addi/lib/addi-client/AdditionalInformation.php
+++ b/modules/ting_covers_addi/lib/addi-client/AdditionalInformation.php
@@ -8,10 +8,12 @@ class AdditionalInformation {
 
   public $thumbnailUrl;
   public $detailUrl;
+  public $externUrl;
 
-  public function __construct($thumbnail_url, $detail_url) {
+  public function __construct($thumbnail_url, $detail_url, $extern_url) {
     $this->thumbnailUrl = $thumbnail_url;
     $this->detailUrl = $detail_url;
+    $this->externUrl = $extern_url;
   }
 
 }

--- a/modules/ting_covers_addi/lib/addi-client/AdditionalInformation.php
+++ b/modules/ting_covers_addi/lib/addi-client/AdditionalInformation.php
@@ -10,6 +10,9 @@ class AdditionalInformation {
   public $detailUrl;
   public $externUrl;
 
+  /**
+   * AdditionalInformation constructor.
+   */
   public function __construct($thumbnail_url, $detail_url, $extern_url) {
     $this->thumbnailUrl = $thumbnail_url;
     $this->detailUrl = $detail_url;

--- a/modules/ting_covers_addi/ting_covers_addi.admin.inc
+++ b/modules/ting_covers_addi/ting_covers_addi.admin.inc
@@ -59,5 +59,42 @@ function ting_covers_addi_admin_settings_form($form, &$form_state) {
     '#default_value' => variable_get('ting_covers_addi_enable_logging', FALSE),
   );
 
+  $form['addi']['external_url'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('External URL'),
+    '#description' => t('For some materials without cover, the service will return an URL to an external cover supplied by the owner of the record. Use these settings enable/disable this feature and, if enabled, which sources to use them on.'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  $form['addi']['external_url']['ting_covers_addi_external_url'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable external URL'),
+    '#default_value' => variable_get('ting_covers_addi_external_url', TRUE),
+  );
+
+  $sources = variable_get('ting_well_sources', array());
+  $form['addi']['external_url']['ting_covers_addi_external_url_sources'] = array(
+    '#type' => 'checkboxes',
+    '#title' => t('External URL sources'),
+    '#options' => drupal_map_assoc($sources),
+    '#default_value' => variable_get('ting_covers_addi_external_url_sources', _ting_covers_addi_default_external_url_sources()),
+  );
+
+  $form['addi']['external_url']['update'] = array(
+    '#type' => 'submit',
+    '#value' => t('Update sources'),
+    '#submit' => array('ting_covers_addi_source_update'),
+  );
+
   return system_settings_form($form);
+}
+
+/**
+ * Submit handler.
+ *
+ * Updates the list of known sources from the data well.
+ */
+function ting_covers_addi_source_update($form, &$form_state) {
+  _ting_fetch_well_sources();
 }

--- a/modules/ting_covers_addi/ting_covers_addi.module
+++ b/modules/ting_covers_addi/ting_covers_addi.module
@@ -62,6 +62,9 @@ function ting_covers_addi_ting_covers($entities) {
       elseif ($cover->thumbnailUrl) {
         $source_url = $cover->thumbnailUrl;
       }
+      elseif ($cover->externUrl) {
+        $source_url = $cover->externUrl;
+      }
 
       if ($source_url) {
         // Return the path to the cover.

--- a/modules/ting_covers_addi/ting_covers_addi.module
+++ b/modules/ting_covers_addi/ting_covers_addi.module
@@ -62,8 +62,14 @@ function ting_covers_addi_ting_covers($entities) {
       elseif ($cover->thumbnailUrl) {
         $source_url = $cover->thumbnailUrl;
       }
-      elseif ($cover->externUrl) {
-        $source_url = $cover->externUrl;
+
+      // If we still haven't found a cover check if we can use external URL.
+      if (!$source_url && variable_get('ting_covers_addi_external_url', TRUE)) {
+        $entity = $entities[$pid];
+        $sources = variable_get('ting_covers_addi_external_url_sources', _ting_covers_addi_default_external_url_sources());
+        if (in_array(drupal_strtolower($entity->getAc_source()), $sources)) {
+          $source_url = $cover->externUrl;
+        }
       }
 
       if ($source_url) {
@@ -81,4 +87,15 @@ function ting_covers_addi_ting_covers($entities) {
 
   // Return all image information.
   return $covers;
+}
+
+/**
+ * Default sources where external URL should be used.
+ */
+function _ting_covers_addi_default_external_url_sources() {
+  return array(
+    'ereolen global',
+    'comics plus',
+    'pressreader',
+  );
 }

--- a/modules/ting_covers_addi/ting_covers_addi.module
+++ b/modules/ting_covers_addi/ting_covers_addi.module
@@ -64,7 +64,7 @@ function ting_covers_addi_ting_covers($entities) {
       }
 
       // If we still haven't found a cover check if we can use external URL.
-      if (!$source_url && variable_get('ting_covers_addi_external_url', TRUE)) {
+      if (!$source_url && isset($cover->externUrl) && variable_get('ting_covers_addi_external_url', TRUE)) {
         $entity = $entities[$pid];
         $sources = variable_get('ting_covers_addi_external_url_sources', _ting_covers_addi_default_external_url_sources());
         if (in_array(drupal_strtolower($entity->getAc_source()), $sources)) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3892

#### Description

In some cases moreinfo supplies an external reference to a cover. In this PR I implement the usage of this and related settings.

There's a lot more info in the case.

#### Screenshot of the result

Ereolen global search without externURL:

![sogning-ereolen-global-uden-externurl](https://user-images.githubusercontent.com/5011234/46866514-fdacc100-ce21-11e8-8596-ca2e2575f3bd.PNG)

Ereolen global search with externURL:

![sogning-ereolen-global-med-externurl](https://user-images.githubusercontent.com/5011234/46866532-1026fa80-ce22-11e8-8101-c7ca4dc0a7be.PNG)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

