### PR TITLE
3905: Do not retrieve online urls to determine if object is online

### DIFF
--- a/modules/ding_availability/ding_availability.field.inc
+++ b/modules/ding_availability/ding_availability.field.inc
@@ -229,7 +229,7 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
           // not always predefined online type we need to check if the entity
           // has an online URL. Please not tht that this in most cases will
           // trigger a search request with get all relations.
-          if (in_array(drupal_strtolower($type), $online_types) || $entities[0]->getOnline_url()) {
+          if (in_array(drupal_strtolower($type), $online_types) || $entities[0]->isOnline()) {
             if (!isset($output['#types']['online'])) {
               // Add label "online" to output.
               $output['#types']['online'] = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3905

#### Description

Before the search abstraction layer was introduced [the `getOnline_url()`
method accepted a boolean to determine whether to retrieve relations
for fetching online urls for an object or not](https://github.com/ding2/ding2/blob/7.x-4.2.1/modules/ting/ting.entities.inc#L289-L333). [The availability field 
Formatter was the only element which used this functionality](https://github.com/ding2/ding2/blob/7.x-4.2.1/modules/ding_availability/ding_availability.field.inc#L227) to prevent 
relations from being fetched when determining whether a material was 
online or not.

When the search abstraction layer was introduced a new method for
determining if an object is online without fetching relations was 
introduced: [`isOnline()`](https://github.com/ding2/ding2/blob/7.x-4.3.0/modules/opensearch/src/OpenSearchTingObject.php#L209-L212) and [`getOnline_url()` lost the boolean and always
fetched relations](https://github.com/ding2/ding2/blob/7.x-4.3.0/modules/opensearch/src/OpenSearchTingObject.php#L214-L243). However [the availability module was not updated
accordingly](https://github.com/ding2/ding2/blob/7.x-4.3.0/modules/ding_availability/ding_availability.field.inc#L229). Consequently display of the availability field would
always fetch relations which potentially could lead to a new search
for each object being displayed.

With an empty cache this means that performing a search leads to
a search request + requests per object.

In the context of the availability field formatter the online urls are
still not needed so we can replace the call to `getOnline_url()` with
`isOnline()` and thus prevent a lot of unneeded requests.

I have tested this change by going through the following scenario on releases 4.2.1 (the last release before the search abstraction layer was introduced), 4.3.4 (the final bugfix release after the search abstraction layer was introduced but before new features have been added) and master (~4.6.0-rc1):

1. Install Ding2 with no extra modules added
2. Monitor site using [Xdebug profiling](https://xdebug.org/docs/profiler) and [Webgrind](https://github.com/jokkedk/webgrind)
3. Clearing the site cache
4. Load the frontpage
5. Search for "Denmark" using the search field in the site header (initial search)
6. Check how many times `curl` is called (as that is the way we send requests to OpenSearch)
7. Click the search button to search for Denmark again (repeat search)
8. Check how many times `curl` is called (as that is the way we send requests to OpenSearch)

This yielded the following results:

- 4.2.1
  - Initial search: 1 request
    - 1 search request
  - Repeat search: 0 requests
- 4.3.4
  - Initial search: 11 requests
    - 1 search request
    - 10 object requests
  - Repeat search: 0 requests
- 4.6.0-rc1
  - Initial search: 10 requests
    - 1 search request
    - 9 object requests
  - Repeat search: 0 requests

Making this change for release 4.3.4 and 4.6.0-rc1 and repeating the test yields this result:

- 4.3.4
  - Initial search: 1 requests
    - 1 search request
  - Repeat search: 0 requests
- 4.6.0-rc1
  - Initial search: 2 requests
    - 1 search request
    - 1 object request
  - Repeat search: 0 requests

Note that the single object request made in release 4.6.0-rc1 is a request for multiple objects. These objects may potentially already be in the cache but at that point they have been cached with a [cache id based on the search request](https://github.com/ding2/ding2/blob/824d0584f9193a68a2e1db9ca60b3058c40cff7e/modules/opensearch/opensearch.client.inc#L535-L553). This time the request is an object request for a range of ids. This will generate different cache ids. There is already significant complexity in [preemptively predicting cache entries](https://github.com/ding2/ding2/blob/824d0584f9193a68a2e1db9ca60b3058c40cff7e/modules/opensearch/opensearch.client.inc#L430-L450). This could be expanded if we want to avoid this request. I wil leave that for a separate pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
