### PR TITLE
3957: Trying to fix webtrekk race-condition

### DIFF
--- a/modules/ding_campaign_plus/js/ding_campaign_plus_trekk.js
+++ b/modules/ding_campaign_plus/js/ding_campaign_plus_trekk.js
@@ -5,6 +5,8 @@
 (function ($) {
   'use strict';
 
+  var queue = [];
+
   // Use custom event fired when campaign is loaded to track the campaign.
   $(document).on('campaignPlusLoaded', function (event, campaignId) {
     // The global wt (webtrekk) object is only loaded on approved domains. So to
@@ -15,5 +17,24 @@
         campaignAction: 'view'
       });
     }
+    else {
+      queue.push({
+        campaignId: campaignId,
+        campaignAction: 'view'
+      });
+    }
   });
+
+  // Try to busy wait for the "wt" variable to exists in global space to push
+  // variables to webtrekk. There will always be a race-condition here and
+  // this was the best try to get around it.
+  var timer = setInterval(processQueue, 500);
+  function processQueue() {
+    if (typeof(wt) !== 'undefined') {
+      clearInterval(timer);
+      for (var i in queue) {
+        wt.sendinfo(queue[i]);
+      }
+    }
+  }
 })(jQuery);

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--image.tpl.php
@@ -88,7 +88,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text-and-image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text-and-image.tpl.php
@@ -96,7 +96,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text-with-image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text-with-image.tpl.php
@@ -95,7 +95,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text.tpl.php
@@ -95,7 +95,10 @@
   <script type="text/javascript">
     (function ($) {
       'use strict';
-      $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+
+      $(document).ready(function () {
+        $(document).trigger('campaignPlusLoaded', [ '<?php print $wt_mc_id ?>' ]);
+      });
     })(jQuery);
   </script>
 </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3573

#### Description

There is a race-condition between when campaigns are loaded and the tracking code from web-trekk. So this is the best take on trying to fix it for campaigns.

A very simple queue is added and when window.wt becomes available the events in the queue is pushed to webtrekk. 

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This PR have not be tested as web-trekk is not able to load on local development machines. So I did not have any way to test it.