### PR TITLE
1353 carousel availability

### DIFF
--- a/modules/ding_carousel/js/ding_carousel.js
+++ b/modules/ding_carousel/js/ding_carousel.js
@@ -172,15 +172,15 @@
       dataType : 'json',
       success : function (data) {
         // Remove placeholders.
-        item.target.find('.ding-carousel-item.placeholder').remove();
-        item.target.slick('slickAdd', data.content);
+        item.tab.find('.ding-carousel-item.placeholder').remove();
+        item.tab.find('.carousel').slick('slickAdd', data.content);
         item.tab.data('offset', data.offset);
         item.tab.data('updating', false);
 
         // This ensures that ting objects loaded via ajax in the carousel's gets
         // reservations buttons displayed if available. So basically it finds
         // the material ids and coverts them into ding_availability format and
-        // updates the settings, which is this used when behaviors are attached
+        // updates the settings, which is then used when behaviors are attached
         // below. This is a hack, but the alternative was to re-write
         // ding_availability.
         var matches = data.content.match(/reservation-\d+-\w+:\d+/gm);
@@ -201,17 +201,15 @@
 
         // Carry on processing the queue.
         running = false;
-        update();
+        check_for_update(item.tab, item.slick);
       }
     });
   };
 
   /**
-   * Event handler for progressively loading more covers.
+   * Handler for progressively loading more covers.
    */
