### PR TITLE
3643 by Inlead: Disable the 'Pre-sending to BPI' status and update translations.

### DIFF
--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -220,7 +220,7 @@ function bpi_update_7005() {
 /**
  * Disable the 'Pre-sending to BPI' state.
  */
-function bpi_update_7006() {
+function bpi_update_7006(&$sandbox) {
   global $user;
 
   if (!isset($sandbox['processed'])) {

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -221,12 +221,69 @@ function bpi_update_7005() {
  * Disable the 'Pre-sending to BPI' state.
  */
 function bpi_update_7006() {
-  /** @var Workflow $workflow */
-  $workflow = workflow_load('bpi');
-  /** @var WorkflowState $pre_bpi_state */
-  $pre_bpi_state = $workflow->getState('pre_bpi');
-  /** @var WorkflowState $local_content_state */
-  $local_content_state = $workflow->getState('local_content');
+  global $user;
 
-  $pre_bpi_state->deactivate($local_content_state->sid);
+  if (!isset($sandbox['processed'])) {
+    /** @var Workflow $workflow */
+    $workflow = workflow_load('bpi');
+    /** @var WorkflowState $pre_bpi_state */
+    $pre_bpi_state = $workflow->getState('pre_bpi');
+    /** @var WorkflowState $local_content_state */
+    $local_content_state = $workflow->getState('local_content');
+
+    $query = db_select('node', 'n');
+    $query->join('field_data_field_bpi_workflow', 'bwf', 'n.nid = bwf.entity_id');
+    $query
+      ->fields('n', array('nid'))
+      ->condition('bwf.field_bpi_workflow_value', $pre_bpi_state->sid, '=');
+    $results = $query->execute()->fetchCol();
+
+    $sandbox['total'] = count($results);
+    $sandbox['processed'] = 0;
+    $sandbox['bpi'] = [
+      'pre_bpi_state' => $pre_bpi_state,
+      'local_content_state' => $local_content_state,
+    ];
+  }
+
+  if ($sandbox['total']) {
+    $query = db_select('node', 'n');
+    $query->join('field_data_field_bpi_workflow', 'bwf', 'n.nid = bwf.entity_id');
+    $query
+      ->fields('n', array('nid'))
+      ->condition('bwf.field_bpi_workflow_value', $sandbox['bpi']['pre_bpi_state']->sid, '=')
+      ->range($sandbox['processed'], 20);
+    $results = $query->execute()->fetchCol();
+
+    $field_name = 'field_bpi_workflow';
+    foreach ($results as $nid) {
+      $bpi_node = node_load($nid);
+      if ($bpi_node) {
+        $transition = new WorkflowTransition();
+        $transition->setValues(
+          'node',
+          $bpi_node,
+          $field_name,
+          $sandbox['bpi']['pre_bpi_state']->sid,
+          $sandbox['bpi']['local_content_state']->sid,
+          $user->uid,
+          REQUEST_TIME,
+          ''
+        );
+        $transition->save();
+
+        $bpi_node->{$field_name}[LANGUAGE_NONE][0]['value'] = $sandbox['bpi']['local_content_state']->sid;
+        field_attach_presave('node', $bpi_node);
+        field_attach_update('node', $bpi_node);
+        entity_get_controller('node')->resetCache(array($bpi_node->nid));
+      }
+
+      $sandbox['processed']++;
+    }
+
+    $sandbox['#finished'] = $sandbox['processed'] / $sandbox['total'];
+    if ($sandbox['#finished'] >= 1) {
+      $sandbox['bpi']['pre_bpi_state']->deactivate($sandbox['bpi']['local_content_state']->sid);
+    }
+  }
 }

--- a/modules/bpi/bpi.install
+++ b/modules/bpi/bpi.install
@@ -216,3 +216,17 @@ function bpi_update_7005() {
   }
   variable_set('views_defaults', $views_defaults);
 }
+
+/**
+ * Disable the 'Pre-sending to BPI' state.
+ */
+function bpi_update_7006() {
+  /** @var Workflow $workflow */
+  $workflow = workflow_load('bpi');
+  /** @var WorkflowState $pre_bpi_state */
+  $pre_bpi_state = $workflow->getState('pre_bpi');
+  /** @var WorkflowState $local_content_state */
+  $local_content_state = $workflow->getState('local_content');
+
+  $pre_bpi_state->deactivate($local_content_state->sid);
+}

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1011,7 +1011,7 @@ function bpi_features_views_default_views_alter(&$views) {
       'table' => 'views_entity_node',
       'field' => 'workflow_node',
       'label' => 'Operations',
-      'text' => 'change BPI state',
+      'text' => 'change the node status in BPI',
     );
 
     $style_options = &$display_options['style_options'];

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -400,15 +400,13 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
       array_unshift($form['#validate'], 'bpi_form_workflow_transition_form_validate');
     }
     elseif (!empty($_GET['bpi_id'])) {
-      $states = bpi_workflow_by_machine_names(array('pre_bpi', 'local_content'));
+      $states = bpi_workflow_by_machine_names(array('local_content'));
       $local_sid = $states['local_content']->sid;
-      $pre_sid = $states['pre_bpi']->sid;
 
       // Hide normal save button via css. We can't just unset it, because that
       // will result in only the normal button to be shown. That will only work
       // when removing "non-normal" buttons.
       drupal_add_css('#edit-workflow-' . $local_sid . ' { display: none; }', 'inline');
-      drupal_add_css('#edit-workflow-' . $pre_sid . ' { display: none; }', 'inline');
     }
     else {
       // Hide 'Save from BPI button'.
@@ -775,12 +773,10 @@ function bpi_form_workflow_transition_form_alter(&$form, &$form_state, $form_id)
     'sent_to_bpi',
     'deleted_bpi',
     'created_bpi',
-    'pre_bpi',
   ));
   $push_sid = $states['sent_to_bpi']->sid;
   $delete_sid = $states['deleted_bpi']->sid;
   $created_sid = $states['created_bpi']->sid;
-  $presend_sid = $states['pre_bpi']->sid;
 
   // Remove 'Save and push' button if the current state is already 'Sent to
   // BPI'. We have to do this, because it's not possible to disallow workflow
@@ -792,12 +788,6 @@ function bpi_form_workflow_transition_form_alter(&$form, &$form_state, $form_id)
   // Remove "Delete from BPI" button, when we have already deleted from BPI.
   if ($form['#default_value'] == $delete_sid) {
     unset($form['workflow']['workflow_sid']['#options'][$delete_sid]);
-  }
-
-  // Remove "Save" button (saving to same workflow state) when the node is
-  // prepared for sending to BPI.
-  if ($form['#default_value'] == $presend_sid) {
-    unset($form['workflow']['workflow_sid']['#options'][$presend_sid]);
   }
 
   // We can't get the node id directly from the form, so we get it from the

--- a/modules/bpi/bpi_features/bpi_features.features.field_base.inc
+++ b/modules/bpi/bpi_features/bpi_features.features.field_base.inc
@@ -29,7 +29,6 @@ function bpi_features_field_default_field_bases() {
       'allowed_values_function' => 'workflowfield_allowed_values',
       'allowed_values_string' => '1 | (creation)
 2 | Local content
-3 | Pre-sending to BPI
 4 | Sent to BPI
 5 | Sent, updated locally
 6 | Created from BPI

--- a/modules/bpi/bpi_features/bpi_features.features.inc
+++ b/modules/bpi/bpi_features/bpi_features.features.inc
@@ -18,7 +18,7 @@ function bpi_features_default_Workflow() {
     "states" : {
       "(creation)" : {"weight":"-50","sysid":"1","state":"(creation)","status":"1","name":"(creation)"},
       "local_content" : {"weight":"-19","sysid":"0","state":"Local content","status":"1","name":"local_content"},
-      "pre_bpi" : {"weight":"-18","sysid":"0","state":"Pre-sending to BPI","status":"1","name":"pre_bpi"},
+      "pre_bpi" : {"weight":"-18","sysid":"0","state":"Pre-sending to BPI","status":"0","name":"pre_bpi"},
       "sent_to_bpi" : {"weight":"-17","sysid":"0","state":"Sent to BPI","status":"1","name":"sent_to_bpi"},
       "sent_local" : {"weight":"-16","sysid":"0","state":"Sent, updated locally","status":"1","name":"sent_local"},
       "created_bpi" : {"weight":"-15","sysid":"0","state":"Created from BPI","status":"1","name":"created_bpi"},

--- a/modules/bpi/bpi_features/bpi_features.features.inc
+++ b/modules/bpi/bpi_features/bpi_features.features.inc
@@ -26,13 +26,9 @@ function bpi_features_default_Workflow() {
     },
     "transitions" : {
       "_creation_to_local_content" : {"roles":{"-1":-1,"3":3,"4":4,"6":6,"7":7},"name":"_creation_to_local_content","label":"Save","start_state":"(creation)","end_state":"local_content"},
-      "_creation_to_pre_bpi" : {"roles":{"3":3,"4":4,"6":6,"7":7},"name":"_creation_to_pre_bpi","label":"Save and push","start_state":"(creation)","end_state":"pre_bpi"},
       "_creation_to_created_bpi" : {"roles":{"3":3,"4":4,"6":6,"7":7},"name":"_creation_to_created_bpi","label":"Save content from BPI","start_state":"(creation)","end_state":"created_bpi"},
       "local_content_to_local_content" : {"roles":{"-1":-1,"3":3,"4":4,"6":6,"7":7},"name":"local_content_to_local_content","label":"Save","start_state":"local_content","end_state":"local_content"},
       "local_content_to_sent_to_bpi" : {"roles":{"3":3,"4":4,"6":6,"7":7},"name":"local_content_to_sent_to_bpi","label":"Save and push","start_state":"local_content","end_state":"sent_to_bpi"},
-      "pre_bpi_to_local_content" : {"roles":{"3":3,"4":4,"6":6,"7":7},"name":"pre_bpi_to_local_content","label":"Save local content","start_state":"pre_bpi","end_state":"local_content"},
-      "pre_bpi_to_pre_bpi" : {"roles":{"-1":-1,"3":3,"4":4,"6":6,"7":7},"name":"pre_bpi_to_pre_bpi","label":"Save","start_state":"pre_bpi","end_state":"pre_bpi"},
-      "pre_bpi_to_sent_to_bpi" : {"roles":{"-1":-1,"3":3,"4":4,"6":6,"7":7},"name":"pre_bpi_to_sent_to_bpi","label":"Send to BPI","start_state":"pre_bpi","end_state":"sent_to_bpi"},
       "sent_to_bpi_to_sent_to_bpi" : {"roles":{"-1":-1,"3":3,"4":4,"6":6,"7":7},"name":"sent_to_bpi_to_sent_to_bpi","label":"Save and push","start_state":"sent_to_bpi","end_state":"sent_to_bpi"},
       "sent_to_bpi_to_sent_local" : {"roles":{"3":3,"4":4,"6":6,"7":7},"name":"sent_to_bpi_to_sent_local","label":"Save","start_state":"sent_to_bpi","end_state":"sent_local"},
       "sent_to_bpi_to_deleted_bpi" : {"roles":{"-1":-1,"3":3,"6":6},"name":"sent_to_bpi_to_deleted_bpi","label":"Delete from BPI","start_state":"sent_to_bpi","end_state":"deleted_bpi"},

--- a/modules/bpi/bpi_features/bpi_features.rules_defaults.inc
+++ b/modules/bpi/bpi_features/bpi_features.rules_defaults.inc
@@ -33,17 +33,5 @@ function bpi_features_default_rules_configuration() {
       "DO" : [ { "bpi_rules_delete" : { "entity" : [ "node" ] } } ]
     }
   }');
-  $items['rules_new_content_with_save_and_push_'] = entity_import('rules_config', '{ "rules_new_content_with_save_and_push_" : {
-      "LABEL" : "New content with \\u0027Save and push\\u0027",
-      "PLUGIN" : "reaction rule",
-      "OWNER" : "rules",
-      "REQUIRES" : [ "rules" ],
-      "ON" : { "node_insert--ding_news" : { "bundle" : "ding_news" } },
-      "IF" : [
-        { "data_is" : { "data" : [ "node:field-bpi-workflow" ], "value" : "3" } }
-      ],
-      "DO" : [ { "redirect" : { "url" : "node\\/[node:nid]\\/workflow" } } ]
-    }
-  }');
   return $items;
 }

--- a/translations/da.po
+++ b/translations/da.po
@@ -10478,8 +10478,8 @@ msgid "Save content from BPI"
 msgstr "Gem indhold fra BPI"
 
 #: /index.php
-msgid "change BPI state"
-msgstr "Redigér BPI status"
+msgid "change the node status in BPI"
+msgstr "Redigér artiklens status i BPI"
 
 #: /index.php
 msgid "Workflow state"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3643

#### Description

Disable the 'Pre-sending to BPI' status. Also migrate content that might have this status to 'Local content' status instead.

#### Screenshot of the result

![screenshot from 2018-11-08 14-05-22](https://user-images.githubusercontent.com/574498/48198031-3926a680-e360-11e8-9ff1-659f6509b83e.png)

#### Checklist

- [x] My code complies with [coding guidelines](../docs/code_guidelines.md).
- [x] My code passes static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Removing the `Pre-sending to BPI` workflow state, as a result, also introduced the fact that upon new node creation the `Save and push` button is also removed. This button was linked to a Rule definition that redirected the user to the workflow page of lately created node, which is removed as well in this PR.

Overall, taking into consideration that original issue stated that this workflow status is redundant and confuses users, removal of it also brought some UX changes as well. These, however, might not fit the general requirement in the final result.