### PR TITLE
3296 by Inlead: Refactored waiting list state.

### DIFF
--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -1072,27 +1072,43 @@ function _ding_place2book_status_processing($p2b_result) {
   if (!empty($p2b_result->headers['sales-status'])) {
     // Check if the event is closed for admissions.
     if ($p2b_result->headers['sales-status'] == 'closed') {
-      $p2b_ticket_result['type'] = 'closed-admission';
+      // Check if waiting list is activated.
+      if ($p2b_result->headers['waiting-list'] == 'true') {
+        $p2b_ticket_result['type'] = 'order-waiting-list';
+        $p2b_ticket_result['url'] = $p2b_result->headers['location'];
+      }
+      else {
+        $p2b_ticket_result['type'] = 'closed-admission';
+      }
     }
     // Check if sales period is in the future and ticket sale has not
     // started yet.
     elseif ($p2b_result->headers['sales-status'] == 'upcoming') {
-      $p2b_ticket_result['type'] = 'sale-not-started';
-    }
-    else {
-      // Check if sales are open and if available tickets is 0
-      if ($p2b_result->headers['sales-status'] == 'open' && (int) $p2b_result->headers['available-tickets'] == 0) {
+      // Check if waiting list is activated.
+      if ($p2b_result->headers['waiting-list'] == 'true') {
         $p2b_ticket_result['type'] = 'order-waiting-list';
         $p2b_ticket_result['url'] = $p2b_result->headers['location'];
       }
+      else {
+        $p2b_ticket_result['type'] = 'sale-not-started';
+      }
+    }
+    else {
       /*
        * Check if we have no tickets left
        * number from Available-Tickets header is a string and must be tested as
        * such. Also Available-Tickets header can have a negative value, which
        * we also interpret as "no ticket left".
        */
-      elseif ($p2b_result->headers['available-tickets'] == "0" || (int) $p2b_result->headers['available-tickets'] < 0) {
-        $p2b_ticket_result['type'] = 'no-tickets-left';
+      if ($p2b_result->headers['available-tickets'] == "0" || (int) $p2b_result->headers['available-tickets'] < 0) {
+        // Check if waiting list is activated.
+        if ($p2b_result->headers['waiting-list'] == 'true') {
+          $p2b_ticket_result['type'] = 'order-waiting-list';
+          $p2b_ticket_result['url'] = $p2b_result->headers['location'];
+        }
+        else {
+          $p2b_ticket_result['type'] = 'no-tickets-left';
+        }
       }
       else {
         // Check to see if we should present an link for ordering a ticket
@@ -1107,6 +1123,13 @@ function _ding_place2book_status_processing($p2b_result) {
         if ($p2b_result->headers['sales-status'] == 'open' && ((int) $p2b_result->headers['available-tickets'] > 0 || strpos($p2b_result->headers['available-tickets'], 'antal') > 0)) {
           $p2b_ticket_result['type'] = 'order-link';
           $p2b_ticket_result['url'] = $p2b_result->headers['location'];
+        }
+        else {
+          // Check if waiting list is activated.
+          if ($p2b_result->headers['waiting-list'] == 'true') {
+            $p2b_ticket_result['type'] = 'order-waiting-list';
+            $p2b_ticket_result['url'] = $p2b_result->headers['location'];
+          }
         }
       }
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3296

#### Description

Initial implementation (https://github.com/ding2/ding2/pull/1009) was made by checking whether sales status was open and amount of tickets is 0:
```
if ($p2b_result->headers['sales-status'] == 'open' && (int) $p2b_result->headers['available-tickets'] == 0) {
  $type = 'order-waiting-list';
  $url = $p2b_result->headers['location'];
}
```
However this is not what defines whether an event is with a waiting list or not. This is defined in the properties of the event in the external system, and the event gets a header called "`waiting-list`".

This value can be true even if the event is paused, stopped or open for sales. Therefore the check in this change-set is duplicated. Code is convoluted and refactoring is not a part of this task.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.