### PR TITLE
3893: Add and enable expanded to node menu settings

### DIFF
--- a/modules/ding_ddbasic/ding_ddbasic.module
+++ b/modules/ding_ddbasic/ding_ddbasic.module
@@ -179,6 +179,22 @@ function ding_ddbasic_form_alter(&$form, &$form_state, $form_id) {
 }
 
 /**
+ * Implements hook_form_BASE_FORM_ID_alter().
+ *
+ * Add and autofill the expanded checkbox to the node form.
+ */
+function ding_ddbasic_form_node_form_alter(&$form, $form_state) {
+  if (isset($form['menu']['link'])) {
+    $form['menu']['link']['expanded'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('Show as expanded'),
+      '#description' => t('If selected and this menu link has children, the menu will always appear expanded.'),
+      '#default_value' => !empty($form['#node']->menu['mlid']) ? $form['#node']->menu['expanded'] : 1,
+    );
+  }
+}
+
+/**
  * Custom validator for the system_theme_settings form.
  *
  * We force the color scheme to be custom, so the elements we've changed to


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3893

#### Description

Add and enable the expanded checkbox to the menu settings part of a node form.

#### Screenshot of the result

![screenshot_2018-11-01 edit side samtykke og opbevaring af information tidligere lan pbj ding virt b14cms dk](https://user-images.githubusercontent.com/163625/47855955-38cd5f00-dde6-11e8-8b5b-2f7e83e0b1c7.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.