### PR TITLE
3905: Ensure static OpenSearch cache is always initialized

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -560,7 +560,7 @@ function _opensearch_predict_cache(array $collections, TingClientRequest $reques
  *   The cached response. NULL if no cached entry exists.
  */
 function _opensearch_cache(TingClientRequest $request, $response = NULL) {
-  static $static_cache;
+  static $static_cache = array();
   $cid = _opensearch_cache_id($request);
 
   // Count the number of arguments to determine if $value has been provided.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3905

#### Description

If it is not then we risk passing NULL to array_key_exists(). This
will issue a warning.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.