-  var update_handler = function (e, slick) {
-    var tab = e.data;
-
+  var check_for_update = function (tab, slick) {
     if (!tab.data('updating')) {
       // If its the first batch or we're near the end.
       if (tab.data('offset') === 0 ||
@@ -221,11 +219,18 @@
         // Disable updates while updating.
         tab.data('updating', true);
         // Add to queue.
-        queue.push({'tab': tab, 'slick': slick, 'target': $(e.target)});
+        queue.push({'tab': tab, 'slick': slick});
       }
     }
     // Run queue.
     update();
+  };
+
+  /**
+   * Event handler for progressively loading more covers.
+   */
+  var update_handler = function (e, slick) {
+    check_for_update(e.data, slick);
   };
 
   /**

--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -31,15 +31,17 @@ function ting_search_carousel_carousel_content_type_render($subtype, $conf, $pan
         'subtitle' => '',
         'query' => '',
         'sort' => '',
+        'available' => '',
       );
-      $query = new TingSearchCarouselQuery($search['query'], $search['sort']);
+      $query = new TingSearchCarouselQuery($search['query'], $search['sort'], $search['available']);
       $chunk = ting_search_carousel_get_entities($query, 0, TING_SEARCH_CAROUSEL_CHUNK_SIZE);
-
       $items = array();
       foreach ($chunk['entities'] as $entity) {
         $items[] = ting_object_view($entity, 'teaser');
       }
 
+      $placeholders = count($items) ? count($items) : TING_SEARCH_CAROUSEL_CHUNK_SIZE;
+      $placeholders = $chunk['next_offset'] > -1 ? ($placeholders) + 1 : 0;
       $carousels[] = array(
         '#type' => 'ding_carousel',
         '#title' => $search['title'],
@@ -48,7 +50,7 @@ function ting_search_carousel_carousel_content_type_render($subtype, $conf, $pan
         '#offset' => $chunk['next_offset'],
         // Add a single placeholder to fetch more content later if there is more
         // content.
-        '#placeholders' => $chunk['next_offset'] > -1 ? TING_SEARCH_CAROUSEL_CHUNK_SIZE + 1 : 0,
+        '#placeholders' => $placeholders,
       );
     }
 
@@ -176,7 +178,7 @@ function ting_search_carousel_carousel_content_type_edit_form_submit(&$form, &$f
   // submit and the client will not have to wait until those requests are
   // happening when page is opened.
   foreach ($searches as $search) {
-    $query = new TingSearchCarouselQuery($search['query'], $search['sort']);
+    $query = new TingSearchCarouselQuery($search['query'], $search['sort'], $search['available']);
     ting_search_carousel_get_entities($query, 0, 8, FALSE);
   }
 }
@@ -236,6 +238,13 @@ function ting_search_carousel_query_form(array $item = array(), $index = 0) {
     '#default_value' => isset($item['sort']) ? $item['sort'] : '',
   );
 
+  $form['available'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Only show available materials'),
+    '#description' => t('Filter out unavailable materials when rendering carousel.'),
+    '#default_value' => isset($item['available']) ? $item['available'] : '',
+  );
+
   $form['remove'] = array(
     '#type' => 'submit',
     '#value' => t('Remove'),
@@ -280,6 +289,7 @@ function ting_search_carousel_admin_form_add_one($form, &$form_state) {
     'subtitle' => '',
     'query' => '',
     'sort' => '',
+    'available' => 0,
   );
   $form_state['rebuild'] = TRUE;
 }

--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -132,9 +132,9 @@ function ting_search_carousel_get_entities(TingSearchCarouselQuery $query, $star
         $cache_data['search_page_size'],
         $ignore_ids);
 
-    foreach ($found_entities as $id => $entities) {
+    foreach ($found_entities as $id => $entity) {
       $ignore_ids[$id] = TRUE;
-      $cache_data['pool'][] = $entities;
+      $cache_data['pool'][] = $entity;
     }
   }
 

--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -97,7 +97,7 @@ function ting_search_carousel_get_entities(TingSearchCarouselQuery $query, $star
     $cache_data = $cache->data;
   }
 
-  $slice = _ting_search_carousel_get_slice($cache_data, $start, $count);
+  $slice = _ting_search_carousel_filter_available(_ting_search_carousel_get_slice($cache_data, $start, $count), $query);
   if ($query_only || $slice['next_offset'] != $start) {
     return $slice;
   }
@@ -111,7 +111,7 @@ function ting_search_carousel_get_entities(TingSearchCarouselQuery $query, $star
     if ($cache = cache_get("ting_search_carousel_search_" . $query_id)) {
       if (isset($cache->data)) {
         $cache_data = $cache->data;
-        return _ting_search_carousel_get_slice($cache_data, $start, $count);
+        return _ting_search_carousel_filter_available(_ting_search_carousel_get_slice($cache_data, $start, $count), $query);
       }
     }
     // Else return an empty list with the same start offset. Should trigger a
@@ -141,7 +141,7 @@ function ting_search_carousel_get_entities(TingSearchCarouselQuery $query, $star
   cache_set("ting_search_carousel_search_" . $query_id, $cache_data);
   lock_release($lock_name);
 
-  return _ting_search_carousel_get_slice($cache_data, $start, $count);
+  return _ting_search_carousel_filter_available(_ting_search_carousel_get_slice($cache_data, $start, $count), $query);
 }
 
 /**
@@ -181,6 +181,42 @@ function _ting_search_carousel_get_slice(array $cache_data, $start, $count) {
       'next_offset' => $start,
     );
   }
+}
+
+/**
+ * Filter slice down to available entities, if the query specify so.
+ *
+ * @param array $slice
+ *   Array with an 'entities' key which is an array of ting_entiites.
+ * @param TingSearchCarouselQuery $query
+ *   The query being performed.
+ *
+ * @return array
+ *   The input slice with unavailable entities removed.
+ */
+function _ting_search_carousel_filter_available(array $slice, TingSearchCarouselQuery $query) {
+  // Soft dependency on ding_availability.
+  if ($query->getOnlyAvailable() && function_exists('ding_availability_items')) {
+    $ids = array_map(function ($entity) {
+      return $entity->localId;
+    }, $slice['entities']);
+
+    if ($ids) {
+      $available = array_map(function ($availability) {
+        return $availability['available'];
+      }, ding_availability_items($ids));
+
+      $available = array_filter($available);
+
+      if ($available) {
+        $slice['entities'] = array_filter($slice['entities'], function ($entity) use ($available) {
+          return isset($available[$entity->localId]);
+        });
+      }
+    }
+  }
+
+  return $slice;
 }
 
 /**
@@ -302,6 +338,13 @@ class TingSearchCarouselQuery {
   protected $sort = '';
 
   /**
+   * Whether to only show available materials.
+   *
+   * @var bool
+   */
+  protected $onlyAvailable = FALSE;
+
+  /**
    * Create a new query object.
    *
    * @param string $query
@@ -309,9 +352,10 @@ class TingSearchCarouselQuery {
    * @param string $sort
    *   The sort to use.
    */
-  public function __construct($query, $sort = '') {
+  public function __construct($query, $sort = '', $onlyAvailable = FALSE) {
     $this->query = $query;
     $this->sort = $sort;
+    $this->onlyAvailable = (bool) $onlyAvailable;
   }
 
   /**
@@ -329,10 +373,21 @@ class TingSearchCarouselQuery {
   }
 
   /**
+   * Get availability flag.
+   */
+  public function getOnlyAvailable() {
+    return $this->onlyAvailable;
+  }
+
+  /**
    * Convert to string representation.
    */
   public function __toString() {
-    return base64_encode(json_encode(array($this->query, $this->sort)));
+    return base64_encode(json_encode(array(
+      $this->query,
+      $this->sort,
+      $this->onlyAvailable ? 1 : 0,
+    )));
   }
 
   /**
@@ -343,9 +398,9 @@ class TingSearchCarouselQuery {
    */
   public static function fromString($string) {
     $data = json_decode(base64_decode($string));
-    $data += array('');
+    $data += array('', 0);
     if (!empty($data[0])) {
-      $query = new TingSearchCarouselQuery($data[0], $data[1]);
+      $query = new TingSearchCarouselQuery($data[0], $data[1], $data[2]);
       return $query;
     }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1353

#### Description

Adds option to filter carousel materials down to available items.

It's done in the ajax callback, using provider availability data, in order to not have to deal with ting caching.

Requires https://github.com/ding2/ding2/pull/1235