### PR TITLE
3816 by Inlead: Filter by taxonomy in /content.

### DIFF
--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -25,6 +25,13 @@ function ding_base_menu() {
     'file path' => drupal_get_path('module', 'system'),
   );
 
+  $items['ding_base/taxonomy/autocomplete'] = array(
+    'title' => 'Autocomplete taxonomy',
+    'page callback' => 'ding_base_taxonomy_autocomplete',
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -749,4 +756,98 @@ function ding_base_validate_email($email) {
 
   $domain = strtoupper(substr($email, strrpos($email, '.') + 1));
   return empty($tld_list) || in_array($domain, $tld_list);
+}
+
+/**
+ * Implements hook_views_pre_view().
+ */
+function ding_base_views_pre_view(&$view, &$display_id, &$args) {
+  if ($view->name == 'admin_views_node' && $display_id == 'system_1') {
+    $filter_options = [
+      'id' => 'ding_base_term_name',
+      'table' => 'taxonomy_term_data',
+      'field' => 'name',
+      'relationship' => 'term_node_tid',
+      'group_type' => 'group',
+      'operator' => "contains",
+      'value' => '',
+      'group' => 1,
+      'exposed' => TRUE,
+      'required' => FALSE,
+      'type' => 'text',
+      'expose' => [
+        'operator_id' => 'name_op',
+        'label' => t('Terms'),
+        'operator' => 'name_op',
+        'identifier' => 'ding_base_term_name',
+      ],
+    ];
+
+    $filters = $view->display_handler->get_option('filters');
+
+    if (empty($filters['ding_base_term_name'])) {
+      // There is no such filter so we have to add it.
+      $view->add_item(
+        $view->current_display,
+        'filter',
+        'taxonomy_term_data',
+        'name',
+        $filter_options
+      );
+    }
+  }
+}
+
+/**
+ * Implements hook_form_alter().
+ */
+function ding_base_form_alter(&$form, &$form_state, $form_id) {
+  if ($form_id == 'views_exposed_form' && $form_state['view']->name == 'admin_views_node') {
+    $form['ding_base_term_name']['#type'] = 'textfield';
+    $form['ding_base_term_name']['#id'] = 'edit-ding-base-term-name';
+    $form['ding_base_term_name']['#attached']['js'][] = [
+      'data' => drupal_get_path('module', 'ding_base') . '/js/ding_base.prevent_auto_submit.js',
+      'type' => 'file',
+    ];
+
+    // If no vocabulary selected, disable "Terms" filter.
+    if ($form_state['input']['vid'] == 'All') {
+      $form['ding_base_term_name']['#attributes'] = [
+        'disabled' => TRUE,
+      ];
+    }
+    else {
+      $vid = $form_state['input']['vid'];
+      $form['ding_base_term_name']['#autocomplete_path'] = 'ding_base/taxonomy/autocomplete/' . $vid;
+      $form['ding_base_term_name']['#description'] = t('Autocomplete with terms of selected vocabulary');
+      $form['ding_base_term_name']['#attributes'] = [
+        'class' => [
+          'ctools-auto-submit-exclude',
+        ],
+      ];
+    }
+  }
+}
+
+/**
+ * Admin content "Terms" filter autocomplete callback.
+ */
+function ding_base_taxonomy_autocomplete($vid, $tag) {
+  if (!empty($vid)) {
+    $vocabulary = taxonomy_vocabulary_load($vid);
+
+    $tags = db_select('taxonomy_term_data', 't')
+      ->fields('t', ['tid', 'name'])
+      ->condition('vid', $vid)
+      ->condition('t.name', '%' . db_like($tag) . '%', 'LIKE')
+      ->execute()
+      ->fetchAll();
+
+    $items = [];
+    foreach ($tags as $item) {
+      $items[$item->name] = $item->name;
+    }
+
+    drupal_json_output($items);
+  }
 }

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -830,6 +830,48 @@ function ding_base_form_alter(&$form, &$form_state, $form_id) {
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ */
+function ding_base_preprocess_views_exposed_form(&$variables) {
+  if (isset($variables['form']) && $variables['form']['#id'] == 'views-exposed-form-admin-views-node-system-1') {
+    $widgets = $variables['widgets'];
+
+    // Get widgets keys for further processing.
+    $widgets_keys = array_keys($widgets);
+
+    // Switch key with value, to have an numeric value.
+    $widgets_keys = array_flip($widgets_keys);
+
+    // Getting Vocabulary filter position.
+    $vid_position = $widgets_keys['filter-vid'];
+    // Set needed position to Taxonomy terms filter field.
+    $widgets_keys['filter-name'] = $vid_position + 1;
+
+    // Modifying positions.
+    foreach ($widgets_keys as $key => $pos) {
+      if ($pos >= $widgets_keys['filter-name'] && $key != 'filter-name') {
+        $widgets_keys[$key] = $pos + 1;
+      }
+    }
+
+    // Flip array to get numeric values as keys.
+    $normalize = array_flip($widgets_keys);
+
+    // Sort array by numeric keys.
+    ksort($normalize, SORT_ASC);
+
+    // Prepare ordered array.
+    $normalized = array_flip($normalize);
+
+    // Order widgets objects by correctly positioned structure.
+    $widgets = array_merge($normalized, $widgets);
+
+    // Return widgets back in variables.
+    $variables['widgets'] = $widgets;
+  }
+}
+
+/**
  * Admin content "Terms" filter autocomplete callback.
  */
 function ding_base_taxonomy_autocomplete($vid, $tag) {

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -759,10 +759,13 @@ function ding_base_validate_email($email) {
 }
 
 /**
- * Implements hook_views_pre_view().
+ * Implements hook_views_default_views_alter().
+ *
+ * Adding custom Taxonomy Terms filter to admin_views_node view.
  */
-function ding_base_views_pre_view(&$view, &$display_id, &$args) {
-  if ($view->name == 'admin_views_node' && $display_id == 'system_1') {
+function ding_base_views_default_views_alter(&$views) {
+  if (isset($views['admin_views_node'])) {
+    $view = &$views['admin_views_node'];
     $filter_options = [
       'id' => 'ding_base_term_name',
       'table' => 'taxonomy_term_data',
@@ -783,17 +786,11 @@ function ding_base_views_pre_view(&$view, &$display_id, &$args) {
       ],
     ];
 
-    $filters = $view->display_handler->get_option('filters');
+    $filters = $view->display['default']->display_options['filters'];
 
-    if (empty($filters['ding_base_term_name'])) {
+    if (empty($filters['name'])) {
       // There is no such filter so we have to add it.
-      $view->add_item(
-        $view->current_display,
-        'filter',
-        'taxonomy_term_data',
-        'name',
-        $filter_options
-      );
+      $views['admin_views_node']->display['default']->display_options['filters']['name'] = $filter_options;
     }
   }
 }
@@ -831,6 +828,9 @@ function ding_base_form_alter(&$form, &$form_state, $form_id) {
 
 /**
  * Implements hook_preprocess_HOOK().
+ *
+ * Used for changing order of filter fields, so the "Terms" filter is positioned
+ * right after "Vocabulary" filter.
  */
 function ding_base_preprocess_views_exposed_form(&$variables) {
   if (isset($variables['form']) && $variables['form']['#id'] == 'views-exposed-form-admin-views-node-system-1') {
@@ -876,8 +876,6 @@ function ding_base_preprocess_views_exposed_form(&$variables) {
  */
 function ding_base_taxonomy_autocomplete($vid, $tag) {
   if (!empty($vid)) {
-    $vocabulary = taxonomy_vocabulary_load($vid);
-
     $tags = db_select('taxonomy_term_data', 't')
       ->fields('t', ['tid', 'name'])
       ->condition('vid', $vid)

--- a/modules/ding_base/js/ding_base.prevent_auto_submit.js
+++ b/modules/ding_base/js/ding_base.prevent_auto_submit.js
@@ -4,15 +4,10 @@
  * Processing "Terms" filter field behavior.
  */
 (function ($) {
+  "use strict";
+
   Drupal.behaviors.prevent_auto_submit = {
     attach: function(context) {
-      function triggerSubmit (e) {
-        var $this = $(this);
-        if (!$this.hasClass('ctools-ajaxing')) {
-          $this.find('.ctools-auto-submit-click').click();
-        }
-      }
-
       // Processing autocomplete functionality for "Terms" filter field.
       $("input[name='ding_base_term_name']", context).on('change keyup', function (e) {
         if (e.type === 'change' || (e.type === 'keyup' && e.which === 13)) {
@@ -26,7 +21,11 @@
           if (selected !== '') {
             $("input[name='ding_base_term_name']").val(selected);
           }
-          triggerSubmit.call(form);
+
+          var $this = $(form);
+          if (!$this.hasClass('ctools-ajaxing')) {
+            $this.find('.ctools-auto-submit-click').click();
+          }
         }
       });
 

--- a/modules/ding_base/js/ding_base.prevent_auto_submit.js
+++ b/modules/ding_base/js/ding_base.prevent_auto_submit.js
@@ -1,0 +1,40 @@
+/**
+ * @file
+ *
+ * Processing "Terms" filter field behavior.
+ */
+(function ($) {
+  Drupal.behaviors.prevent_auto_submit = {
+    attach: function(context) {
+      function triggerSubmit (e) {
+        var $this = $(this);
+        if (!$this.hasClass('ctools-ajaxing')) {
+          $this.find('.ctools-auto-submit-click').click();
+        }
+      }
+
+      // Processing autocomplete functionality for "Terms" filter field.
+      $("input[name='ding_base_term_name']", context).on('change keyup', function (e) {
+        if (e.type === 'change' || (e.type === 'keyup' && e.which === 13)) {
+          var form = $(this).closest('form');
+          var selected;
+
+          if ($(form).find('#autocomplete ul li.selected').length !== 0) {
+            selected = $(form).find('#autocomplete ul li.selected')[0].textContent;
+          }
+
+          if (selected !== '') {
+            $("input[name='ding_base_term_name']").val(selected);
+          }
+          triggerSubmit.call(form);
+        }
+      });
+
+      // Resetting "Terms" field value when switching vocabulary.
+      $("select#edit-vid").change(function () {
+        $("input[name='ding_base_term_name']").val("");
+      });
+    }
+  };
+
+})(jQuery);

--- a/modules/ding_base/js/ding_base.prevent_auto_submit.js
+++ b/modules/ding_base/js/ding_base.prevent_auto_submit.js
@@ -12,10 +12,11 @@
       $("input[name='ding_base_term_name']", context).on('change keyup', function (e) {
         if (e.type === 'change' || (e.type === 'keyup' && e.which === 13)) {
           var form = $(this).closest('form');
+          var autocomplete_value = $(form).find('#autocomplete ul li.selected');
           var selected;
 
-          if ($(form).find('#autocomplete ul li.selected').length !== 0) {
-            selected = $(form).find('#autocomplete ul li.selected')[0].textContent;
+          if (autocomplete_value.length !== 0) {
+            selected = autocomplete_value[0].textContent;
           }
 
           if (selected !== '') {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3816

#### Description

As it was requested, was added possibility to filter nodes on /content page by taxonomy terms. The taxonomy term filtration depends on selected taxonomy vocabulary filter from the same form.
New filter is realized as a textfield which will be in disabled state until taxonomy vocabulary filter is not selected. If an taxonomy vocabulary is selected, terms filter changes it's state to active and autocomplete functionality is added.

Regarding opportunity to assign taxonomies through bulk update, this is already realized in VBO actions and can be done with "Change value" action.

#### Screenshot of the result

![content-view_voc-term](https://user-images.githubusercontent.com/800338/48207263-f2917600-e378-11e8-8cb1-82cc2f3980e9.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.