### PR TITLE
3703: Fix ekurser date sort

### DIFF
--- a/modules/ding_ekurser/ding_ekurser.info
+++ b/modules/ding_ekurser/ding_ekurser.info
@@ -5,6 +5,7 @@ project = ding_ekurser
 dependencies[] = ctools
 dependencies[] = oembed
 dependencies[] = page_manager
+dependencies[] = opensearch
 features[ctools][] = oembed:oembed_provider:1
 features[ctools][] = page_manager:pages_default:1
 features[features_api][] = api:2

--- a/modules/ding_ekurser/ding_ekurser.module
+++ b/modules/ding_ekurser/ding_ekurser.module
@@ -149,7 +149,7 @@ function ding_ekurser_search_execute($keys = NULL, $conditions = NULL) {
 function ding_ekurser_conditions_callback($keys) {
   $conditions = ting_search_conditions_callback($keys);
   if (empty($conditions['sort'])) {
-    $conditions['sort'] = 'acquisitionDate_descending';
+    $conditions['sort'] = 'date_descending';
   }
   return $conditions;
 }
@@ -164,8 +164,8 @@ function ding_ekurser_search_sort_options() {
   $options = array(
     'title_ascending' => t('Title (Ascending)'),
     'title_descending' => t('Title (Descending)'),
-    'acquisitionDate_ascending' => t('Acquisition date (Ascending)'),
-    'acquisitionDate_descending' => t('Acquisition date (Descending)'),
+    'date_ascending' => t('Acquisition date (Ascending)'),
+    'date_descending' => t('Acquisition date (Descending)'),
   );
 
   // Add label to the front of the options.
@@ -189,7 +189,7 @@ function ding_ekurser_form_ting_search_sort_form_alter(&$form, &$form_state, $fo
   // Set our own sorting options and set default sort, if it's not set.
   $form['sort']['#options'] = ding_ekurser_search_sort_options();
   if (empty($form['sort']['#default_value'])) {
-    $form['sort']['#default_value'] = 'acquisitionDate_descending';
+    $form['sort']['#default_value'] = 'date_descending';
   }
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3703

#### Description

Opensearch is using date field for sorting, but ding_ekurser was using acquisitionDate. Before the introduction of SAL this was no problem, but now Ting search has to verify that the provider supports the current sort. Since opensearch is not returning acquisitionDate it's ignored bothwhen performing search and setting default value.

date = The date the material was published.
acquisitionDate = The date the material was added to the library.

Even though the Opensearch webservice is supporting acquisitionDate (and also localAcquisitionDate), the simplest and best solution seems to be just make ding_ekurser use date field for sort. I think it's the most intuitive sort and it prevents us from having to introduce acquisitionDate in the main search functionality by adding it to `opensearch_search_sort_options()`.

Since ding_ekurser is dependendant on opensearch to work correctly I also added a dependency.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.