### PR TITLE
3898 by Inlead: Fix misspellings.

### DIFF
--- a/modules/ding_adhl_frontend/templates/ding_adhl_frontend_recommendation_list_entry.tpl.php
+++ b/modules/ding_adhl_frontend/templates/ding_adhl_frontend_recommendation_list_entry.tpl.php
@@ -6,7 +6,7 @@
  *
  * Available variables:
  * - $creators: The creators of the recommendation as a comma separated list or
- *   FALSE if no creators where found.
+ *   FALSE if no creators were found.
  * - $link: Array with an uri and link title for the recommend Ting entity.
  * - $item: Ting entity with all information available about the recommended
  *   object.

--- a/modules/ding_campaign/ding_campaign.module
+++ b/modules/ding_campaign/ding_campaign.module
@@ -142,7 +142,7 @@ function ding_campaign_display($context, $count, $offset, $style = 'medium') {
   // Get node id's for the campaign nodes matching the context.
   $campaigns = ding_campaign_get_campaigns($context, $count, $offset);
 
-  // If any campaigns where found.
+  // If any campaigns were found.
   if (!empty($campaigns)) {
     // Set outer wrapper.
     $content = array(

--- a/modules/ding_event/ding_event.views_default.inc
+++ b/modules/ding_event/ding_event.views_default.inc
@@ -54,7 +54,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['empty']['area']['field'] = 'area';
   $handler->display->display_options['empty']['area']['label'] = 'Empty text';
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = 'No events where found.';
+  $handler->display->display_options['empty']['area']['content'] = 'No events were found.';
   $handler->display->display_options['empty']['area']['format'] = 'ding_wysiwyg';
   /* Relationship: OG membership: OG membership from Node */
   $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';
@@ -1186,7 +1186,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['empty']['area']['field'] = 'area';
   $handler->display->display_options['empty']['area']['label'] = 'Empty text';
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = 'No events where found in the group.';
+  $handler->display->display_options['empty']['area']['content'] = 'No events were found in the group.';
   $handler->display->display_options['empty']['area']['format'] = 'ding_wysiwyg';
   $handler->display->display_options['defaults']['relationships'] = FALSE;
   /* Relationship: OG membership group */
@@ -1696,7 +1696,7 @@ function ding_event_views_default_views() {
     t('Stigende'),
     t('Faldende'),
     t('Empty text'),
-    t('No events where found.'),
+    t('No events were found.'),
     t('OG membership from node'),
     t('<div class="event-list-date-wrapper">
   <span class="event-list-day">[field_ding_event_date]</span>
@@ -1754,7 +1754,7 @@ function ding_event_views_default_views() {
     t('« first'),
     t('next ›'),
     t('last »'),
-    t('No events where found in the group.'),
+    t('No events were found in the group.'),
     t('RSS library event list'),
     t('Simple event list'),
     t('RSS event list'),

--- a/modules/ding_gatewayf/ding_gatewayf.module
+++ b/modules/ding_gatewayf/ding_gatewayf.module
@@ -372,7 +372,7 @@ function _ding_gatewayf_provider_login(array $attributes) {
         'values' => $credentials,
       );
 
-      // Submit login form to trigger login, where the login process goes
+      // Submit login form to trigger login, were the login process goes
       // through the whole process in ding_user.
       drupal_form_submit('user_login_block', $form_state);
 
@@ -515,7 +515,7 @@ function _ding_gatewayf_get_required_attributes(array $attributes, array $requir
     }
   }
 
-  // Check that required attributes where found. If not reset the array to be
+  // Check that required attributes were found. If not reset the array to be
   // empty as some attributes may have been found.
   if (count($required_attributes) != count($attribute_list)) {
     watchdog('ding_gatewayf', t('Not all required attributes was returned from gatewayf'), array(), WATCHDOG_ERROR);

--- a/modules/ding_news/ding_news.views_default.inc
+++ b/modules/ding_news/ding_news.views_default.inc
@@ -52,7 +52,7 @@ function ding_news_views_default_views() {
   $handler->display->display_options['empty']['area']['field'] = 'area';
   $handler->display->display_options['empty']['area']['label'] = 'Empty text';
   $handler->display->display_options['empty']['area']['empty'] = TRUE;
-  $handler->display->display_options['empty']['area']['content'] = 'No news where found.';
+  $handler->display->display_options['empty']['area']['content'] = 'No news were found.';
   $handler->display->display_options['empty']['area']['format'] = 'ding_wysiwyg';
   /* Relationship: Content: Author */
   $handler->display->display_options['relationships']['uid']['id'] = 'uid';
@@ -2149,7 +2149,7 @@ function ding_news_views_default_views() {
     t('Library news'),
     t('See all news'),
     t('Empty text'),
-    t('No news where found.'),
+    t('No news were found.'),
     t('author'),
     t('<span class="news-label">[field_ding_news_category]</span> <span class="news-date">[created]</span>  |  <span class="news-author">by [name]</span>'),
     t('News list (frontpage)'),

--- a/modules/ding_provider/connie_search/src/ConnieSearchResult.php
+++ b/modules/ding_provider/connie_search/src/ConnieSearchResult.php
@@ -89,7 +89,7 @@ class ConnieSearchResult implements TingSearchResultInterface {
    * Facet matched in the result with term matches.
    *
    * @return \Ting\Search\TingSearchFacet[]
-   *   List of facets, empty if none where found.
+   *   List of facets, empty if none were found.
    */
   public function getFacets() {
     $terms = [

--- a/modules/ting/src/Search/TingSearchFacet.php
+++ b/modules/ting/src/Search/TingSearchFacet.php
@@ -70,7 +70,7 @@ class TingSearchFacet {
    * Sets one or more terms matches from the facet encountered during searching.
    *
    * @param \Ting\Search\TingSearchFacetTerm[] $terms
-   *   The list of terms, empty if none where found.
+   *   The list of terms, empty if none were found.
    */
   public function setTerms($terms) {
     $this->terms = [];

--- a/modules/ting/src/Search/TingSearchResultInterface.php
+++ b/modules/ting/src/Search/TingSearchResultInterface.php
@@ -64,7 +64,7 @@ interface TingSearchResultInterface {
    * The list is keyed by facet name.
    *
    * @return \Ting\Search\TingSearchFacet[]
-   *   List of facets, empty if none where found.
+   *   List of facets, empty if none were found.
    */
   public function getFacets();
 

--- a/translations/da.po
+++ b/translations/da.po
@@ -17119,7 +17119,7 @@ msgid "See all events"
 msgstr "Se alle arrangementer"
 
 #: /install.php?profile=ding2&locale=en&id=1&op=do
-msgid "No events where found."
+msgid "No events were found."
 msgstr "Ingen arrangementer"
 
 #: /index.php
@@ -17131,7 +17131,7 @@ msgid "Group events"
 msgstr "Arrangementer"
 
 #: /index.php
-msgid "No events where found in the group."
+msgid "No events were found in the group."
 msgstr "Ingen arrangementer til temaet"
 
 #: /index.php
@@ -17234,7 +17234,7 @@ msgid "See all news"
 msgstr "Se alle nyheder"
 
 #: /index.php
-msgid "No news where found."
+msgid "No news were found."
 msgstr "Ingen nyheder"
 
 #: /index.php
@@ -17246,7 +17246,7 @@ msgid "Group news"
 msgstr "Nyheder"
 
 #: /index.php
-msgid "No news where found for this group."
+msgid "No news were found for this group."
 msgstr "Ingen nyheder til temaet"
 
 msgid "nodequeue"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3898

#### Description

Multiple places within the sourcecode there is misspellings of "were found", which is given as "where found". Some places are strings that are actually presented/displayed to the user.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.