### PR TITLE
3923: Fixed Ding news render empty materials ref

### DIFF
--- a/modules/ting_reference/ting_reference.module
+++ b/modules/ting_reference/ting_reference.module
@@ -349,10 +349,11 @@ function ting_reference_field_formatter_view($entity_type, $entity, $field, $ins
           '#view_mode' => $display['settings']['view_mode'],
         );
       }
-
-      $element['#attached']['js'] = array(
-        drupal_get_path('module', 'ting_reference') . '/js/ting_reference_ajax.js',
-      );
+      if (!empty($element)) {
+        $element['#attached']['js'] = array(
+          drupal_get_path('module', 'ting_reference') . '/js/ting_reference_ajax.js',
+        );
+      }
       break;
 
     case 'ting_reference_reverse_default':


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3923

#### Description

ting_reference default formatter attached js even when the field was empty, that causes the field to be rendered. Now the js is only attached if the field has content.
