### PR TITLE
Core: Fix builds of PHP images on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,9 +89,9 @@ jobs:
         command: |
           sudo apt install -y libpng-dev mysql-client
           sudo -E docker-php-ext-install gd pdo_mysql
-          sudo chmod 0777 /usr/local/etc/php/conf.d
-          echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-drupal.ini
-          rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+          sudo chmod 0777 $PHP_INI_DIR/conf.d
+          echo "memory_limit = 512M" >> $PHP_INI_DIR/conf.d/docker-php-drupal.ini
+          rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
           php -i
     - run:
         name: Install Drush
@@ -138,9 +138,9 @@ jobs:
         command: |
           sudo apt install -y libpng-dev mysql-client
           sudo -E docker-php-ext-install gd pdo_mysql
-          sudo chmod 0777 /usr/local/etc/php/conf.d
-          echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-drupal.ini
-          rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+          sudo chmod 0777 $PHP_INI_DIR/conf.d
+          echo "memory_limit = 512M" >> $PHP_INI_DIR/conf.d/docker-php-drupal.ini
+          rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
           php -i
     - run:
         name: Install Drush
@@ -185,9 +185,9 @@ jobs:
         command: |
           sudo apt install -y libpng-dev mysql-client
           sudo -E docker-php-ext-install gd pdo_mysql
-          sudo chmod 0777 /usr/local/etc/php/conf.d
-          echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-drupal.ini
-          rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+          sudo chmod 0777 $PHP_INI_DIR/conf.d
+          echo "memory_limit = 512M" >> $PHP_INI_DIR/conf.d/docker-php-drupal.ini
+          rm -f $PHP_INI_DIR/conf.d/docker-php-ext-xdebug.ini
           php -i
     - run:
         name: Configure Apache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
         name: Configure PHP for Drupal
         command: |
           sudo apt install -y libpng-dev mysql-client
-          sudo docker-php-ext-install gd pdo_mysql
+          sudo -E docker-php-ext-install gd pdo_mysql
           sudo chmod 0777 /usr/local/etc/php/conf.d
           echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-drupal.ini
           rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
@@ -137,7 +137,7 @@ jobs:
         name: Configure PHP for Drupal
         command: |
           sudo apt install -y libpng-dev mysql-client
-          sudo docker-php-ext-install gd pdo_mysql
+          sudo -E docker-php-ext-install gd pdo_mysql
           sudo chmod 0777 /usr/local/etc/php/conf.d
           echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-drupal.ini
           rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
@@ -184,7 +184,7 @@ jobs:
         name: Configure PHP for Drupal
         command: |
           sudo apt install -y libpng-dev mysql-client
-          sudo docker-php-ext-install gd pdo_mysql
+          sudo -E docker-php-ext-install gd pdo_mysql
           sudo chmod 0777 /usr/local/etc/php/conf.d
           echo "memory_limit = 512M" >> /usr/local/etc/php/conf.d/docker-php-drupal.ini
           rm -f /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini


### PR DESCRIPTION
#### Link to issue

None - Core issue.

#### Description

Currently our builds fail on CircleCI when installing additional extensions with the error: `/usr/local/bin/docker-php-ext-enable: 108: /usr/local/bin/docker-php-ext-enable: cannot create /conf.d/docker-php-ext-gd.ini: Directory nonexistent`

This is caused by a change in the underlying PHP image - see also docker-library/php#750.

This change applies the suggested fix and furthermore improves our use of the `PHP_INI_DIR` environment variable which is the source of the issue.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.