### PR TITLE
3640 by Inlead: Hide comment workflow field.

### DIFF
--- a/modules/bpi/bpi_features/bpi_features.features.field_base.inc
+++ b/modules/bpi/bpi_features/bpi_features.features.field_base.inc
@@ -48,7 +48,7 @@ function bpi_features_field_default_field_bases() {
       'watchdog_log' => 1,
       'wid' => 1,
       'widget' => array(
-        'comment' => 1,
+        'comment' => 0,
         'hide' => 0,
         'name_as_title' => 1,
         'options' => 'buttons',

--- a/modules/bpi/bpi_features/bpi_features.features.field_instance.inc
+++ b/modules/bpi/bpi_features/bpi_features.features.field_instance.inc
@@ -53,7 +53,7 @@ function bpi_features_field_default_field_instances() {
       'active' => 1,
       'module' => 'workflowfield',
       'settings' => array(
-        'comment' => 1,
+        'comment' => 0,
         'name_as_title' => 1,
       ),
       'type' => 'workflow_default',


### PR DESCRIPTION
#### Link to issue ####
https://platform.dandigbib.org/issues/3640

#### Description ####
Hide the field via features. Revert of `bpi_features` is needed to accomplish the task.

#### Screenshot of the result ####
![screenshot from 2018-11-06 13-23-31](https://user-images.githubusercontent.com/574498/48061378-5d9b4b00-e1c7-11e8-8955-ce2825580bd7.png)