### PR TITLE
3816 by Inlead: Filter by taxonomy in /content.

### DIFF
--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -759,10 +759,57 @@ function ding_base_validate_email($email) {
 }
 
 /**
+ * Implements hook_views_pre_view().
+ */
+function ding_base_views_pre_view(&$view, &$display_id, &$args) {
+  if ($view->name == 'admin_views_node' && $display_id == 'system_1') {
+    $filter_options = array(
+        'id' => 'ding_base_term_name',
+        'table' => 'taxonomy_term_data',
+        'field' => 'name',
+        'relationship' => 'term_node_tid',
+        'group_type' => 'group',
+        'operator' => "contains",
+        'value' => '',
+        'group' => 1,
+        'exposed' => TRUE,
+        'required' => FALSE,
+        'type' => 'text',
+        'expose' => array(
+          'operator_id' => 'name_op',
+          'label' => t('Terms'),
+          'operator' => 'name_op',
+          'identifier' => 'ding_base_term_name',
+        ),
+    );
+
+    $filters = $view->display_handler->get_option('filters');
+
+    if (empty($filters['ding_base_term_name'])) {
+      // There is no vid filter so we have to add it
+      $view->add_item(
+        $view->current_display,
+        'filter',
+        'taxonomy_term_data',
+        'name',
+        $filter_options
+      );
+    }
+  }
+}
+
+/**
  * Implements hook_form_alter().
  */
 function ding_base_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == 'views_exposed_form' && $form_state['view']->name == 'admin_views_node') {
+    $form['ding_base_term_name']['#type'] = 'textfield';
+    $form['ding_base_term_name']['#id'] = 'edit-ding-base-term-name';
+    $form['ding_base_term_name']['#attached']['js'][] = array(
+      'data' => drupal_get_path('module', 'ding_base') . '/js/ding_base.prevent_auto_submit.js',
+      'type' => 'file',
+    );
+
     // If no vocabulary selected, disable "Terms" filter.
     if ($form_state['input']['vid'] == 'All') {
       $form['ding_base_term_name']['#attributes'] = [
@@ -777,11 +824,6 @@ function ding_base_form_alter(&$form, &$form_state, $form_id) {
         'class' => array(
           'ctools-auto-submit-exclude',
         ),
-      );
-
-      $form['ding_base_term_name']['#attached']['js'][] = array(
-        'data' => drupal_get_path('module', 'ding_base') . '/js/ding_base.prevent_auto_submit.js',
-        'type' => 'file',
       );
     }
   }

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -763,30 +763,30 @@ function ding_base_validate_email($email) {
  */
 function ding_base_views_pre_view(&$view, &$display_id, &$args) {
   if ($view->name == 'admin_views_node' && $display_id == 'system_1') {
-    $filter_options = array(
-        'id' => 'ding_base_term_name',
-        'table' => 'taxonomy_term_data',
-        'field' => 'name',
-        'relationship' => 'term_node_tid',
-        'group_type' => 'group',
-        'operator' => "contains",
-        'value' => '',
-        'group' => 1,
-        'exposed' => TRUE,
-        'required' => FALSE,
-        'type' => 'text',
-        'expose' => array(
-          'operator_id' => 'name_op',
-          'label' => t('Terms'),
-          'operator' => 'name_op',
-          'identifier' => 'ding_base_term_name',
-        ),
-    );
+    $filter_options = [
+      'id' => 'ding_base_term_name',
+      'table' => 'taxonomy_term_data',
+      'field' => 'name',
+      'relationship' => 'term_node_tid',
+      'group_type' => 'group',
+      'operator' => "contains",
+      'value' => '',
+      'group' => 1,
+      'exposed' => TRUE,
+      'required' => FALSE,
+      'type' => 'text',
+      'expose' => [
+        'operator_id' => 'name_op',
+        'label' => t('Terms'),
+        'operator' => 'name_op',
+        'identifier' => 'ding_base_term_name',
+      ],
+    ];
 
     $filters = $view->display_handler->get_option('filters');
 
     if (empty($filters['ding_base_term_name'])) {
-      // There is no vid filter so we have to add it
+      // There is no such filter so we have to add it.
       $view->add_item(
         $view->current_display,
         'filter',
@@ -805,10 +805,10 @@ function ding_base_form_alter(&$form, &$form_state, $form_id) {
   if ($form_id == 'views_exposed_form' && $form_state['view']->name == 'admin_views_node') {
     $form['ding_base_term_name']['#type'] = 'textfield';
     $form['ding_base_term_name']['#id'] = 'edit-ding-base-term-name';
-    $form['ding_base_term_name']['#attached']['js'][] = array(
+    $form['ding_base_term_name']['#attached']['js'][] = [
       'data' => drupal_get_path('module', 'ding_base') . '/js/ding_base.prevent_auto_submit.js',
       'type' => 'file',
-    );
+    ];
 
     // If no vocabulary selected, disable "Terms" filter.
     if ($form_state['input']['vid'] == 'All') {
@@ -820,11 +820,11 @@ function ding_base_form_alter(&$form, &$form_state, $form_id) {
       $vid = $form_state['input']['vid'];
       $form['ding_base_term_name']['#autocomplete_path'] = 'ding_base/taxonomy/autocomplete/' . $vid;
       $form['ding_base_term_name']['#description'] = t('Autocomplete with terms of selected vocabulary');
-      $form['ding_base_term_name']['#attributes'] = array(
-        'class' => array(
+      $form['ding_base_term_name']['#attributes'] = [
+        'class' => [
           'ctools-auto-submit-exclude',
-        ),
-      );
+        ],
+      ];
     }
   }
 }
@@ -837,7 +837,7 @@ function ding_base_taxonomy_autocomplete($vid, $tag) {
     $vocabulary = taxonomy_vocabulary_load($vid);
 
     $tags = db_select('taxonomy_term_data', 't')
-      ->fields('t', array('tid', 'name'))
+      ->fields('t', ['tid', 'name'])
       ->condition('vid', $vid)
       ->condition('t.name', '%' . db_like($tag) . '%', 'LIKE')
       ->execute()

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -25,6 +25,13 @@ function ding_base_menu() {
     'file path' => drupal_get_path('module', 'system'),
   );
 
+  $items['ding_base/taxonomy/autocomplete'] = array(
+    'title' => 'Autocomplete taxonomy',
+    'page callback' => 'ding_base_taxonomy_autocomplete',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -749,4 +756,56 @@ function ding_base_validate_email($email) {
 
   $domain = strtoupper(substr($email, strrpos($email, '.') + 1));
   return empty($tld_list) || in_array($domain, $tld_list);
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function ding_base_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'views_exposed_form' && $form_state['view']->name == 'admin_views_node') {
+    // If no vocabulary selected, disable "Terms" filter.
+    if ($form_state['input']['vid'] == 'All') {
+      $form['ding_base_term_name']['#attributes'] = [
+        'disabled' => TRUE,
+      ];
+    }
+    else {
+      $vid = $form_state['input']['vid'];
+      $form['ding_base_term_name']['#autocomplete_path'] = 'ding_base/taxonomy/autocomplete/' . $vid;
+      $form['ding_base_term_name']['#description'] = t('Autocomplete with terms of selected vocabulary');
+      $form['ding_base_term_name']['#attributes'] = array(
+        'class' => array(
+          'ctools-auto-submit-exclude',
+        ),
+      );
+
+      $form['ding_base_term_name']['#attached']['js'][] = array(
+        'data' => drupal_get_path('module', 'ding_base') . '/js/ding_base.prevent_auto_submit.js',
+        'type' => 'file',
+      );
+    }
+  }
+}
+
+/**
+ * Admin content "Terms" filter autocomplete callback.
+ */
+function ding_base_taxonomy_autocomplete($vid, $tag) {
+  if (!empty($vid)) {
+    $vocabulary = taxonomy_vocabulary_load($vid);
+
+    $tags = db_select('taxonomy_term_data', 't')
+      ->fields('t', array('tid', 'name'))
+      ->condition('vid', $vid)
+      ->condition('t.name', '%' . db_like($tag) . '%', 'LIKE')
+      ->execute()
+      ->fetchAll();
+
+    $items = [];
+    foreach ($tags as $item) {
+      $items[$item->name] = $item->name;
+    }
+
+    drupal_json_output($items);
+  }
 }

--- a/modules/ding_base/js/ding_base.prevent_auto_submit.js
+++ b/modules/ding_base/js/ding_base.prevent_auto_submit.js
@@ -1,0 +1,42 @@
+/**
+ * @file
+ *
+ * Processing "Terms" filter field behavior.
+ */
+(function ($) {
+  "use strict";
+
+  function triggerSubmit () {
+    var $this = $(this);
+    if (!$this.hasClass('ctools-ajaxing')) {
+      $this.find('.ctools-auto-submit-click').click();
+    }
+  }
+
+  Drupal.behaviors.prevent_auto_submit = {
+    attach: function() {
+
+      // Processing autocomplete functionality for "Terms" filter field.
+      $("input[name='ding_base_term_name']").on('change keyup', function (e) {
+        if (e.type === 'change' || (e.type === 'keyup' && e.which === 13)) {
+          var form = $(this).closest('form');
+          var selected;
+          if ($(form).find('#autocomplete ul li.selected') !== undefined) {
+            selected = $(form).find('#autocomplete ul li.selected')[0].textContent;
+          }
+
+          if (selected !== undefined) {
+            $("input[name='ding_base_term_name']").val(selected);
+          }
+          triggerSubmit.call(form);
+        }
+      });
+
+      // Resetting "Terms" field value when switching vocabulary.
+      $("select#edit-vid").change(function () {
+        $("input[name='ding_base_term_name']").val("");
+      });
+    }
+  };
+
+})(jQuery);

--- a/modules/ding_base/js/ding_base.prevent_auto_submit.js
+++ b/modules/ding_base/js/ding_base.prevent_auto_submit.js
@@ -4,17 +4,15 @@
  * Processing "Terms" filter field behavior.
  */
 (function ($) {
-  "use strict";
-
-  function triggerSubmit () {
-    var $this = $(this);
-    if (!$this.hasClass('ctools-ajaxing')) {
-      $this.find('.ctools-auto-submit-click').click();
-    }
-  }
-
   Drupal.behaviors.prevent_auto_submit = {
     attach: function(context) {
+      function triggerSubmit (e) {
+        var $this = $(this);
+        if (!$this.hasClass('ctools-ajaxing')) {
+          $this.find('.ctools-auto-submit-click').click();
+        }
+      }
+
       // Processing autocomplete functionality for "Terms" filter field.
       $("input[name='ding_base_term_name']", context).on('change keyup', function (e) {
         if (e.type === 'change' || (e.type === 'keyup' && e.which === 13)) {

--- a/modules/ding_base/js/ding_base.prevent_auto_submit.js
+++ b/modules/ding_base/js/ding_base.prevent_auto_submit.js
@@ -14,18 +14,18 @@
   }
 
   Drupal.behaviors.prevent_auto_submit = {
-    attach: function() {
-
+    attach: function(context) {
       // Processing autocomplete functionality for "Terms" filter field.
-      $("input[name='ding_base_term_name']").on('change keyup', function (e) {
+      $("input[name='ding_base_term_name']", context).on('change keyup', function (e) {
         if (e.type === 'change' || (e.type === 'keyup' && e.which === 13)) {
           var form = $(this).closest('form');
           var selected;
-          if ($(form).find('#autocomplete ul li.selected') !== undefined) {
+
+          if ($(form).find('#autocomplete ul li.selected').length !== 0) {
             selected = $(form).find('#autocomplete ul li.selected')[0].textContent;
           }
 
-          if (selected !== undefined) {
+          if (selected !== '') {
             $("input[name='ding_base_term_name']").val(selected);
           }
           triggerSubmit.call(form);

--- a/modules/ding_tabroll/ding_tabroll.module
+++ b/modules/ding_tabroll/ding_tabroll.module
@@ -122,29 +122,15 @@ function ding_tabroll_node_delete($node) {
  * Implements hook_form_alter().
  */
 function ding_tabroll_form_alter(&$form, &$form_state, $form_id) {
-  if ($form_id == 'views_content_views_panes_content_type_edit_form') {
-    if (!empty($form_state['pane'])) {
-      $pane = $form_state['pane'];
-      if ($pane->subtype == 'ding_tabroll-ding_frontpage_tabroll') {
-        $switch_speed = variable_get('ding_tabroll_speed', 5000);
-        $form['ding_tabroll_speed'] = array(
-          '#type' => 'textfield',
-          '#title' => t('Tabroll speed (ms)'),
-          '#description' => t('Define speed of slide switching'),
-          '#default_value' => $switch_speed,
-        );
-        $form['#submit'][] = 'ding_tabroll_pane_settings_submit';
-      }
-    }
-  }
-}
+  if ($form_id == 'ding_frontpage_admin_settings') {
+    // Get slide's switching speed, if variable is empty set default 5s.
+    $switch_speed = variable_get('ding_tabroll_speed', 5000);
 
-/**
- * Custom tabroll pane settings form submit handler.
- */
-function ding_tabroll_pane_settings_submit($form, &$form_state) {
-  if (!empty($form_state['values']['ding_tabroll_speed'])) {
-    $ding_tabroll_speed = $form_state['values']['ding_tabroll_speed'];
-    variable_set('ding_tabroll_speed', $ding_tabroll_speed);
+    $form['ding_frontpage']['ding_tabroll_speed'] = array(
+      '#type' => 'textfield',
+      '#title' => t('Tabroll speed (ms)'),
+      '#description' => t('Define speed of slide switching'),
+      '#default_value' => $switch_speed,
+    );
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3816

#### Description

As it was requested, was added possibility to filter nodes on /content page by taxonomy terms. The taxonomy term filtration depends on selected taxonomy vocabulary filter from the same form.
New filter is realized as a textfield which will be in disabled state until taxonomy vocabulary filter is not selected. If an taxonomy vocabulary is selected, terms filter changes it's state to active and autocomplete functionality is added.

Regarding opportunity to assign taxonomies through bulk update, this is already realized in VBO actions and can be done with "Change value" action.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
