### PR TITLE
3639 by Inlead: Remove authorship checkbox.

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -854,7 +854,6 @@ function bpi_form_workflow_transition_form_submit($form, &$form_state) {
     'bpi_push_category',
     'bpi_push_audience',
     'bpi_push_images',
-    'bpi_push_ccl',
     'bpi_push_editable',
     'bpi_push_refs',
   );
@@ -868,7 +867,6 @@ function bpi_form_workflow_transition_form_submit($form, &$form_state) {
   $category = $form_state['values']['bpi_push_category'];
   $audience = $form_state['values']['bpi_push_audience'];
   $with_images = $form_state['values']['bpi_push_images'];
-  $authorship = !$form_state['values']['bpi_push_ccl'];
   $editable = $form_state['values']['bpi_push_editable'];
   $with_refs = $form_state['values']['bpi_push_refs'];
 
@@ -877,7 +875,6 @@ function bpi_form_workflow_transition_form_submit($form, &$form_state) {
     'category' => $category,
     'audience' => $audience,
     'with_images' => $with_images,
-    'authorship' => $authorship,
     'editable' => $editable,
     'with_refs' => $with_refs,
   );

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -60,13 +60,6 @@ function bpi_http_push_action_form($nid) {
     '#default_value' => FALSE,
   );
 
-  $form['configurations']['bpi_push_ccl'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('I want to be anonymous'),
-    '#description' => t('If checked the content will be pushed as anonymous to BPI.'),
-    '#default_value' => FALSE,
-  );
-
   $form['configurations']['bpi_push_refs'] = array(
     '#type' => 'checkbox',
     '#title' => t('Push with references'),
@@ -89,7 +82,6 @@ function bpi_http_push_action_form($nid) {
       $form['vocabularies']['bpi_push_category']['#default_value'] = $data['category'];
       $form['vocabularies']['bpi_push_audience']['#default_value'] = $data['audience'];
       $form['configurations']['bpi_push_images']['#default_value'] = $data['with_images'];
-      $form['configurations']['bpi_push_ccl']['#default_value'] = !$data['authorship'];
       $form['configurations']['bpi_push_refs']['#default_value'] = $data['with_refs'];
       $form['configurations']['bpi_push_editable']['#default_value'] = $data['editable'];
     }
@@ -160,7 +152,7 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
   if ($with_refs) {
     // Function field_get_items returns data with 2 different structure, depending from stage when it was called.
     $items = field_get_items('node', $node, variable_get('bpi_field_materials', ''));
-    foreach ($items as $item) {
+    foreach ((array) $items as $item) {
       // First case, we have completly saved node, when it returns ding_object_id.
       if (!empty($item['ting_object_id'])) {
         $id = $item['ting_object_id'];
@@ -213,7 +205,7 @@ function bpi_convert_to_bpi($node, $category, $audience, $with_images = FALSE, $
   $bpi_content['audience'] = $audience;
   $bpi_content['related_materials'] = $materials_drupal;
   $bpi_content['editable'] = (int) $editable;
-  $bpi_content['authorship'] = ($authorship) ? FALSE : TRUE;
+  $bpi_content['authorship'] = !$authorship;
   $bpi_content['assets'] = array();
 
   if ($with_images) {

--- a/modules/bpi/bpi.rules.inc
+++ b/modules/bpi/bpi.rules.inc
@@ -72,7 +72,6 @@ function bpi_rules_push($node) {
   $category = $data['category'];
   $audience = $data['audience'];
   $with_images = $data['with_images'];
-  $authorship = $data['authorship'];
   $editable = $data['editable'];
   $with_refs = $data['with_refs'];
 
@@ -87,7 +86,7 @@ function bpi_rules_push($node) {
     return FALSE;
   }
 
-  $bpi_content = bpi_convert_to_bpi($node, $category, $audience, $with_images, $authorship, $editable, $with_refs);
+  $bpi_content = bpi_convert_to_bpi($node, $category, $audience, $with_images, FALSE, $editable, $with_refs);
 
   $bpi = bpi_client_instance();
   $push_result = $bpi->push($bpi_content)->getProperties();


### PR DESCRIPTION
#### Link to issue ####
https://platform.dandigbib.org/issues/3639

#### Description ####
Simply remove the authorship checkbox and push all content with FALSE authorship value.
This change will display the authorship in backend (when syndicating) and not in frontend (after syndication). Normally authorship would appear as a suffix to the body value, which is not the case now.
For existing nodes that were pushed with authorship flag enabled, this also involves service changes to make sure no authoring information is appended to the content.

#### Screenshot of the result ####
![screenshot from 2018-11-06 12-44-35](https://user-images.githubusercontent.com/574498/48059501-0a72c980-e1c2-11e8-817c-14a747b8f51b.png)