### PR TITLE
3914: Enable campaign plus as default

### DIFF
--- a/ding2.info
+++ b/ding2.info
@@ -32,6 +32,7 @@ dependencies[] = customerroralt
 
 ; Ding modules.
 dependencies[] = ding_base
+dependencies[] = ding_campaign_plus
 dependencies[] = ding_user_frontend
 dependencies[] = ding_ting_frontend
 dependencies[] = ding_frontpage

--- a/ding2.install
+++ b/ding2.install
@@ -665,3 +665,10 @@ function ding2_update_7055() {
 function ding2_update_7056() {
   module_enable(array('ding_libs'));
 }
+
+/**
+ * Enable Campaign plus module.
+ */
+function ding2_update_7057() {
+  module_enable(array('ding_campaign_plus'));
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3914

#### Description

Enables campaign plus as default.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
