### PR TITLE
3908: Allow searching without keywords when using profile

### DIFF
--- a/modules/ting_field_search/plugins/ting_field_search_ctools_export_ui.inc
+++ b/modules/ting_field_search/plugins/ting_field_search_ctools_export_ui.inc
@@ -125,12 +125,6 @@ function ting_field_search_profile_export_form(&$form, &$form_state) {
     '#default_value' => $profile->config['search_request']['new_materials'],
     '#element_validate' => array('element_validate_integer_positive'),
   );
-  $form['config']['search_request']['allow_empty'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Allow empty'),
-    '#description' => t('Remove the default requirement for a search key.'),
-    '#default_value' => $profile->config['search_request']['allow_empty'],
-  );
 
   // User interaction.
   $form['config']['user_interaction'] = array(

--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -162,7 +162,9 @@ function ting_field_search_opensearch_pre_execute($request) {
 
   // Following modification should only be made on search requests.
   if ($class == 'TingClientSearchRequest') {
-    if (empty($request->getQuery()) && $config['search_request']['allow_empty']) {
+    // Users should always be allowed to search without entering keywords when
+    // using a profile.
+    if (empty($request->getQuery())) {
       $request->setQuery('*');
     }
 
@@ -654,25 +656,22 @@ function ting_field_search_search_block_submit($form, &$form_state) {
   // Add profile machine name query to redirect URL.
   $form_state['redirect'][1]['query']['profile'] = $selected_profile;
 
-  // Ting search will flag an error in this case and we need to clear it if the
-  // profile has allow_empty activated.
+  // We need to allow users to search without keywords when using a profile, but
+  // Ting search will flag a form error in this case and we need to clear it to
+  // avoid confusion.
   if (!$form_state['values']['search_block_form']) {
-    $profile = ting_field_search_profiles_load($selected_profile);
-
-    if ($profile && $profile->config['search_request']['allow_empty']) {
-      // This is a bit hacky, but apparently the only way we can clear an error
-      // for a single form element. Using form_clear_error will just remove all
-      // errors.
-      // See: https://api.drupal.org/comment/49163#comment-49163
-      $errors = &drupal_static('form_set_error', array());
-      $messages = &$_SESSION['messages']['error'];
-      $messages = array_diff($messages, array($errors['keys']));
-      unset($errors['keys']);
-      // If there's no messages left remove it completely to avoid empty space
-      // area where messages should have been.
-      if (empty($messages)) {
-        unset($_SESSION['messages']['error']);
-      }
+    // This is a bit hacky, but apparently the only way we can clear an error
+    // for a single form element. Using form_clear_error will just remove all
+    // errors.
+    // See: https://api.drupal.org/comment/49163#comment-49163
+    $errors = &drupal_static('form_set_error', array());
+    $messages = &$_SESSION['messages']['error'];
+    $messages = array_diff($messages, array($errors['keys']));
+    unset($errors['keys']);
+    // If there's no messages left remove it completely to avoid empty space
+    // area where messages should have been.
+    if (empty($messages)) {
+      unset($_SESSION['messages']['error']);
     }
   }
 }
@@ -1070,7 +1069,6 @@ function ting_field_search_config_default() {
       'well_profile' => '',
       'query' => '',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'search_result' => array(
       'results_per_page' => 10,

--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -162,8 +162,7 @@ function ting_field_search_opensearch_pre_execute($request) {
 
   // Following modification should only be made on search requests.
   if ($class == 'TingClientSearchRequest') {
-    // Allow empty: ting_search adds '()' for empty queries.
-    if ($request->getQuery() == '()' && $config['search_request']['allow_empty']) {
+    if (empty($request->getQuery()) && $config['search_request']['allow_empty']) {
       $request->setQuery('*');
     }
 

--- a/modules/ting_field_search/ting_field_search.ting_field_search_default_profiles.inc
+++ b/modules/ting_field_search/ting_field_search.ting_field_search_default_profiles.inc
@@ -21,7 +21,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'term.acsource any "ebsco masterfile tidsskriftsartikler biography in context avisartikler store danske science in context litteratursiden historiens verden 1001 fortællinger forfatterweb faktalink"',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -108,7 +107,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'term.acsource=bibliotekskatalog and term.type=bog and (dk=sk or dk=82* or dk=83* or dk=84* or dk=85* or dk=86* or dk=87* or dk=88.4* or dk=88.6* or dk=88.7* or dk=88.8*)',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -223,7 +221,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'term.acsource=bibliotekskatalog and term.type=bog not (dk=sk or dk=82* or dk=83* or dk=84* or dk=85* or dk=86* or dk=87* or dk=88.4* or dk=88.6* or dk=88.7* or dk=88.8*)',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -310,7 +307,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => '(ma=xc and ma=lm) or (ma=xc and ma=th) not (ma=mu or ma=ly or ma=xk or dk=sk)',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -383,7 +379,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'term.acsource=filmstriben or (term.acsource=bibliotekskatalog and term.workType=movie not (term.type=bog or term.type="film (net)" or ma=xc))',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -505,7 +500,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'ma=xe and term.type=ebog and sp=dan',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -613,7 +607,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'ma=xe and term.type=ebog not sp=dan',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -693,7 +686,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'ma=ly not (dk=78* or em=sprog*)',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -801,7 +793,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'ma=mu',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -888,7 +879,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'ma=bg or term.type=spil',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -968,7 +958,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'term.type=tegneserie or term.type="graphic novel"',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,
@@ -1005,7 +994,6 @@ function ting_field_search_ting_field_search_default_profiles() {
       'well_profile' => '',
       'query' => 'term.acsource any "pressreader zinio" or (term.acsource=bibliotekskatalog and ma=pe not ma=åp not ma=ms not ma=av not term.type=bog not term.type=spil not term.type=tegneserie not ma=tb not serie)',
       'new_materials' => '',
-      'allow_empty' => 0,
     ),
     'user_interaction' => array(
       'exposed' => 1,

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -811,7 +811,7 @@ function ddbasic_process_ting_object(&$vars) {
             );
           }
 
-          //Truncate abstract
+          // Truncate abstract.
           $vars['content']['group_text']['ting_abstract'][0]['#markup'] = add_ellipsis($vars['content']['group_text']['ting_abstract'][0]['#markup'], 330);
 
           // Check if teaser has rating function and remove abstract.
@@ -856,10 +856,10 @@ function ddbasic_process_ting_object(&$vars) {
             ), 0, 1);
           }
 
-          //Truncate default title
+          // Truncate default title.
           $vars['static_title'] = '<div class="field-name-ting-title"><h2>' . add_ellipsis($vars['elements']['group_text']['group_inner']['ting_title'][0]['#markup'], 40) . '</h2></div>';
 
-          //Truncate abstract
+          // Truncate abstract.
           $vars['content']['group_text']['ting_abstract'][0]['#markup'] = add_ellipsis($vars['content']['group_text']['ting_abstract'][0]['#markup'], 330);
 
           // Check if teaser has rating function and remove abstract.

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -37,6 +37,7 @@ function ddbasic_preprocess_html(&$vars) {
       $path = menu_get_item()['path'];
       switch ($path) {
         case 'search/ting/%';
+        case 'search/ting';
         case 'ding_frontpage':
           $vars['classes_array'][] = 'extended-search-is-open';
       }
@@ -809,7 +810,7 @@ function ddbasic_process_ting_object(&$vars) {
               'default'
             );
           }
-          
+
           //Truncate abstract
           $vars['content']['group_text']['ting_abstract'][0]['#markup'] = add_ellipsis($vars['content']['group_text']['ting_abstract'][0]['#markup'], 330);
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3908 

#### Description

There was an option to allow for "empty searches" on profiles, but it stopped working because the '()' was, rightfully, removed from the query when there was no keywords entered in the UI.

I fixed this and decided to remove the option, such that it's always possible to search without keywords when using a profile. I think it makes really good sense to allow searching without keywords, when the user already have selected a profile. And I couldn't come up with any good reasons to why you would not want that functionality on a search profile.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
