### PR TITLE
3861: Responsive image format on event teasers

### DIFF
--- a/themes/ddbasic/sass/components/node/event.scss
+++ b/themes/ddbasic/sass/components/node/event.scss
@@ -103,19 +103,27 @@
         padding-right: 0;
       }
     }
-    .event-list-image {
+    .event-list-image-container {
       position: absolute;
       z-index: 1;
+      top: 0;
+      left: 0;
       width: 100%;
-      height: 200px;
-      overflow: hidden;
-      background-size: cover;
-      background-position: center center;
+      padding-top: 56.25%; // 16:9 format
 
-      // Mobile
       @include media($mobile) {
         display: none;
       }
+    }
+    .event-list-image {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      background-size: cover;
+      background-position: center center;
     }
     .library {
       .field-item {
@@ -127,10 +135,14 @@
     }
     &.has-image {
       .inner {
-        padding: 0 $box-padding 10px $box-padding;
+        padding: 56.25% $box-padding 10px $box-padding; // 56.25% equals height of image
+
+        @include media($mobile) {
+          padding: 0 $box-padding 10px $box-padding;
+        }
       }
       .event-text {
-        padding-top: 215px;
+        padding-top: 15px;
 
         // Mobile
         @include media($mobile) {

--- a/themes/ddbasic/templates/node/node--ding-event--view-mode--teaser.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-event--view-mode--teaser.tpl.php
@@ -110,7 +110,7 @@
     </div>
     <?php
       if (!empty($event_background_image)):
-        print '<div class="event-list-image" style="background-image:url(' . $event_background_image . ');"' . $image_title . '></div>';
+        print '<div class="event-list-image-container"><div class="event-list-image" style="background-image:url(' . $event_background_image . ');"' . $image_title . '></div></div>';
       endif;
     ?>
   </a>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3861

#### Description

New method used for sizing image on event teasers. This ensures the image format is the same on all screen sizes.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/22191849/47006679-c34f6680-d136-11e8-9ca6-63142dce78a5.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments