### PR TITLE
3603: Use updated jQuery version on admin theme

### DIFF
--- a/modules/ding_base/ding_base.install
+++ b/modules/ding_base/ding_base.install
@@ -77,6 +77,21 @@ function ding_base_install() {
 }
 
 /**
+ * Implements hook_update_dependencies().
+ */
+function ding_base_update_requirements() {
+  // Update hook which sets the jQuery version to use for Seven (admin theme)
+  // with jQuery Update to the site default version.
+  $dependencies['ding_base'][7006] = array(
+    // The update hook that sets the jQuery version to use for Seven
+    // to Drupal default (1.4) if no specific admin theme version has been set.
+    'jquery_update' => 7001,
+  );
+
+  return $dependencies;
+}
+
+/**
  * Restore default dates to Drupal standard.
  */
 function ding_base_update_7000() {
@@ -168,4 +183,12 @@ function ding_base_update_7005() {
     'ding_ddbasic',
     'ding_ddbasic_opening_hours',
   ));
+}
+
+/**
+ * Use default jQuery version set by jQuery Update for admin theme.
+ */
+function ding_base_update_7006() {
+  // Use the default version by setting an falsy value.
+  _jquery_update_set_theme_version('seven', '');
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3603

#### Description

We have previously updated the site default version of jQuery to
Use via JQuery Update to 3.1. The module has previously been used
to update the site to 1.7.2 and use the same version for the admin
theme.

However the migration path for the updated version of jQuery Update will
set the version to use for the admin theme to Drupal default (1.4) if no
specific version has been set.

This causes JavaScript to break as some of our code relies on updated
versions of jQuery and calls functions which are not defined in 1.4.

To fix this we run an update hook which configures the admin theme to
use the default version set by jQuery Update (3.1).

It is important that this update hook runs after jQuery Updates own
update hooks which will set the version to Drupal default (1.4).

#### Screenshot of the result

<img width="896" alt="jquery update ding2 2018-11-29 15-32-36" src="https://user-images.githubusercontent.com/73966/49228611-07977d00-f3ec-11e8-85c1-e96e0f0e39e6.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.