### PR TITLE
3822 by Inlead: Changes to tabroll settings in new version.

### DIFF
--- a/modules/ding_tabroll/ding_tabroll.module
+++ b/modules/ding_tabroll/ding_tabroll.module
@@ -122,15 +122,29 @@ function ding_tabroll_node_delete($node) {
  * Implements hook_form_alter().
  */
 function ding_tabroll_form_alter(&$form, &$form_state, $form_id) {
-  if ($form_id == 'ding_frontpage_admin_settings') {
-    // Get slide's switching speed, if variable is empty set default 5s.
-    $switch_speed = variable_get('ding_tabroll_speed', 5000);
+  if ($form_id == 'views_content_views_panes_content_type_edit_form') {
+    if (!empty($form_state['pane'])) {
+      $pane = $form_state['pane'];
+      if ($pane->subtype == 'ding_tabroll-ding_frontpage_tabroll') {
+        $switch_speed = variable_get('ding_tabroll_speed', 5000);
+        $form['ding_tabroll_speed'] = array(
+          '#type' => 'textfield',
+          '#title' => t('Tabroll speed (ms)'),
+          '#description' => t('Define speed of slide switching'),
+          '#default_value' => $switch_speed,
+        );
+        $form['#submit'][] = 'ding_tabroll_pane_settings_submit';
+      }
+    }
+  }
+}
 
-    $form['ding_frontpage']['ding_tabroll_speed'] = array(
-      '#type' => 'textfield',
-      '#title' => t('Tabroll speed (ms)'),
-      '#description' => t('Define speed of slide switching'),
-      '#default_value' => $switch_speed,
-    );
+/**
+ * Custom tabroll pane settings form submit handler.
+ */
+function ding_tabroll_pane_settings_submit($form, &$form_state) {
+  if (!empty($form_state['values']['ding_tabroll_speed'])) {
+    $ding_tabroll_speed = $form_state['values']['ding_tabroll_speed'];
+    variable_set('ding_tabroll_speed', $ding_tabroll_speed);
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3822

#### Description

Move tabroll pane items switching speed configuration from deprecated ding_frontend settings form into pane's settings form.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.