### PR TITLE
3919: Changed event_teaser location markup

### DIFF
--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -258,6 +258,13 @@ function ddbasic_preprocess__node__ding_event(&$variables) {
         // Hide library from render array.
         $variables['content']['og_group_ref']['#access'] = FALSE;
       }
+      elseif ($variables['alt_location_is_set'] && empty($variables['field_ding_event_place'])) {
+        // Hide library from render array.
+        $variables['content']['og_group_ref']['#access'] = FALSE;
+        // Only show location name, so hide locality- and street from event location.
+        $variables['content']['field_ding_event_location'][0]['locality_block']['#access'] = FALSE;
+        $variables['content']['field_ding_event_location'][0]['street_block']['#access'] = FALSE;
+      }
 
       break;
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3919

#### Description

Hides library, locality_block and street_block from ding_event teaser, when no place room is entered.

#### Screenshot of the result

![screenshot 2018-11-22 at 10 38 29](https://user-images.githubusercontent.com/30495061/48894348-dc88b880-ee42-11e8-9cd9-5a4b844d4096.png)
