### PR TITLE
153 by Inlead: Disable ability to syndicate own content.

### DIFF
--- a/modules/bpi/bpi.syndicate.inc
+++ b/modules/bpi/bpi.syndicate.inc
@@ -398,6 +398,8 @@ function bpi_preprocess_bpi_search_results(array &$variables) {
     return;
   }
 
+  $bpi_agency_id = variable_get('bpi_agency_id', '');
+
   $rows = array();
   foreach ($items as $i => $item) {
     $rows[$i]['title'] = sprintf(
@@ -444,10 +446,17 @@ function bpi_preprocess_bpi_search_results(array &$variables) {
         'admin/bpi/preview/nojs/' . $item['bpi_id'],
         array('attributes' => array('class' => 'use-ajax'))
       ),
-      l(t('Syndicate'),
-        'admin/bpi/syndicate/' . $item['bpi_id']
-      ),
     );
+
+    // No need to be able to syndicate own content.
+    // The ownership is based on agency id.
+    if ($bpi_agency_id != $item['agency_id']) {
+      $actions[] = l(
+        t('Syndicate'),
+        'admin/bpi/syndicate/' . $item['bpi_id']
+      );
+    }
+
     $rows[$i]['actions'] = implode(' ', $actions);
   }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/153

#### Description

Simply hide the `Syndicate` link in the result set for the content that has the same agency as the current bpi setup.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/574498/49224044-129cde00-f3e9-11e8-9c6e-3e75838ee36c.png)

#### Checklist

- [x] My complies with [coding guidelines](../docs/code_guidelines.md).
- [x] My code passes static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process. _Unknown reason._
