### PR TITLE
3905: Cache multiple objects per collection

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -355,28 +355,48 @@ function opensearch_execute(TingClientRequest $request) {
     $request->setRelationData('full');
   }
 
-  // Build cache id for this request.
-  $cid = _opensearch_cache_id($request);
-
   // Check static cache first as this is the fasts lookup. We use the fast
   // static pattern described on drupal.org in the drupal_static
   // documentation.
   static $opensearch_static_fast = array();
-  if (array_key_exists($cid, $opensearch_static_fast)) {
-    return $opensearch_static_fast[$cid];
+
+  if ($response = _opensearch_cache_get($request, $opensearch_static_fast)) {
+    return $response;
   }
 
-  // Check the database/memcached cache for the request also check that the
-  // cache data has not expired before using it.
-  $cache = cache_get($cid, 'cache_opensearch');
-  if ($cache && ($cache->expire > REQUEST_TIME)) {
-    $data = $cache->data;
+  // If we are retrieving multiple objects then there might not be a single
+  // request for all these objects combined in the cache but they might be
+  // cached individually.
+  $cached_objects = [];
+  if ($request instanceof TingClientObjectRequest) {
+    $ids = array_combine($request->getObjectIds(), $request->getObjectIds());
 
-    // Update the static cache with the database cache content to speed up the
-    // next request for the same data.
-    $opensearch_static_fast[$cid] = $data;
+    // Try to retrieve an object for each id. Entries which does not have cached
+    // data will get the value FALSE for easy subsequent filtering.
+    $object_ids = array_map(function ($id) use ($request, $opensearch_static_fast) {
+      $object_request = clone $request;
+      $object_request->setObjectId($id);
+      if ($cached_response = _opensearch_cache_get($object_request, $opensearch_static_fast)) {
+        // A response for a single object is an array with a single object so
+        // just return the object.
+        return array_shift($cached_response);
+      }
+      else {
+        return FALSE;
+      }
+    }, $ids);
+    $cached_objects = array_filter($object_ids);
 
-    return $data;
+    // Ids that we still need to fetch will not be appearing in the list of
+    // cached objects.
+    $uncached_ids = array_diff_key($ids, $cached_objects);
+    $request->setObjectIds(array_keys($uncached_ids));
+
+    // If there are no ids to fetch then there is no need to issue a request.
+    // Just return the array of cached objects.
+    if (empty($uncached_ids)) {
+      return $cached_objects;
+    }
   }
 
   try {
@@ -392,6 +412,12 @@ function opensearch_execute(TingClientRequest $request) {
     }
 
     $response = $request->parseResponse($res);
+
+    if ($request instanceof TingClientObjectRequest) {
+      // Merge in any cached objects. The map uses ids as keys. The order does
+      // not matter for object requests.
+      $response = array_merge($cached_objects, $response);
+    }
 
     // Pass parsed results to other modules.
     $props = module_invoke_all('opensearch_post_execute', $request, $response, $res);
@@ -530,6 +556,40 @@ function _opensearch_cache_insert(TingClientRequest $request, $response, array &
   if ($ttl = variable_get('opensearch_cache_lifetime', OPENSEARCH_DEFAULT_CACHE_LIFETIME)) {
     cache_set($cid, $response, 'cache_opensearch', REQUEST_TIME + $ttl);
   }
+}
+
+/**
+ * Retrieve a earch response based on a request.
+ *
+ * @param TingClientRequest $request
+ *   The search request for which to retrieve a cached response.
+ * @param array $opensearch_static_fast
+ *   The fast static cache used by opensearch_execute().
+ *
+ * @return \TingClientSearchResult|\TingClientObjectCollection|\TingClientObject[]|NULL
+ *   The cached response. NULL if no cached entry exists.
+ */
+function _opensearch_cache_get(TingClientRequest $request, array &$opensearch_static_fast) {
+  // Build cache id for this request.
+  $cid = _opensearch_cache_id($request);
+  if (array_key_exists($cid, $opensearch_static_fast)) {
+    return $opensearch_static_fast[$cid];
+  }
+
+  // Check the database/memcached cache for the request also check that the
+  // cache data has not expired before using it.
+  $cache = cache_get($cid, 'cache_opensearch');
+  if ($cache && ($cache->expire > REQUEST_TIME)) {
+    $data = $cache->data;
+
+    // Update the static cache with the database cache content to speed up the
+    // next request for the same data.
+    $opensearch_static_fast[$cid] = $data;
+
+    return $data;
+  }
+
+  return NULL;
 }
 
 /**

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -475,8 +475,11 @@ function opensearch_execute(TingClientRequest $request) {
  */
 function _opensearch_predict_cache(array $collections, array &$opensearch_static_fast, TingClientRequest $request) {
   foreach ($collections as $collection) {
-    if (is_object($collection->objects[0])) {
-      $object = reset($collection->objects);
+    foreach ($collection->objects as $object) {
+      if (!is_object($object)) {
+        watchdog('opensearch', 'Predict cache found collection with empty objects. Search query: @query', array('@query' => $request->getQuery()), WATCHDOG_WARNING);
+        break;
+      }
 
       $collection_request = opensearch_get_request_factory()->getCollectionRequest();
       $collection_request->setAllObjects(FALSE);
@@ -530,9 +533,6 @@ function _opensearch_predict_cache(array $collections, array &$opensearch_static
       $object_response = array();
       $object_response[$object->id] = clone $object;
       _opensearch_cache_insert($object_request, $object_response, $opensearch_static_fast);
-    }
-    else {
-      watchdog('opensearch', 'Predict cache found collection with empty objects. Search query: @query', array('@query' => $request->getQuery()), WATCHDOG_WARNING);
     }
   }
 }

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -355,12 +355,8 @@ function opensearch_execute(TingClientRequest $request) {
     $request->setRelationData('full');
   }
 
-  // Check static cache first as this is the fasts lookup. We use the fast
-  // static pattern described on drupal.org in the drupal_static
-  // documentation.
-  static $opensearch_static_fast = array();
-
-  if ($response = _opensearch_cache_get($request, $opensearch_static_fast)) {
+  if ($response = _opensearch_cache($request)) {
+    // Exact match for request is found in cache. Return early.
     return $response;
   }
 
@@ -373,10 +369,10 @@ function opensearch_execute(TingClientRequest $request) {
 
     // Try to retrieve an object for each id. Entries which does not have cached
     // data will get the value FALSE for easy subsequent filtering.
-    $object_ids = array_map(function ($id) use ($request, $opensearch_static_fast) {
+    $object_ids = array_map(function ($id) use ($request) {
       $object_request = clone $request;
       $object_request->setObjectId($id);
-      if ($cached_response = _opensearch_cache_get($object_request, $opensearch_static_fast)) {
+      if ($cached_response = _opensearch_cache($object_request)) {
         // A response for a single object is an array with a single object so
         // just return the object.
         return array_shift($cached_response);
@@ -429,14 +425,14 @@ function opensearch_execute(TingClientRequest $request) {
 
     // Update the cache with the raw response object from the data well for
     // faster processing. Also set the static cache.
-    _opensearch_cache_insert($request, $response, $opensearch_static_fast);
+    _opensearch_cache($request, $response);
 
     // To speed up the entity module, which will trigger an search for each
     // collection. Try and predict the search request an warm up the cache.
     // Alternative rewrite the whole ting entity module, which currently is
     // overkill.
     if ($response instanceof TingClientSearchResult) {
-      _opensearch_predict_cache($response->collections, $opensearch_static_fast, $request);
+      _opensearch_predict_cache($response->collections, $request);
     }
 
     return $response;
@@ -465,15 +461,13 @@ function opensearch_execute(TingClientRequest $request) {
  *
  * @param array $collections
  *   The collections found in TingClientSearchResult object.
- * @param array $opensearch_static_fast
- *   The fast static cache used by opensearch_execute().
  * @param TingClientRequest $request
  *   The request used to get the collections.
  *
  * @throws \TingClientException
  *   If the search client request fails.
  */
-function _opensearch_predict_cache(array $collections, array &$opensearch_static_fast, TingClientRequest $request) {
+function _opensearch_predict_cache(array $collections, TingClientRequest $request) {
   foreach ($collections as $collection) {
     foreach ($collection->objects as $object) {
       if (!is_object($object)) {
@@ -509,7 +503,7 @@ function _opensearch_predict_cache(array $collections, array &$opensearch_static
 
       // Build the response that matches the request and put it into cache.
       $collection_response = new TingClientObjectCollection($collection->objects);
-      _opensearch_cache_insert($collection_request, $collection_response, $opensearch_static_fast);
+      _opensearch_cache($collection_request, $collection_response);
 
       $object_request = opensearch_get_request_factory()->getObjectRequest();
       $object_request->setObjectId($object->id);
@@ -532,64 +526,55 @@ function _opensearch_predict_cache(array $collections, array &$opensearch_static
       // Build the response that matches the request and put it into cache.
       $object_response = array();
       $object_response[$object->id] = clone $object;
-      _opensearch_cache_insert($object_request, $object_response, $opensearch_static_fast);
+      _opensearch_cache($object_request, $object_response);
     }
   }
 }
 
 /**
- * Insert search response based on request.
+ * Cache/retrieve from cache a search response based on a request.
  *
  * @param TingClientRequest $request
- *   The search request that gives the response.
- * @param \TingClientObject|\TingClientObjectCollection|array $response
- *   The response to the request.
- * @param array $opensearch_static_fast
- *   The fast static cache used by opensearch_execute().
- */
-function _opensearch_cache_insert(TingClientRequest $request, $response, array &$opensearch_static_fast) {
-  $cid = _opensearch_cache_id($request);
-
-  // Update the cache with the raw response object from the data well for
-  // faster processing. Also set the static cache.
-  $opensearch_static_fast[$cid] = $response;
-  if ($ttl = variable_get('opensearch_cache_lifetime', OPENSEARCH_DEFAULT_CACHE_LIFETIME)) {
-    cache_set($cid, $response, 'cache_opensearch', REQUEST_TIME + $ttl);
-  }
-}
-
-/**
- * Retrieve a earch response based on a request.
- *
- * @param TingClientRequest $request
- *   The search request for which to retrieve a cached response.
- * @param array $opensearch_static_fast
- *   The fast static cache used by opensearch_execute().
+ *   The search request for which to set/retrieve a cached response.
+ * @param \TingClientSearchResult|\TingClientObjectCollection|\TingClientObject[]|NULL $response
+ *   The response to cache. NULL to reset the cache entry for the request.
  *
  * @return \TingClientSearchResult|\TingClientObjectCollection|\TingClientObject[]|NULL
  *   The cached response. NULL if no cached entry exists.
  */
-function _opensearch_cache_get(TingClientRequest $request, array &$opensearch_static_fast) {
-  // Build cache id for this request.
+function _opensearch_cache(TingClientRequest $request, $response = NULL) {
+  static $static_cache;
   $cid = _opensearch_cache_id($request);
-  if (array_key_exists($cid, $opensearch_static_fast)) {
-    return $opensearch_static_fast[$cid];
+
+  // Count the number of arguments to determine if $value has been provided.
+  // This allows us to distinguish between situations where $value is not set
+  // and we want to retrieve the cache value and where $value is set to NULL
+  // explicitly.
+  if (func_num_args() == 2) {
+    // Update the cache with the provided value.
+    $static_cache[$cid] = $response;
+    if ($ttl = variable_get('opensearch_cache_lifetime', OPENSEARCH_DEFAULT_CACHE_LIFETIME)) {
+      cache_set($cid, $response, 'cache_opensearch', REQUEST_TIME + $ttl);
+    }
+    return $response;
   }
+  else {
+    // Try to retrieve value from cache.
+    if (array_key_exists($cid, $static_cache)) {
+      return $static_cache[$cid];
+    }
 
-  // Check the database/memcached cache for the request also check that the
-  // cache data has not expired before using it.
-  $cache = cache_get($cid, 'cache_opensearch');
-  if ($cache && ($cache->expire > REQUEST_TIME)) {
-    $data = $cache->data;
+    $cache = cache_get($cid, 'cache_opensearch');
+    if ($cache && ($cache->expire > REQUEST_TIME)) {
+      $data = $cache->data;
 
-    // Update the static cache with the database cache content to speed up the
-    // next request for the same data.
-    $opensearch_static_fast[$cid] = $data;
+      // Update the static cache with the database cache content to speed up the
+      // next request for the same data.
+      $static_cache[$cid] = $data;
 
-    return $data;
+      return $data;
+    }
   }
-
-  return NULL;
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3905

#### Description

This PR is based on the work from #1269. Only the last three commits should be considered.

OpenSearch supports retrieving many objects in a single request by
passing multiple ids.

This results in a unique request for all these ids and thus a unique
cache entry despite the fact that information for some or all of these
objects may already be cached based on individual requests.

Consequently we update our cache handling to split all object requests 
into multiple single id object requests, check each request for a
cached version and if found merge these cached responses into the
combined response.

To facilitate this cache handling is moved to single function combining
retrieval and insertion as well as static and persistent caching.

We also cache all objects in a collection when predicting cache entries.
There does not seem to be a reason to only cache the first one.

With this change displaying search results from an empty cache is reduced 
to a single request to OpenSearch.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.