### PR TITLE
3910: Change text color. Remove redundant css

### DIFF
--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -226,7 +226,6 @@
       }
       .field-name-ting-title {
         h2 {
-          @include transition(width $speed $ease);
           @include font('display');
           width: 100%;
           margin-bottom: 4px;
@@ -234,13 +233,11 @@
         }
       }
       .field-name-ting-author {
-        @include transition(width $speed $ease);
         @include font('display-small');
         width: 100%;
-        color: $color-text-link-on-dark;
-        //margin-bottom: 15px;
+        color: $charcoal-opacity-dark;
         a:hover {
-          color: $color-text-link-on-dark;
+          color: $charcoal-opacity-dark;
         }
       }
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3910

#### Description

Text color changed on ting teasers with disabled overlay. Redundant css removed.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/22191849/49371526-04f09c80-f6f8-11e8-9cf7-ee3219f8e1bf.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No further comments.