### PR TITLE
3828: workmatch memory

### DIFF
--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -623,31 +623,13 @@ function opensearch_search_sort_options() {
  */
 function opensearch_search_object_ids($ids) {
   if (is_array($ids) && !empty($ids)) {
-    $translated_ids = array();
+    $translated_ids = [];
 
-    // Open search is limited to 50 results per call, so split up in chunks to
-    // ensure we get PIDs for all passed local IDs.
-    foreach (array_chunk($ids, 50) as $chunk) {
-      $query = 'rec.id any "' . implode(" ", $chunk) . '" AND facet.acSource=bibliotekskatalog';
-      // Ensure that the work match in opensearch doesn't hide ids for us.
-      $options['collectionType'] = 'manifestation';
-
-      // Ensure we have OpenSearch client.
-      module_load_include('inc', 'opensearch', 'opensearch.client');
-      $res = opensearch_do_search($query, 1, count($chunk), $options);
-
-      // Sometimes the well will be unreachable or not even one of the ids in
-      // chunk was searchable. In any case, this protects against a notice.
-      if (empty($res)) {
-        continue;
-      }
-
-      foreach ($res->collections as $pid => $collection) {
-        $faust = explode(':', $pid)[1];
-        if ($key = array_search($faust, $ids)) {
-          $translated_ids[$faust] = $pid;
-          unset($ids[$key]);
-        }
+    foreach (opensearch_get_objects($ids, TRUE) as $pid => $object) {
+      $faust = explode(':', $pid)[1];
+      if ($key = array_search($faust, $ids)) {
+        $translated_ids[$faust] = $pid;
+        unset($ids[$key]);
       }
     }
 
@@ -661,7 +643,6 @@ function opensearch_search_object_ids($ids) {
     // without holdingsitem.agencyid filter. This way the providers will know
     // which materials can be searched with the current agency id and generate
     // a link to them.
-    //
     foreach ($ids as $faust) {
       $translated_ids[$faust] = '870970-basis:' . $faust;
     }
@@ -669,9 +650,8 @@ function opensearch_search_object_ids($ids) {
     return $translated_ids;
   }
   elseif (is_numeric($ids)) {
-    module_load_include('client.inc', 'opensearch');
-    $obj = opensearch_do_search('rec.id=' . $ids . ' AND facet.acSource=bibliotekskatalog');
-    return !empty($obj) ? key($obj->collections) : '870970-basis:' . $ids;
+    $objects = opensearch_get_objects(array($ids), TRUE);
+    return !empty($objects) ? key($objects) : '870970-basis:' . $ids;
   }
   return FALSE;
 }
@@ -688,7 +668,7 @@ function opensearch_search_object_ids($ids) {
 function opensearch_search_autocomplete($string) {
   $matches = array();
   $default_settings = opensearch_search_autocomplete_settings();
-  
+
   $query['q'] = check_plain(strtolower($string));
   $query['type'] = 'all';
   $query['rows'] = $default_settings['maxSuggestions'];
@@ -718,7 +698,7 @@ function opensearch_search_autocomplete($string) {
 }
 
 /**
- * SuggestionService - retrieve suggestions with drupal_http_request() 
+ * SuggestionService - retrieve suggestions with drupal_http_request()
  *
  * @param array $query
  *   Search suggestion parameters.
@@ -738,7 +718,7 @@ function opensearch_search_autocomplete_suggestions(array $query) {
     );
     return $items;
   }
-  
+
   $url = url($rest_url, array('query' => $query));
   $headers = array('Accept' => 'application/json');
   $result = drupal_http_request($url, $headers);

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -69,6 +69,8 @@ function opensearch_get_object($object_id, $collection = FALSE, $with_relations 
  *
  * @param string[] $ids
  *   Data-well PIDs for the objects to get.
+ * @param bool $local
+ *   Flag to indicate whether $ids contains pids or local ids (fausts).
  *
  * @return bool|\TingClientSearchResult
  *   The objects fetched from the data-well.
@@ -76,7 +78,7 @@ function opensearch_get_object($object_id, $collection = FALSE, $with_relations 
  * @throws \TingClientException
  *   This may throw this exception if the search request fails.
  */
-function opensearch_get_objects(array $ids) {
+function opensearch_get_objects(array $ids, $local = FALSE) {
   $request = opensearch_get_request_factory()->getObjectRequest();
 
   // Set agency from the administration interface.
@@ -97,7 +99,12 @@ function opensearch_get_objects(array $ids) {
   // See: https://platform.dandigbib.org/issues/3828#note-16.
   $objects = [];
   foreach (array_chunk($ids, 100) as $chunk) {
-    $request->setObjectIds($chunk);
+    if ($local) {
+      $request->setLocalIds($chunk);
+    }
+    else {
+      $request->setObjectIds($chunk);
+    }
     $objects += opensearch_execute($request);
   }
 

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -78,7 +78,6 @@ function opensearch_get_object($object_id, $collection = FALSE, $with_relations 
  */
 function opensearch_get_objects(array $ids) {
   $request = opensearch_get_request_factory()->getObjectRequest();
-  $request->setObjectIds($ids);
 
   // Set agency from the administration interface.
   if ($agency = variable_get('ting_agency', FALSE)) {
@@ -91,7 +90,18 @@ function opensearch_get_objects(array $ids) {
     $request->setProfile($profile);
   }
 
-  return opensearch_execute($request);
+  // Opensearch getObject complains if it has to return more than 200 records,
+  // with the message 'getObject can fetch up to 200 records. '. But it seems
+  // it also have trouble fething over 169 records, which appears to be a bug.
+  // In any case, we should be safe, if we only fetch 100 records a time.
+  // See: https://platform.dandigbib.org/issues/3828#note-16.
+  $objects = [];
+  foreach (array_chunk($ids, 100) as $chunk) {
+    $request->setObjectIds($chunk);
+    $objects += opensearch_execute($request);
+  }
+
+  return $objects;
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3828

Related PR: https://github.com/ding2/ting-client/pull/25

#### Description

We used a special 'manifestation' search request to translate fausts to pids, but this was interfering with caching of collections, such that the manifestation would be cached as single object collections. This would result in material types getting "hidden" from users in the UI, because of these incomplete collections.

Switching to getObject request instead of search will fix this (in situations where the translation is the culprit) and is also a better solution in my opinion. 

There might still be problems with incomplete collection in other places, but this is out of scope of this PR.

Also fixes issue with get_objects, when over 169 objects are requested. See this comment for more info about this: https://platform.dandigbib.org/issues/3828#note-16

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This PR is dependant on https://github.com/ding2/ting-client/pull/25 to work correctly.
