### PR TITLE
3910: Color correction for ting object teaser with disabled overlay

### DIFF
--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -237,10 +237,10 @@
         @include transition(width $speed $ease);
         @include font('display-small');
         width: 100%;
-        color: $color-text-link-on-dark;
-        //margin-bottom: 15px;
+        color: $charcoal-opacity-dark;
+
         a:hover {
-          color: $color-text-link-on-dark;
+          color: $charcoal-opacity-dark;
         }
       }
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3910

#### Description

Text color changed for ting teasers with disabled overlay

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/22191849/47994212-f3fd3d00-e0f1-11e8-8bab-c36d93169b52.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No further comments