### PR TITLE
2608 by Inlead: Set proper menu item types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ web-services that runs OpenSSL v1.0.x or newer works.
   ~$ wget -qO- http://drupal.org/files/ssl-socket-transports-1879970-13.patch | patch -p1
 ```
 
+This [patch](https://www.drupal.org/project/drupal/issues/1079628) fixes menu item types
+shown in the frontend.
+```sh
+  ~$ wget -qO- https://www.drupal.org/files/issues/programatically_added-1079628-29-d7.patch | patch -p1
+```
+
 __Optional, but recommended patches__
 
 Ensures that Ajax errors only are displayed when not in readystate 4. So when

--- a/drupal.make
+++ b/drupal.make
@@ -10,6 +10,7 @@ projects[drupal][patch][] = "http://www.drupal.org/files/issues/1232416-autocomp
 projects[drupal][patch][] = "http://drupal.org/files/issues/translate_role_names-2205581-1.patch"
 projects[drupal][patch][] = "http://www.drupal.org/files/issues/drupal-tabledrag-scroll-2843240-36.patch"
 projects[drupal][patch][] = "patches/drupal_core.robots.txt.ding2.patch"
+projects[drupal][patch][] = "https://www.drupal.org/files/issues/programatically_added-1079628-29-d7.patch"
 
 ; Get the profile, which will contain the next makefile.
 projects[ding2][type] = "profile"

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -81,10 +81,12 @@ function bpi_menu() {
     'page callback' => 'bpi_syndicate_action',
     'page arguments' => array(3),
     'access arguments' => array('bpi syndicate content'),
+    'type' => MENU_CALLBACK,
     'file' => 'bpi.syndicate.inc',
   );
 
   $menu['admin/bpi/statistics/nojs'] = array(
+    'title' => 'BPI statistics',
     'page callback' => 'bpi_statistics',
     'page arguments' => array(3),
     'access arguments' => array('view bpi statistics'),
@@ -93,12 +95,15 @@ function bpi_menu() {
 
   $menu['admin/bpi/statistics/ajax'] = array(
     'delivery callback' => 'ajax_deliver',
+    'type' => MENU_CALLBACK,
   ) + $menu['admin/bpi/statistics/nojs'];
 
   $menu['admin/bpi/images/nojs'] = array(
+    'title' => 'BPI syndicate images',
     'page callback' => 'bpi_syndicate_images',
     'page arguments' => array(3),
     'access arguments' => array('bpi syndicate content'),
+    'type' => MENU_CALLBACK,
     'file' => 'bpi.images.inc',
   );
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/2608

#### Description

Set proper menu item types, since when missing, item types defaults to `MENU_NORMAL_ITEM`. This makes the menu items visible.

On top of that, patch to drupal core is required for this to work - https://www.drupal.org/project/drupal/issues/1079628

#### Screenshot of the result

![screenshot from 2018-11-07 12-56-09](https://user-images.githubusercontent.com/574498/48128035-f399a900-e28d-11e8-8be3-3226976bad83.png)

#### Additional comments or questions

This change-set itself doesn't solve the issue, a patch to Drupal core is required which is provided above. In short - drupal cache clear doesn't cleanup the `menu_links` table when changing menu item type to `MENU_CALLBACK`. This results in menu items that became route callbacks to be still rendered as normal menu items.