### PR TITLE
3573: Trying to fix webtrekk race-condition

### DIFF
--- a/modules/ding_campaign_plus/js/ding_campaign_plus_trekk.js
+++ b/modules/ding_campaign_plus/js/ding_campaign_plus_trekk.js
@@ -5,6 +5,8 @@
 (function ($) {
   'use strict';
 
+  var queue = [];
+
   // Use custom event fired when campaign is loaded to track the campaign.
   $(document).on('campaignPlusLoaded', function (event, campaignId) {
     // The global wt (webtrekk) object is only loaded on approved domains. So to
@@ -15,5 +17,24 @@
         campaignAction: 'view'
       });
     }
+    else {
+      queue.push({
+        campaignId: campaignId,
+        campaignAction: 'view'
+      });
+    }
   });
+
+  // Try to busy wait for the "wt" variable to exists in global space to push
+  // variables to webtrekk. There will always be a race-condition here and
+  // this was the best try to get around it.
+  var timer = setInterval(processQueue, 500);
+  function processQueue() {
+    if (typeof(wt) !== 'undefined') {
+      clearInterval(timer);
+      for (var i in queue) {
+        wt.sendinfo(queue[i]);
+      }
+    }
+  }
 })(jQuery);

--- a/modules/ding_content/ding_content.pages_default.inc
+++ b/modules/ding_content/ding_content.pages_default.inc
@@ -341,7 +341,14 @@ function ding_content_default_page_manager_handlers() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/modules/ding_eresource/ding_eresource.pages_default.inc
+++ b/modules/ding_eresource/ding_eresource.pages_default.inc
@@ -156,7 +156,14 @@ function ding_eresource_default_page_manager_handlers() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/modules/ding_event/ding_event.pages_default.inc
+++ b/modules/ding_event/ding_event.pages_default.inc
@@ -233,7 +233,14 @@ function ding_event_default_page_manager_handlers() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );
@@ -719,7 +726,14 @@ events
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );
@@ -1037,7 +1051,14 @@ node/%node:nid/events
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/modules/ding_frontpage/ding_frontpage.pages_default.inc
+++ b/modules/ding_frontpage/ding_frontpage.pages_default.inc
@@ -193,7 +193,14 @@ function ding_frontpage_default_page_manager_pages() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/modules/ding_groups/ding_groups.pages_default.inc
+++ b/modules/ding_groups/ding_groups.pages_default.inc
@@ -806,7 +806,14 @@ function ding_groups_default_page_manager_pages() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/modules/ding_library/ding_library.pages_default.inc
+++ b/modules/ding_library/ding_library.pages_default.inc
@@ -808,7 +808,14 @@ function ding_library_default_page_manager_pages() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/modules/ding_news/ding_news.pages_default.inc
+++ b/modules/ding_news/ding_news.pages_default.inc
@@ -448,7 +448,14 @@ function ding_news_default_page_manager_handlers() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );
@@ -693,7 +700,14 @@ taxonomy/term/%term:tid',
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );
@@ -1036,7 +1050,14 @@ news/%tid:name',
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );
@@ -1364,7 +1385,14 @@ node/%node:nid/news
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/modules/ding_page/ding_page.pages_default.inc
+++ b/modules/ding_page/ding_page.pages_default.inc
@@ -151,7 +151,14 @@ function ding_page_default_page_manager_handlers() {
       'override_title_text' => '',
       'override_title_heading' => 'h2',
     );
-    $pane->cache = array();
+    $pane->cache = array(
+      'method' => 'lazy',
+      'settings' => array(
+        'load_strategy' => 'pane-visible',
+        'show_spinner' => 1,
+        'load_text' => '',
+      ),
+    );
     $pane->style = array(
       'settings' => NULL,
     );

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--image.tpl.php
@@ -88,7 +88,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text-and-image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text-and-image.tpl.php
@@ -96,7 +96,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text-with-image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text-with-image.tpl.php
@@ -95,7 +95,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text.tpl.php
@@ -95,7 +95,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3573

#### Description

There is a race-condition between when campaigns are loaded and the tracking code from web-trekk. So this is the best take on trying to fix it for campaigns.

A very simple queue is added and when window.wt becomes available the events in the queue is pushed to webtrekk. 

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This PR have not be tested as web-trekk is not able to load on local development machines. So I did not have any way to test it.
