### PR TITLE
3638 by Inlead: Push with images option as dropdown.

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -55,6 +55,16 @@ define('BPI_DATE_PICKER_FORMAT', 'Y-m-d');
 define('BPI_ONE_MONTH', 86400 * 30);
 
 /**
+ * Push with images identifier.
+ */
+define('BPI_WITH_IMAGES', 'with_images');
+
+/**
+ * Push without images identifier.
+ */
+define('BPI_WITHOUT_IMAGES', 'without_images');
+
+/**
  * Implements hook_menu().
  */
 function bpi_menu() {
@@ -803,6 +813,27 @@ function bpi_form_workflow_transition_form_alter(&$form, &$form_state, $form_id)
   if ($nid > 0 && $form['#default_value'] != $created_sid) {
     $form['bpi'] = bpi_http_push_action_form($nid);
     array_unshift($form['#validate'], 'bpi_form_workflow_transition_form_validate');
+  }
+}
+
+/**
+ * Validates the push with images dropdown field prior pushing content.
+ *
+ * @param array $element
+ *   The element to be validated.
+ * @param array $form_state
+ *   The form state
+ *
+ * @see bpi_http_push_action_form()
+ */
+function bpi_push_with_images_validate($element, $form_state) {
+  $allowed_values = array(
+    BPI_WITH_IMAGES,
+    BPI_WITHOUT_IMAGES
+  );
+
+  if (!in_array($form_state['values']['bpi_push_images'], $allowed_values)) {
+    form_error($element, t('Please choose an option.'));
   }
 }
 

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -822,14 +822,14 @@ function bpi_form_workflow_transition_form_alter(&$form, &$form_state, $form_id)
  * @param array $element
  *   The element to be validated.
  * @param array $form_state
- *   The form state
+ *   The form state.
  *
  * @see bpi_http_push_action_form()
  */
-function bpi_push_with_images_validate($element, $form_state) {
+function bpi_push_with_images_validate(array $element, array &$form_state) {
   $allowed_values = array(
     BPI_WITH_IMAGES,
-    BPI_WITHOUT_IMAGES
+    BPI_WITHOUT_IMAGES,
   );
 
   if (!in_array($form_state['values']['bpi_push_images'], $allowed_values)) {

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -54,10 +54,16 @@ function bpi_http_push_action_form($nid) {
   );
 
   $form['configurations']['bpi_push_images'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Push with images'),
+    '#type' => 'select',
+    '#title' => t('Push with image'),
+    '#options' => array(
+      '_none' => t('Choose'),
+      BPI_WITHOUT_IMAGES => t('Not approved for sharing'),
+      BPI_WITH_IMAGES => t('Approved for sharing'),
+    ),
     '#description' => t('You should have permission to publish the images before selecting this option.'),
-    '#default_value' => FALSE,
+    '#default_value' => '_none',
+    '#element_validate' => array('bpi_push_with_images_validate'),
   );
 
   $form['configurations']['bpi_push_refs'] = array(

--- a/modules/bpi/bpi.rules.inc
+++ b/modules/bpi/bpi.rules.inc
@@ -71,7 +71,7 @@ function bpi_rules_push($node) {
   $data = unserialize($bpi_values->data);
   $category = $data['category'];
   $audience = $data['audience'];
-  $with_images = $data['with_images'];
+  $with_images = BPI_WITH_IMAGES === $data['with_images'];
   $editable = $data['editable'];
   $with_refs = $data['with_refs'];
 

--- a/modules/bpi/translations/da.po
+++ b/modules/bpi/translations/da.po
@@ -187,9 +187,21 @@ msgstr "Kategori"
 msgid "Audience"
 msgstr "Målgruppe"
 
-#: bpi.push.inc:108;230
-msgid "Push with images"
-msgstr "Inkludér billeder"
+#: bpi.push.inc:58
+msgid "Push with image"
+msgstr "Inkludér billede"
+
+#: bpi.push.inc:60
+msgid "Choose"
+msgstr "Vælg"
+
+#: bpi.push.inc:61
+msgid "Not approved for sharing"
+msgstr "Ikke godkendt til deling"
+
+#: bpi.push.inc:62
+msgid "Approved for sharing"
+msgstr "Godkendt til deling"
 
 #: bpi.push.inc:118;240
 msgid ""

--- a/translations/da.po
+++ b/translations/da.po
@@ -45917,9 +45917,21 @@ msgstr "Det mislykkedes at hente noden fra BPI."
 msgid "Push to BPI"
 msgstr "Send til BPI"
 
-#: bpi.push.inc:108;230
-msgid "Push with images"
-msgstr "Inkludér billeder"
+#: bpi.push.inc:58
+msgid "Push with image"
+msgstr "Inkludér billede"
+
+#: bpi.push.inc:60
+msgid "Choose"
+msgstr "Vælg"
+
+#: bpi.push.inc:61
+msgid "Not approved for sharing"
+msgstr "Ikke godkendt til deling"
+
+#: bpi.push.inc:62
+msgid "Approved for sharing"
+msgstr "Godkendt til deling"
 
 #: bpi.push.inc:165
 msgid "Node %title was successfully pushed to BPI well."


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3638

#### Description

Replace checkbox with a dropdown with image pushing options prior to node push towards BPI.

#### Screenshot of the result

![screenshot from 2018-11-29 14-28-03](https://user-images.githubusercontent.com/574498/49221996-5a206b80-f3e3-11e8-8c6f-5fbbbd128c5d.png)

#### Checklist

- [x] My complies with [coding guidelines](../docs/code_guidelines.md).
- [x] My code passes static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
