### PR TITLE
3012: Do not depend on tags for CircleCI releases and Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -276,9 +276,14 @@ jobs:
         name: "Publish release on GitHub"
         command: |
           CIRCLE_TAG="$(cd ~/project && git tag -l --points-at HEAD)"
-          PRERELEASE=$([[ $CIRCLE_TAG =~ rc ]] && echo "-prerelease" || echo "")
-          mv ding2-$CIRCLE_SHA1.tar.gz ding2-$CIRCLE_TAG.tar.gz
-          ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${PRERELEASE} ${CIRCLE_TAG} ding2-$CIRCLE_TAG.tar.gz
+          if [ -n "${CIRCLE_TAG}" ]
+          then
+            PRERELEASE=$([[ $CIRCLE_TAG =~ rc ]] && echo "-prerelease" || echo "")
+            mv ding2-$CIRCLE_SHA1.tar.gz ding2-$CIRCLE_TAG.tar.gz
+            ghr -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -n ${CIRCLE_TAG} -delete ${PRERELEASE} ${CIRCLE_TAG} ding2-$CIRCLE_TAG.tar.gz
+          else
+            echo "No release created. No tag detected for commit."
+          fi
 
   docker_db_image:
     docker:
@@ -340,10 +345,9 @@ workflows:
           - unit_tests
           - behat_tests
         filters:
-          tags:
-            only: /^7\.x\-.+/
           branches:
-            ignore: /.*/
+            only:
+              - /^release.*/
     - docker_db_image:
         requires:
           - site_install
@@ -351,5 +355,4 @@ workflows:
           branches:
             only:
               - master
-          tags:
-            only: /^7\.x\-.+/
+              - /^release.*/


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3012

#### Description

CircleCI has an odd way of handling jobs which are both filtered by tags
and requiring other jobs. In these cases all precursors must also be
filtered by tags for the job to run.
-> https://discuss.circleci.com/t/builds-for-tags-not-triggering/17681/5

This lead to the workflow for the latest release 7.x-4.6.0-rc1 looking like this. A tagged Docker image was not created and the release was not published. 

![image](https://user-images.githubusercontent.com/73966/48138223-1df66100-e2a4-11e8-9d56-9afd1d13cec6.png)

This is hard to handle so instead of requiring tags we require the
release branch (which usually contain our tags) and only publish 
releases if a tag for the commit can be determined.

#### Screenshot of the result

After the change the workflow for a `release` branch should look like [this](https://circleci.com/workflow-run/5227900a-dae0-415f-9adc-5c530810b663):

![image](https://user-images.githubusercontent.com/73966/48138148-f2737680-e2a3-11e8-9ba6-0ea9fcaada18.png)

Resulting releases can be found here:

- https://github.com/reload/ding2/releases/tag/release-test
- https://hub.docker.com/r/reload/ding2-mysql/tags/

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.