### PR TITLE
3901: Webtrekk MWA traking

### DIFF
--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -359,10 +359,12 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
   );
 
   $form['actions_container']['actions_top']['renew_all'] = array(
-    '#type' => 'markup',
-    '#prefix' => '<div class="renew-all action-all action-button js-renew-all">',
-    '#markup' => '<a href="#">' . t('Renew all') . '</a>',
-    '#suffix' => '</div>',
+    '#type' => 'html_tag',
+    '#tag' => 'div',
+    '#value' => '<a href="#">' . t('Renew all') . '</a>',
+    '#attributes' => [
+      'class' => ['renew-all', 'action-all', 'action-button', 'js-renew-all'],
+    ],
   );
 
   return $form;

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -233,9 +233,6 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
           ),
         ),
         '#disabled' => !$loan->renewable,
-        '#attributes' => [
-          'data' => ['test'],
-        ],
       );
 
       // Add material number.

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -233,6 +233,9 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
           ),
         ),
         '#disabled' => !$loan->renewable,
+        '#attributes' => [
+          'data' => ['test'],
+        ],
       );
 
       // Add material number.

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -363,7 +363,12 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
     '#tag' => 'div',
     '#value' => '<a href="#">' . t('Renew all') . '</a>',
     '#attributes' => [
-      'class' => ['renew-all', 'action-all', 'action-button', 'js-renew-all'],
+      'class' => [
+        'renew-all',
+        'action-all',
+        'action-button',
+        'js-renew-all',
+      ],
     ],
   );
 

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -19,7 +19,6 @@
     return link + seperator + urlParameter;
   };
 
-
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
       // Attach Webtrekk events. This is the preffered to track events in ding
@@ -46,6 +45,18 @@
             });
           });
         })
+      });
+
+      // Track autocomplete selections.
+      $('.form-item-search-block-form .form-autocomplete', context)
+        .once('ding-webtrekk')
+        .on('autocompleteSelect', function(e, selected) {
+          if (($(selected).text())) {
+            wt.sendinfo({
+              type: 'e_autocomplete_search',
+              text: $(selected).text()
+            });
+          }
       });
 
       // Special handling for ding_carousel. The primary reason for this is that

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -39,6 +39,7 @@
       $('.ding-webtrekk-rating-event', context).once('ding-webtrekk', function() {
         var contentId = $(this).data('ding-entity-rating-id');
         $('.js-rating-symbol', this).each(function(index) {
+          var rating = index + 1;
           $(this).click(function() {
             wts.push(['send', 'click', {
               linkId:'Materiale rating',

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -93,14 +93,14 @@
 
         $('.slick-arrow', this).once('ding-webtrekk').click(function() {
           var linkId = 'Karousel, click på forrige knappen';
-          var clickParameter = 60;
+          var customClickParameter = { 60: carouselTitle };
           if ($(this).hasClass('slick-next')) {
             linkId = 'Karousel, click på næste knappen';
-            clickParameter = 59;
+            var customClickParameter = { 59: carouselTitle };
           }
           wts.push(['send', 'click', {
             linkId: linkId,
-            customClickParameter: { clickParameter: carouselTitle }
+            customClickParameter: customClickParameter
           }]);
         });
       });

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -63,6 +63,24 @@
           }
       });
 
+      // Track ding loan renew selected events. The renew all button is attached
+      // completely on the server, but for renew selected, we need information
+      // about selected loans in the UI, before we send event.
+      $('.ding-webtrekk-event-renew-selected', context)
+        .once('ding-webtrekk')
+        .click(function(e) {
+          var selectedMaterials = [];
+          $('.material-item input[type=checkbox]:checked').each(function() {
+            // We have collected the material ids (pids) in our event data
+            // attribute for each select box.
+            selectedMaterials.push($(this).data('ding-webtrekk-event'));
+          });
+          wts.push(['send', 'click', {
+            linkId: 'Forny valgte materialer',
+            customClickParameter: { 55: selectedMaterials.join(';') }
+          }]);
+      });
+
       // Special handling for ding_carousel. The primary reason for this is that
       // we need the title of the carousel to pass as value in event and URL-
       // parameter. For tabbed carousels the title of the individuals carousels

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -22,7 +22,10 @@
 
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
-      // Attach Webtrekk events.
+      // Attach Webtrekk events. This is the preffered to track events in ding
+      // webtrekk. Modules can alter elements in the backend and add the class
+      // 'ding-webtrekk-event' to enable event traking for that element. Event
+      // data is expected to be passed in the data attribute on the element.
       $('.ding-webtrekk-event', context).once('ding-webtrekk').click(function() {
         wt.sendinfo($(this).data('ding-webtrekk-event'));
       });

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -69,6 +69,14 @@
       $('.ding-webtrekk-event-renew-selected', context)
         .once('ding-webtrekk')
         .click(function(e) {
+          // The renew-all button is implemented by checking all renewable loans
+          // and then trigger a click on the renew-selected button. We can use
+          // this jQuere marker to ensure we don't send two events in this case.
+          // See: https://stackoverflow.com/a/10704256
+          if (e.isTrigger) {
+            return;
+          }
+
           var selectedMaterials = [];
           $('.material-item input[type=checkbox]:checked').each(function() {
             // We have collected the material ids (pids) in our event data

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -13,6 +13,14 @@
 
   "use strict";
 
+  // Webtrekk tracking parameters.
+  var DING_WEBTREKK_PARAMETER_AUTOCOMPLETE = 54;
+  var DING_WEBTREKK_PARAMETER_RENEW_SELECTED = 55;
+  var DING_WEBTREKK_PARAMETER_RENEW_RATING_ID = 57;
+  var DING_WEBTREKK_PARAMETER_RENEW_RATING = 58;
+  var DING_WEBTREKK_PARAMETER_CAROUSEL_NEXT = 59;
+  var DING_WEBTREKK_PARAMETER_CAROUSEL_PREV = 60;
+
   var appendQueryParameter = function(url, key, value) {
     var seperator = (url.indexOf('?') !== -1) ? '&' : '?';
     var urlParameter = key + '=' + encodeURIComponent(value);
@@ -41,8 +49,8 @@
             wts.push(['send', 'click', {
               linkId: 'Materiale rating',
               customClickParameter: {
-                58: rating,
-                57: contentId
+                DING_WEBTREKK_PARAMETER_RENEW_RATING: rating,
+                DING_WEBTREKK_PARAMETER_RENEW_RATING_ID: contentId
               }
             }]);
           });
@@ -54,9 +62,12 @@
         .once('js-ding-webtrekk')
         .on('autocompleteSelect', function(e, selected) {
           if (($(selected).text())) {
+            console.log($(selected).text());
             wts.push(['send', 'click', {
               linkId: 'Autocomplete søgning clicks',
-              customClickParameter: { 54: $(selected).text() }
+              customClickParameter: {
+                DING_WEBTREKK_PARAMETER_AUTOCOMPLETE: $(selected).text()
+              }
             }]);
           }
       });
@@ -84,7 +95,9 @@
           });
           wts.push(['send', 'click', {
             linkId: 'Forny valgte materialer',
-            customClickParameter: { 55: selectedMaterials.join(';') }
+            customClickParameter: {
+              DING_WEBTREKK_PARAMETER_RENEW_SELECTED: selectedMaterials.join(';')
+            }
           }]);
       });
 
@@ -119,10 +132,14 @@
 
         $('.slick-arrow', this).once('js-ding-webtrekk').click(function() {
           var linkId = 'Karousel, click på forrige knappen';
-          var customClickParameter = { 60: carouselTitle };
+          var customClickParameter = {
+            DING_WEBTREKK_PARAMETER_CAROUSEL_PREV: carouselTitle
+          };
           if ($(this).hasClass('slick-next')) {
             linkId = 'Karousel, click på næste knappen';
-            customClickParameter = { 59: carouselTitle };
+            customClickParameter = {
+              DING_WEBTREKK_PARAMETER_CAROUSEL_NEXT: carouselTitle
+            };
           }
           wts.push(['send', 'click', {
             linkId: linkId,

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -71,9 +71,8 @@
         .click(function(e) {
           // The renew-all button is implemented by checking all renewable loans
           // and then trigger a click on the renew-selected button. We can use
-          // this jQuere marker to ensure we don't send two events in this case.
-          // See: https://stackoverflow.com/a/10704256
-          if (e.isTrigger) {
+          // originalEvent to check for this.
+          if (e.originalEvent === undefined) {
             return;
           }
 

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -26,7 +26,9 @@
       // 'ding-webtrekk-event' to enable event traking for that element. Event
       // data is expected to be passed in the data attribute on the element.
       $('.ding-webtrekk-event', context).once('ding-webtrekk').click(function() {
-        wt.sendinfo($(this).data('ding-webtrekk-event'));
+        var eventData = $(this).data('ding-webtrekk-event');
+        console.log(eventData);
+        wts.push(['send', 'click', eventData]);
       });
 
       // Secial handling for ding entity rating event. It would require a
@@ -38,11 +40,10 @@
         var contentId = $(this).data('ding-entity-rating-id');
         $('.js-rating-symbol', this).each(function(index) {
           $(this).click(function() {
-            wt.sendinfo({
-              type: 'e_materialrate',
-              contentId: contentId,
-              rating: ++index
-            });
+            wts.push(['send', 'click', {
+              linkId:'Materiale rating',
+              customClickParameter: { 58: contentId + ';' + rating }
+            }]);
           });
         })
       });
@@ -52,10 +53,10 @@
         .once('ding-webtrekk')
         .on('autocompleteSelect', function(e, selected) {
           if (($(selected).text())) {
-            wt.sendinfo({
-              type: 'e_autocomplete_search',
-              text: $(selected).text()
-            });
+            wts.push(['send', 'click', {
+              linkId: 'Autocomplete søgning clicks',
+              customClickParameter: { 54: $(selected).text() }
+            }]);
           }
       });
 
@@ -90,14 +91,16 @@
         });
 
         $('.slick-arrow', this).once('ding-webtrekk').click(function() {
-          var type = 'e_carousel_previous_click';
+          var linkId = 'Karousel, click på forrige knappen';
+          var clickParameter = 60;
           if ($(this).hasClass('slick-next')) {
-            type = 'e_carousel_next_click';
+            linkId = 'Karousel, click på næste knappen';
+            clickParameter = 59;
           }
-          wt.sendinfo({
-            type: type,
-            carouselTitle: carouselTitle
-          });
+          wts.push(['send', 'click', {
+            linkId: linkId,
+            customClickParameter: { clickParameter: carouselTitle }
+          }]);
         });
       });
     }

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -1,0 +1,56 @@
+/**
+ * @file
+ * Handles webtrekk tracking in the client.
+ *
+ * Some user interactions that we want to track doesn't result in a page load.
+ * These interactions are tracked here with Webtrekk events in the client.
+ *
+ * URL-parametes are used when we want to track relations. For example, was this
+ * ting object view triggered by a link in a carousel? We prefer to attach these
+ * parameters on the server, but in some cases this gets very complicated. For
+ * example, all the object links in a carousel are not loaded all at once on the
+ * page load, but is instead lazy loaded dynamically when the users uses the
+ * carousel. In such cases, it's much easier to add the URL-parameters in
+ * javascript on the client.
+ */
+
+(function($) {
+
+  "use strict"
+
+  var appendQueryParameter = function(link, key, value) {
+    var seperator = (link.indexOf('?') != -1) ? '&' : '?';
+    var urlParameter = key + '=' + encodeURIComponent(value);
+    return link + seperator + urlParameter;
+  };
+
+
+  Drupal.behaviors.ding_webtrekk = {
+    attach: function(context) {
+      var key = 'u_navigatedby';
+      // Tabbed carousels: each tab is a carousel with a title that we will use
+      // for the value of the URL parameter.
+      $('.ding-tabbed-carousel .ding-carousel').each(function() {
+        var value = 'tabbed-carousel:' + $(this).data('title');
+
+        $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('ding_webtrekk', function() {
+          $(this).attr('href', appendQueryParameter($(this).attr('href'), key, value));
+        });
+      });
+
+      // Handle single non-tabbed carousels.
+      $('.ding-carousel').each(function() {
+        var carouselTitle = $(this).parent().siblings('.pane-title');
+        // Carousels are lazy loaded, so we might not find something at first.
+        if (carouselTitle.length) {
+          var value = carouselTitle.html();
+
+          $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('ding_webtrekk', function() {
+            $(this).attr('href', appendQueryParameter($(this).attr('href'), key, value));
+          });
+        }
+      });
+    }
+  };
+
+})(jQuery);

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -27,7 +27,6 @@
       // data is expected to be passed in the data attribute on the element.
       $('.ding-webtrekk-event', context).once('ding-webtrekk').click(function() {
         var eventData = $(this).data('ding-webtrekk-event');
-        console.log(eventData);
         wts.push(['send', 'click', eventData]);
       });
 
@@ -96,7 +95,7 @@
           var customClickParameter = { 60: carouselTitle };
           if ($(this).hasClass('slick-next')) {
             linkId = 'Karousel, click på næste knappen';
-            var customClickParameter = { 59: carouselTitle };
+            customClickParameter = { 59: carouselTitle };
           }
           wts.push(['send', 'click', {
             linkId: linkId,

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -64,7 +64,7 @@
 
           $('.slick-arrow', this).once('ding-webtrekk').click(function() {
             var type = 'e_carousel_previous_click';
-            if ($(this).hassClass('slick-next')) {
+            if ($(this).hasClass('slick-next')) {
               type = 'e_carousel_next_click';
             }
             wt.sendinfo({

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -11,7 +11,7 @@
 
 (function($) {
 
-  "use strict"
+  "use strict";
 
   var appendQueryParameter = function(link, key, value) {
     var seperator = (link.indexOf('?') !== -1) ? '&' : '?';

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -13,16 +13,16 @@
 
   "use strict";
 
-  var appendQueryParameter = function(link, key, value) {
-    var seperator = (link.indexOf('?') !== -1) ? '&' : '?';
+  var appendQueryParameter = function(url, key, value) {
+    var seperator = (url.indexOf('?') !== -1) ? '&' : '?';
     var urlParameter = key + '=' + encodeURIComponent(value);
-    return link + seperator + urlParameter;
+    return url + seperator + urlParameter;
   };
 
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
       // Send Webtrekk events attached in the backend.
-      $('.ding-webtrekk-event', context).once('ding-webtrekk').click(function() {
+      $('.js-ding-webtrekk-event', context).once('js-ding-webtrekk').click(function() {
         var eventData = $(this).data('ding-webtrekk-event');
         wts.push(['send', 'click', eventData]);
       });
@@ -33,13 +33,13 @@
       // theme hook to avoid this. It doesn't provide the ability to add custom
       // attributes/classes in preprocess and is not using using render arrays
       // for rating elements, making them problematic to modify.
-      $('.ding-webtrekk-rating-event', context).once('ding-webtrekk', function() {
+      $('.js-ding-webtrekk-rating-event', context).once('js-ding-webtrekk', function() {
         var contentId = $(this).data('ding-entity-rating-id');
         $('.js-rating-symbol', this).each(function(index) {
           var rating = (index + 1) + '';
           $(this).click(function() {
             wts.push(['send', 'click', {
-              linkId:'Materiale rating',
+              linkId: 'Materiale rating',
               customClickParameter: {
                 58: rating,
                 57: contentId
@@ -51,7 +51,7 @@
 
       // Track autocomplete selections.
       $('.form-item-search-block-form .form-autocomplete', context)
-        .once('ding-webtrekk')
+        .once('js-ding-webtrekk')
         .on('autocompleteSelect', function(e, selected) {
           if (($(selected).text())) {
             wts.push(['send', 'click', {
@@ -66,8 +66,8 @@
       // The renew all button is attached completely on the server, but for
       // renew selected, we need information about selected loans in the UI,
       // before we send event.
-      $('.ding-webtrekk-event-renew-selected', context)
-        .once('ding-webtrekk')
+      $('.js-ding-webtrekk-event-renew-selected', context)
+        .once('js-ding-webtrekk')
         .click(function(e) {
           // The renew-all button is implemented by checking all renewable loans
           // and then trigger a click on the renew-selected button. We can use
@@ -100,13 +100,11 @@
       // and easily change the content tree to add event and URL-parameters to
       // elements (content is already rendered when hook is run).
       $('.ding-carousel').each(function() {
-        var carouselTitle = false;
         var key = 'u_navigatedby';
-
         // We need a title to send as value in the 'u_navigatedby' parameter, so
         // if we can't find a carousel title we will just have to fallback to
         // this generic one.
-        carouselTitle = 'unknown_carousel';
+        var carouselTitle = 'unknown_carousel';
 
         if ($(this).data('title')) {
           carouselTitle = $(this).data('title');
@@ -116,11 +114,11 @@
         }
 
         // Add tracking URL-pararmeters to items in the carousel.
-        $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('ding-webtrekk', function() {
+        $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('js-ding-webtrekk', function() {
           $(this).attr('href', appendQueryParameter($(this).attr('href'), key, carouselTitle));
         });
 
-        $('.slick-arrow', this).once('ding-webtrekk').click(function() {
+        $('.slick-arrow', this).once('js-ding-webtrekk').click(function() {
           var linkId = 'Karousel, click på forrige knappen';
           var customClickParameter = { 60: carouselTitle };
           if ($(this).hasClass('slick-next')) {

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -38,7 +38,7 @@
       $('.ding-webtrekk-rating-event', context).once('ding-webtrekk', function() {
         var contentId = $(this).data('ding-entity-rating-id');
         $('.js-rating-symbol', this).each(function(index) {
-          var rating = index + 1;
+          var rating = (index + 1) + '';
           $(this).click(function() {
             wts.push(['send', 'click', {
               linkId:'Materiale rating',

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -28,7 +28,7 @@
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
       // Attach Webtrekk events.
-      $('.ding-webtrekk-event', context).once('ding_webtrekk').on('click touchstart', function() {
+      $('.ding-webtrekk-event', context).once('ding_webtrekk').click(function() {
         var eventData = $(this).data('ding-webtrekk-event');
         wt.sendinfo(eventData);
       });

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -14,7 +14,7 @@
   "use strict"
 
   var appendQueryParameter = function(link, key, value) {
-    var seperator = (link.indexOf('?') != -1) ? '&' : '?';
+    var seperator = (link.indexOf('?') !== -1) ? '&' : '?';
     var urlParameter = key + '=' + encodeURIComponent(value);
     return link + seperator + urlParameter;
   };

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -28,9 +28,24 @@
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
       // Attach Webtrekk events.
-      $('.ding-webtrekk-event', context).once('ding_webtrekk').click(function() {
-        var eventData = $(this).data('ding-webtrekk-event');
-        wt.sendinfo(eventData);
+      $('.ding-webtrekk-event', context).once('ding-webtrekk').click(function() {
+        wt.sendinfo($(this).data('ding-webtrekk-event'));
+      });
+
+      // Unfortunately we need special handling for ding entity rating event. It
+      // would require a complete rework of the ding_entity_rating_display theme
+      // hook to avoid this.
+      $('.ding-webtrekk-rating-event', context).once('ding-webtrekk', function() {
+        var contentId = $(this).data('ding-entity-rating-id');
+        $('.js-rating-symbol', this).each(function(index) {
+          $(this).click(function() {
+            wt.sendinfo({
+              type: 'e_materialrate',
+              contentId: contentId,
+              rating: ++index
+            });
+          });
+        })
       });
 
       // Attach URL parameters.
@@ -40,7 +55,7 @@
       $('.ding-tabbed-carousel .ding-carousel').each(function() {
         var value = 'tabbed-carousel:' + $(this).data('title');
 
-        $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('ding_webtrekk', function() {
+        $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('ding-webtrekk', function() {
           $(this).attr('href', appendQueryParameter($(this).attr('href'), key, value));
         });
       });
@@ -52,7 +67,7 @@
         if (carouselTitle.length) {
           var value = carouselTitle.html();
 
-          $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('ding_webtrekk', function() {
+          $('.ding-carousel-item .ting-object a[href^="/ting/object/"]', this).once('ding-webtrekk', function() {
             $(this).attr('href', appendQueryParameter($(this).attr('href'), key, value));
           });
         }

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -21,20 +21,18 @@
 
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
-      // Attach Webtrekk events. This is the preffered to track events in ding
-      // webtrekk. Modules can alter elements in the backend and add the class
-      // 'ding-webtrekk-event' to enable event traking for that element. Event
-      // data is expected to be passed in the data attribute on the element.
+      // Send Webtrekk events attached in the backend.
       $('.ding-webtrekk-event', context).once('ding-webtrekk').click(function() {
         var eventData = $(this).data('ding-webtrekk-event');
         wts.push(['send', 'click', eventData]);
       });
 
-      // Secial handling for ding entity rating event. It would require a
-      // complete rework of the ding_entity_rating_display theme hook to avoid
-      // this. It doesn't provide the ability to add custom attributes/classes
-      // in preprocess and is not using using render arrays for the rating
-      // elements, making it really hard to do anything with them.
+      // Secial handling for ding entity rating event.
+      //
+      // It would require a complete rework of the ding_entity_rating_display
+      // theme hook to avoid this. It doesn't provide the ability to add custom
+      // attributes/classes in preprocess and is not using using render arrays
+      // for rating elements, making them problematic to modify.
       $('.ding-webtrekk-rating-event', context).once('ding-webtrekk', function() {
         var contentId = $(this).data('ding-entity-rating-id');
         $('.js-rating-symbol', this).each(function(index) {
@@ -63,9 +61,11 @@
           }
       });
 
-      // Track ding loan renew selected events. The renew all button is attached
-      // completely on the server, but for renew selected, we need information
-      // about selected loans in the UI, before we send event.
+      // Track ding loan renew selected events.
+      //
+      // The renew all button is attached completely on the server, but for
+      // renew selected, we need information about selected loans in the UI,
+      // before we send event.
       $('.ding-webtrekk-event-renew-selected', context)
         .once('ding-webtrekk')
         .click(function(e) {
@@ -81,15 +81,16 @@
           }]);
       });
 
-      // Special handling for ding_carousel. The primary reason for this is that
-      // we need the title of the carousel to pass as value in event and URL-
-      // parameter. For tabbed carousels the title of the individuals carousels
-      // in the tabs are set in the data-title attribute of the carousels. For
-      // single carousels the title is not avialable here, but instead it's
-      // controlled by the configuration on the panel pane. There are no panel
-      // hooks where we can get the title and easily change the content tree to
-      // add event and URL-parameters to elements (content is already rendered
-      // when hook is run).
+      // Special handling for ding_carousel.
+      //
+      // The primary reason for this is that we need the title of the carousel
+      // to pass as value in event and URL-parameter. For tabbed carousels the
+      // title of the individuals carousels in the tabs are set in the
+      // data-title attribute of the carousels. For single carousels the title
+      // is not avialable here, but instead it's controlled by the configuration
+      // on the panel pane. There are no panel hooks where we can get the title
+      // and easily change the content tree to add event and URL-parameters to
+      // elements (content is already rendered when hook is run).
       $('.ding-carousel').each(function() {
         var carouselTitle = false;
         var key = 'u_navigatedby';

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -27,6 +27,13 @@
 
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
+      // Attach Webtrekk events.
+      $('.ding-webtrekk-event', context).once('ding_webtrekk').on('click touchstart', function() {
+        var eventData = $(this).data('ding-webtrekk-event');
+        wt.sendinfo(eventData);
+      });
+
+      // Attach URL parameters.
       var key = 'u_navigatedby';
       // Tabbed carousels: each tab is a carousel with a title that we will use
       // for the value of the URL parameter.

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -111,6 +111,9 @@
       // on the panel pane. There are no panel hooks where we can get the title
       // and easily change the content tree to add event and URL-parameters to
       // elements (content is already rendered when hook is run).
+      // Note that 'once' and 'context' is left out intentionally in the outer
+      // most selector. This is because items in the carousel are lazy loaded
+      // and we want to make sure the selector applies when new items is added.
       $('.ding-carousel').each(function() {
         var key = 'u_navigatedby';
         // We need a title to send as value in the 'u_navigatedby' parameter, so

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -42,7 +42,10 @@
           $(this).click(function() {
             wts.push(['send', 'click', {
               linkId:'Materiale rating',
-              customClickParameter: { 58: contentId + ';' + rating }
+              customClickParameter: {
+                58: rating,
+                57: contentId
+              }
             }]);
           });
         })

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -46,11 +46,11 @@
               }
             }]);
           });
-        })
+        });
       });
 
       // Track autocomplete selections.
-      $('.form-item-search-block-form .form-autocomplete', context)
+      $('.js-ding-webtrekk-autocomplete .form-autocomplete', context)
         .once('js-ding-webtrekk')
         .on('autocompleteSelect', function(e, selected) {
           if (($(selected).text())) {

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -233,11 +233,13 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
   }
 
   // Ding loan stores the loans in the this form element and we take advantage
-  // of that to get the material ids for the event data.
+  // of that to get the material ids for the renewable loans.
   $loans = $form['items']['#value'];
   $material_ids = [];
   foreach ($loans as $loan) {
-    $material_ids[] = $loan->getEntity()->getId();
+    if ($loan->renewable) {
+      $material_ids[] = $loan->getEntity()->getId();
+    }
   }
   $material_ids = implode(';', $material_ids);
 

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -50,6 +50,22 @@ function ding_webtrekk_page_alter(&$page) {
     ],
   ];
 
+  // Add page parameter that tracks whether the user is logged in, and if logged
+  // in; what login provider was used.
+  if (user_is_logged_in()) {
+    $params = [];
+    // Note that this separation of logged in users might be problematic if some
+    // pages are also cached for authenticated users.
+    if (module_exists('ding_gatewayf') && _ding_gatewayf_is_logged_in_with_gatewayf()) {
+      $params['p_isloggedin'] = 'NemId';
+    }
+    // Fallback to cpr+pin if none the modules we know about was used to log in.
+    else {
+      $params['p_isloggedin'] = 'cpr+pinkode';
+    }
+    ding_webtrekk_add_page_parameters($params);
+  }
+
   // Track ting search results. We take advantage of the fact that ting_search
   // module stores the result in a static variable when search is triggered via
   // search_data() function from core search module. Since this is not tied to

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -176,17 +176,26 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
   // Look for at reserve button on this ding entity and setup a Webtrekk event
   // if present. These could be added in every view_mode and page.
   if (isset($entity->content['ding_entity_buttons'])) {
-    $delta = element_children($entity->content['ding_entity_buttons']);
-    $delta = reset($delta);
-    foreach ($entity->content['ding_entity_buttons'][$delta] as $key => &$button) {
-      if (isset($button['#path']) && $button['#path'] == $entity_path . '/reserve') {
-        $button['#options']['attributes']['class'][] = 'ding-webtrekk-event';
-        $event_data = [];
-        $event_data['type'] = 'reservation';
-        $event_data['pid'] = $entity->getId();
-        $event_data = json_encode($event_data);
-        $button['#options']['attributes']['data-ding-webtrekk-event'] = $event_data;
-        break;
+    foreach (element_children($entity->content['ding_entity_buttons']) as $delta) {
+      foreach ($entity->content['ding_entity_buttons'][$delta] as $key => &$button) {
+        // Reserve button.
+        if (isset($button['#path']) && $button['#path'] == $entity_path . '/reserve') {
+          $button['#options']['attributes']['class'][] = 'ding-webtrekk-event';
+          $event_data = json_encode([
+            'type' => 'e_reserver',
+            'pid' => $entity->getId(),
+          ]);
+          $button['#options']['attributes']['data-ding-webtrekk-event'] = $event_data;
+        }
+        // See online button.
+        elseif (isset($button['#attributes']) && in_array('button-see-online', $button['#attributes']['class'])) {
+          $button['#attributes']['class'][] = 'ding-webtrekk-event';
+          $event_data = json_encode([
+            'type' => 'e_online',
+            'pid' => $entity->getId(),
+          ]);
+          $button['#attributes']['data-ding-webtrekk-event'] = $event_data;
+        }
       }
     }
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -94,7 +94,7 @@ function ding_webtrekk_page_alter(&$page) {
       // seems to be more reliable than looking on the filters added to the
       // search request object.
       if (!empty($_GET['facets']) && is_array($_GET['facets'])) {
-        $params['p_s_Facets'] = implode(',', $_GET['facets']);
+        $params['p_s_Facets'] = implode(';', $_GET['facets']);
       }
 
       // Track the page of the search result.
@@ -127,8 +127,6 @@ function ding_webtrekk_page_alter(&$page) {
       }
     }
   }
-
-
 
   if (!empty($params)) {
     ding_webtrekk_add_page_parameters($params);

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -96,12 +96,17 @@ function ding_webtrekk_page_alter(&$page) {
         'OSSr' => $search_result->getNumTotalObjects(),
       ];
 
-      // We want to track facets that users have added themselves from the UI.
-      // Looking for the special URL parameter that is added in these cases
-      // seems to be more reliable than looking on the filters added to the
-      // search request object.
-      if (!empty($_GET['facets']) && is_array($_GET['facets'])) {
-        $params['p_s_Facets'] = implode(';', $_GET['facets']);
+      // Track filters used in the search request. They are called facets, since
+      // for opensearch these will be search facet filters, selected by the user
+      // in the UI.
+      if (!empty($search_result->getSearchRequest()->getFilters())) {
+        $filters = [];
+        foreach ($search_result->getSearchRequest()->getFilters() as $filter) {
+          foreach ($filter->getStatements() as $statement) {
+            $filters[] = $statement->getName() . ':' . $statement->getValue();
+          }
+        }
+        $params['p_s_Facets'] = implode(';', $filters);
       }
 
       // Track the page of the search result.

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -51,10 +51,10 @@ function ding_webtrekk_page_alter(&$page) {
         'option: {}
       };' . $tag_integration_logic,
       'type' => 'inline',
-      // Use the JS_LIBRARY group to add script at the top of head. Use -21 for
-      // weight to ensure it's added below the Page parameters which has -22.
-      // The weights are set above -20 to get it above core jQuery library,
-      // which is added with the weight -20.
+      // We want the webtrekk loader as high as possible in the HTML-head, as
+      // recommended in the implementation guidelines. We therefore use the
+      // JS_LIBRARY group and choose a weight lower than the weights in
+      // system_library().
       // See: ding_webtrekk_preprocess_html().
       // See: system_library().
       'group' => JS_LIBRARY,
@@ -194,7 +194,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       'p_mat_indexno' => $entity->getClassification(),
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
-      'p_mat_category' => implode(';', $entity->reply->getGenre()),
+      'p_mat_category' => implode(';', $entity->getTingObject()->getGenre()),
     ];
     ding_webtrekk_add_page_parameters($params);
   }
@@ -291,6 +291,13 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
 
 /**
  * Use this function to attach webtrekk events to an elements attribute array.
+ *
+ * @param array $attributes
+ *   Attributes array of the element that needs event attached.
+ * @param string $link_id
+ *   The link ID of the event. For example 'Forny alle materialer'.
+ * @param array $data
+ *   The parameter values for the event keyed by the Webtrekk parameter ID.
  */
 function ding_webtrekk_attach_event(&$attributes, $link_id, $data) {
   $event_data = [

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -76,6 +76,16 @@ function ding_webtrekk_page_alter(&$page) {
         'OSS' => $search_result->getSearchRequest()->getFullTextQuery(),
         'OSSr' => $search_result->getNumTotalObjects(),
       ];
+
+      // We want to track facets that users have added themselves from the UI.
+      // Looking for the special URL parameter that is added in these cases
+      // seems to be more reliable than looking on the filters added to the
+      // search request object.
+      if (!empty($_GET['facets'])) {
+        $facets = $_GET['facets'];
+        $test = $facets;
+      }
+
       ding_webtrekk_add_page_parameters($params);
     }
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -32,11 +32,6 @@ function ding_webtrekk_page_alter(&$page) {
     return;
   }
 
-  $params = [
-    'pageTitle' => drupal_get_title(),
-  ];
-  ding_webtrekk_add_page_parameters($params);
-
   // @codingStandardsIgnoreStart
   $tag_integration_logic = '/** start TagIntegration loader  */
 (function(c,d,a,f){c.wts=c.wts||[];var g=function(b){var a="";b.customDomain&&b.customPath?a=b.customDomain+"/"+b.customPath:b.tiDomain&&b.tiId&&(a=b.tiDomain+"/resp/api/get/"+b.tiId+"?url="+encodeURIComponent(c.location.href)+"&v=5");if(b.option)for(var d in b.option)a+="&"+d+"="+encodeURIComponent(b.option[d]);return a};if(-1===d.cookie.indexOf("wt_r=1")){var e=d.getElementsByTagName(a)[0];a=d.createElement(a);a.async=!0;a.onload=function(){if("undefined"!==typeof c.wt_r&&!isNaN(c.wt_r)){var b=new Date,a=b.getTime()+1E3*parseInt(c.wt_r);b.setTime(a);d.cookie="wt_r=1;path=/;expires="+b.toUTCString()}};a.onerror=function(){"undefined"!==typeof c.wt_mcp_hide&&"function"===typeof c.wt_mcp_hide.show&&(c.wt_mcp_hide.show(),c.wt_mcp_hide.show=function(){})};a.src="//"+g(f);e.parentNode.insertBefore(a,e)}})(window,document,"script",_tiConfig);
@@ -62,7 +57,6 @@ function ding_webtrekk_page_alter(&$page) {
   if (strpos(current_path(), 'search/ting') === 0) {
     if ($search_result = ting_search_current_results()) {
       $params = [
-        'pageTitle' => 'Search ting',
         'OSS' => $search_result->getSearchRequest()->getFullTextQuery(),
         'OSSr' => $search_result->getNumTotalObjects(),
       ];
@@ -92,7 +86,6 @@ function ding_webtrekk_views_post_execute(&$view) {
     $params = [
       'internalSearch' => array_shift($view->args),
       'numberSearchResults' => $view->total_rows,
-      'pageTitle' => 'Search content',
     ];
 
     ding_webtrekk_add_page_parameters($params);

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -201,21 +201,19 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       foreach ($entity->content['ding_entity_buttons'][$delta] as $key => &$button) {
         // Reserve button.
         if (isset($button['#path']) && $button['#path'] == $entity_path . '/reserve') {
-          $button['#options']['attributes']['class'][] = 'js-ding-webtrekk-event';
-          $event_data = json_encode([
-            'linkId' => 'Reserver',
-            'customClickParameter' => [50 => $entity->getId()],
-          ]);
-          $button['#options']['attributes']['data-ding-webtrekk-event'] = $event_data;
+          ding_webtrekk_attach_event(
+            $button['#options']['attributes'],
+            'Reserver',
+            [50 => $entity->getId()]
+          );
         }
         // See online button.
         elseif (isset($button['#attributes']) && in_array('button-see-online', $button['#attributes']['class'])) {
-          $button['#attributes']['class'][] = 'js-ding-webtrekk-event';
-          $event_data = json_encode([
-            'linkId' => 'Se online',
-            'customClickParameter' => [51 => $entity->getId()],
-          ]);
-          $button['#attributes']['data-ding-webtrekk-event'] = $event_data;
+          ding_webtrekk_attach_event(
+            $button['#attributes'],
+            'Se online',
+            [51 => $entity->getId()]
+          );
         }
       }
     }
@@ -253,14 +251,11 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
 
   // The renew all button is straight forward. We can attach the event in
   // backend and just pass all renewable ids to the event data attribute.
-  $renew_all = &$form['actions_container']['actions_top']['renew_all'];
-  $renew_all['#attributes']['class'][] = 'js-ding-webtrekk-event';
-  $renew_all['#attributes']['data-ding-webtrekk-event'] = json_encode([
-    'linkId' => 'Forny alle materialer',
-    'customClickParameter' => [
-      56 => implode(';', $material_ids),
-    ],
-  ]);
+  ding_webtrekk_attach_event(
+    $form['actions_container']['actions_top']['renew_all']['#attributes'],
+    'Forny alle materialer',
+    [56 => implode(';', $material_ids)]
+  );
 
   // The renew selected button is more complicated, since we need data about
   // which materials the user has selected in the UI.
@@ -280,6 +275,18 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
       }
     }
   }
+}
+
+/**
+ * Use this function to attach webtrekk events to an elements attribute array.
+ */
+function ding_webtrekk_attach_event(&$attributes, $link_id, $data) {
+  $event_data = [
+    'linkId' => $link_id,
+    'customClickParameter' => $data,
+  ];
+  $attributes['class'][] = 'js-ding-webtrekk-event';
+  $attributes['data-ding-webtrekk-event'] = json_encode($event_data);
 }
 
 /**

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -61,11 +61,21 @@ function ding_webtrekk_page_alter(&$page) {
     // pages are also cached for authenticated users.
     if (module_exists('ding_gatewayf') && _ding_gatewayf_is_logged_in_with_gatewayf()) {
       $params['p_isloggedin'] = 'NemId';
+
+      // This is the landing page for successful user registration with gatewayf.
+      // If the registration was successful, the users will be automatically
+      // logged in. So by also requiring a logged in user before setting parameter
+      // we reduce the chances of false positives. For example, it will prevent
+      // random access to the URL from anonymous users, from being tracked.
+      if (strpos(current_path(), DING_GATEWAYF_REGISTRATION_SUCCESS_URL) === 0) {
+        $params['p_usercreate'] = 'NemId';
+      }
     }
     // Fallback to cpr+pin if none the modules we know about was used to log in.
     else {
       $params['p_isloggedin'] = 'cpr+pinkode';
     }
+
   }
 
   // Track ting search results. We take advantage of the fact that ting_search
@@ -117,6 +127,8 @@ function ding_webtrekk_page_alter(&$page) {
       }
     }
   }
+
+
 
   if (!empty($params)) {
     ding_webtrekk_add_page_parameters($params);

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -179,6 +179,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       'p_mat_indexno' => $entity->getClassification(),
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
+      'p_mat_category' => implode(';', $entity->reply->getGenre()),
     ];
     ding_webtrekk_add_page_parameters($params);
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -159,19 +159,37 @@ function ding_webtrekk_views_post_execute(&$view) {
  * Implements hook_ding_entity_view().
  */
 function ding_webtrekk_ding_entity_view($entity, $view_mode) {
-  // We're adding page parameters to material view, so we need to make sure this
-  // is the entity being viewed in full display mode.
-  if ($view_mode != 'full' && current_path() != entity_uri('ting_object', $entity)) {
-    return;
+  $entity_path = entity_uri('ting_object', $entity)['path'];
+
+  // The page parametes for the ting object view should only be added on the
+  // full page view for the material.
+  if ($view_mode == 'full' && current_path() == $entity_path) {
+    $params = [
+      'p_mat_type' => $entity->getType(),
+      'p_mat_indexno' => $entity->getClassification(),
+      'p_mat_lang' => $entity->getLanguage(),
+      'p_mat_source' => $entity->getAc_source(),
+    ];
+    ding_webtrekk_add_page_parameters($params);
   }
 
-  $params = [
-    'p_mat_type' => $entity->getType(),
-    'p_mat_indexno' => $entity->getClassification(),
-    'p_mat_lang' => $entity->getLanguage(),
-    'p_mat_source' => $entity->getAc_source(),
-  ];
-  ding_webtrekk_add_page_parameters($params);
+  // Look for at reserve button on this ding entity and setup a Webtrekk event
+  // if present. These could be added in every view_mode and page.
+  if (isset($entity->content['ding_entity_buttons'])) {
+    $delta = element_children($entity->content['ding_entity_buttons']);
+    $delta = reset($delta);
+    foreach ($entity->content['ding_entity_buttons'][$delta] as $key => &$button) {
+      if (isset($button['#path']) && $button['#path'] == $entity_path . '/reserve') {
+        $button['#options']['attributes']['class'][] = 'ding-webtrekk-event';
+        $event_data = [];
+        $event_data['type'] = 'reservation';
+        $event_data['pid'] = $entity->getId();
+        $event_data = json_encode($event_data);
+        $button['#options']['attributes']['data-ding-webtrekk-event'] = $event_data;
+        break;
+      }
+    }
+  }
 }
 
 /**

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -183,7 +183,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
           $button['#options']['attributes']['class'][] = 'ding-webtrekk-event';
           $event_data = json_encode([
             'type' => 'e_reserver',
-            'pid' => $entity->getId(),
+            'contentId' => $entity->getId(),
           ]);
           $button['#options']['attributes']['data-ding-webtrekk-event'] = $event_data;
         }
@@ -192,13 +192,20 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
           $button['#attributes']['class'][] = 'ding-webtrekk-event';
           $event_data = json_encode([
             'type' => 'e_online',
-            'pid' => $entity->getId(),
+            'contentId' => $entity->getId(),
           ]);
           $button['#attributes']['data-ding-webtrekk-event'] = $event_data;
         }
       }
     }
   }
+}
+
+/**
+ * Implements hook_preprocess_ding_entity_rating_display().
+ */
+function ding_webtrekk_preprocess_ding_entity_rating_display(&$variables) {
+  $variables['classes_array'][] = 'ding-webtrekk-rating-event';
 }
 
 /**

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -107,6 +107,14 @@ function ding_webtrekk_page_alter(&$page) {
           }
         }
       }
+
+      // Track the ting_field_search profile used in the request. Is the module
+      // enablet and is extended search with profiles activated?
+      if (module_exists('ting_field_search') && variable_get('ting_field_search_search_style', FALSE)) {
+        if ($profile = ting_field_search_get_active_profile()) {
+          $params['p_OSSprofile'] = $profile->name;
+        }
+      }
     }
   }
 

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -88,6 +88,24 @@ function ding_webtrekk_page_alter(&$page) {
       // Track the page of the search result.
       $params['p_s_Page'] = $search_result->getSearchRequest()->getPage();
 
+      // Track the sort used in the search request.
+      if (!empty(ting_search_current_results()->getSearchRequest()->getSorts())) {
+        $current_sort = $search_result->getSearchRequest()->getSorts()[0];
+        $params['p_s_Sort'] = ting_search_sort_key_from_sort($current_sort);
+      }
+      else {
+        $default_sort = variable_get('ting_search_default_sort', '');
+        // If empty string the default "sort" is ranking. If search provider is
+        // opensearch we know how to get the actual ranking used. If not we will
+        // use a generic 'rank' value for the parameter.
+        if ($default_sort === '') {
+          $params['p_s_Sort'] = 'rank';
+          if (ding_provider_get_provider_module_name('search') === 'opensearch') {
+            $params['p_s_Sort'] = variable_get('opensearch_sort_default', 'rank_frequency');
+          }
+        }
+      }
+
       ding_webtrekk_add_page_parameters($params);
     }
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -238,24 +238,39 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
   $material_ids = [];
   foreach ($loans as $loan) {
     if ($loan->renewable) {
-      $material_ids[] = $loan->getEntity()->getId();
+      $material_ids[$loan->id] = $loan->getEntity()->getId();
     }
   }
-  $material_ids = implode(';', $material_ids);
 
+  // The renew all button is straight forward. We can attach the event in
+  // backend and just pass all renewable ids to the event data attribute.
   $renew_all = &$form['actions_container']['actions_top']['renew_all'];
   $renew_all['#attributes']['class'][] = 'ding-webtrekk-event';
   $renew_all['#attributes']['data-ding-webtrekk-event'] = json_encode([
     'linkId' => 'Forny alle materialer',
-    'customClickParameter' => [56 => $material_ids],
+    'customClickParameter' => [
+      56 => implode(';', $material_ids),
+    ],
   ]);
 
+  // The renew selected button is more complicated, since we need data about
+  // which materials the user has selected in the UI.
   $renew_selected = &$form['actions_container']['actions_top']['submit_first'];
-  $renew_selected['#attributes']['class'][] = 'ding-webtrekk-event';
-  $renew_selected['#attributes']['data-ding-webtrekk-event'] = json_encode([
-    'linkId' => 'Forny valgte materialer',
-    'customClickParameter' => [55 => $material_ids]
-  ]);
+  $renew_selected['#attributes']['class'][] = 'ding-webtrekk-event-renew-selected';
+  $groups = _ding_loan_loans_group_loans_by_date($loans);
+  foreach ($groups as $gid => $group) {
+    foreach ($form['loans'][$gid] as $key => &$material_item) {
+      // Skip the title element.
+      if ($key === 'title') {
+        continue;
+      }
+      // For all other elements, the key will be a loan id and we pass it to the
+      // client if it's in our renewable list.
+      if (isset($material_ids[$key])) {
+        $material_item['#attributes']['data-ding-webtrekk-event']= $material_ids[$key];
+      }
+    }
+  }
 }
 
 /**

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -46,6 +46,12 @@ function ding_webtrekk_page_alter(&$page) {
         'option: {}
       };' . $tag_integration_logic,
       'type' => 'inline',
+      // Use the JS_LIBRARY group to add script at the top of head. Use -21 for
+      // weight to ensure it's added below the Page parameters which has -22.
+      // The weights are set above -20 to get it above core jQuery library,
+      // which is added with the weight -20.
+      // See: ding_webtrekk_preprocess_html().
+      // See: system_library().
       'group' => JS_LIBRARY,
       'weight' => -21,
     ],
@@ -107,12 +113,10 @@ function ding_webtrekk_page_alter(&$page) {
         $params['p_s_Sort'] = ting_search_sort_key_from_sort($current_sort);
       }
       else {
-        $default_sort = variable_get('ting_search_default_sort', '');
-        // If empty string the default "sort" is ranking. If search provider is
-        // opensearch we know how to get the actual ranking used. If not we will
-        // use a generic 'rank' value for the parameter.
-        if ($default_sort === '') {
-          $params['p_s_Sort'] = 'rank';
+        $params['p_s_Sort'] = variable_get('ting_search_default_sort', 'rank');
+        // If search provider is opensearch we know how to get the actual
+        // ranking used. If not the value 'rank' will need to do.
+        if ($params['p_s_Sort'] === 'rank') {
           if (ding_provider_get_provider_module_name('search') === 'opensearch') {
             $params['p_s_Sort'] = variable_get('opensearch_sort_default', 'rank_frequency');
           }
@@ -192,7 +196,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       foreach ($entity->content['ding_entity_buttons'][$delta] as $key => &$button) {
         // Reserve button.
         if (isset($button['#path']) && $button['#path'] == $entity_path . '/reserve') {
-          $button['#options']['attributes']['class'][] = 'ding-webtrekk-event';
+          $button['#options']['attributes']['class'][] = 'js-ding-webtrekk-event';
           $event_data = json_encode([
             'linkId' => 'Reserver',
             'customClickParameter' => [50 => $entity->getId()],
@@ -201,7 +205,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
         }
         // See online button.
         elseif (isset($button['#attributes']) && in_array('button-see-online', $button['#attributes']['class'])) {
-          $button['#attributes']['class'][] = 'ding-webtrekk-event';
+          $button['#attributes']['class'][] = 'js-ding-webtrekk-event';
           $event_data = json_encode([
             'linkId' => 'Se online',
             'customClickParameter' => [51 => $entity->getId()],
@@ -217,7 +221,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
  * Implements hook_preprocess_ding_entity_rating_display().
  */
 function ding_webtrekk_preprocess_ding_entity_rating_display(&$variables) {
-  $variables['classes_array'][] = 'ding-webtrekk-rating-event';
+  $variables['classes_array'][] = 'js-ding-webtrekk-rating-event';
 }
 
 /**
@@ -245,7 +249,7 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
   // The renew all button is straight forward. We can attach the event in
   // backend and just pass all renewable ids to the event data attribute.
   $renew_all = &$form['actions_container']['actions_top']['renew_all'];
-  $renew_all['#attributes']['class'][] = 'ding-webtrekk-event';
+  $renew_all['#attributes']['class'][] = 'js-ding-webtrekk-event';
   $renew_all['#attributes']['data-ding-webtrekk-event'] = json_encode([
     'linkId' => 'Forny alle materialer',
     'customClickParameter' => [
@@ -256,7 +260,7 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
   // The renew selected button is more complicated, since we need data about
   // which materials the user has selected in the UI.
   $renew_selected = &$form['actions_container']['actions_top']['submit_first'];
-  $renew_selected['#attributes']['class'][] = 'ding-webtrekk-event-renew-selected';
+  $renew_selected['#attributes']['class'][] = 'js-ding-webtrekk-event-renew-selected';
   $groups = _ding_loan_loans_group_loans_by_date($loans);
   foreach ($groups as $gid => $group) {
     foreach ($form['loans'][$gid] as $key => &$material_item) {
@@ -329,6 +333,9 @@ function ding_webtrekk_preprocess_html() {
   $script = implode(";\n", $script_lines);
   drupal_add_js($script, [
     'type' => 'inline',
+    // Use the JS_LIBRARY group to add script at the top of head. Use -22 weight
+    // to ensure it's added above the Webtrekk loader which has -21.
+    // See: ding_webtrekk_page_alter()
     'group' => JS_LIBRARY,
     'weight' => -22,
   ]);

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -209,6 +209,31 @@ function ding_webtrekk_preprocess_ding_entity_rating_display(&$variables) {
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ *
+ * Attached Webtrekk events to the renew loan buttons.
+ */
+function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
+  // We'll only attach the renew events if there's loans that can be renewed.
+  // Ding loan form checks this and only sets this element if that's the case.
+  if (isset($form['actions_container']['select_all'])) {
+    return;
+  }
+
+  $renew_all = &$form['actions_container']['actions_top']['renew_all'];
+  $renew_all['#attributes']['class'][] = 'ding-webtrekk-event';
+  $renew_all['#attributes']['data-ding-webtrekk-event'] = json_encode([
+    'type' => 'e_forny_alle_materialer',
+  ]);
+
+  $renew_selected = &$form['actions_container']['actions_top']['submit_first'];
+  $renew_selected['#attributes']['class'][] = 'ding-webtrekk-event';
+  $renew_selected['#attributes']['data-ding-webtrekk-event'] = json_encode([
+    'type' => 'e_forny_valgte_materialer',
+  ]);
+}
+
+/**
  * Adds Webtrekk page parameters to the current page.
  *
  * @see ding_webtrekk_preprocess_html().

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -50,10 +50,13 @@ function ding_webtrekk_page_alter(&$page) {
     ],
   ];
 
-  // Add page parameter that tracks whether the user is logged in, and if logged
-  // in; what login provider was used.
+  // Here we collect and add the general page parameters that aren't dependant
+  // on data and timing from a specific hook implementation.
+  $params = [];
+
+  // Tracks whether the user is logged in and, if logged in, what login provider
+  // was used.
   if (user_is_logged_in()) {
-    $params = [];
     // Note that this separation of logged in users might be problematic if some
     // pages are also cached for authenticated users.
     if (module_exists('ding_gatewayf') && _ding_gatewayf_is_logged_in_with_gatewayf()) {
@@ -63,7 +66,6 @@ function ding_webtrekk_page_alter(&$page) {
     else {
       $params['p_isloggedin'] = 'cpr+pinkode';
     }
-    ding_webtrekk_add_page_parameters($params);
   }
 
   // Track ting search results. We take advantage of the fact that ting_search
@@ -72,7 +74,7 @@ function ding_webtrekk_page_alter(&$page) {
   // any path, we also check current_path().
   if (strpos(current_path(), 'search/ting') === 0) {
     if ($search_result = ting_search_current_results()) {
-      $params = [
+      $params += [
         'OSS' => $search_result->getSearchRequest()->getFullTextQuery(),
         'OSSr' => $search_result->getNumTotalObjects(),
       ];
@@ -105,9 +107,11 @@ function ding_webtrekk_page_alter(&$page) {
           }
         }
       }
-
-      ding_webtrekk_add_page_parameters($params);
     }
+  }
+
+  if (!empty($params)) {
+    ding_webtrekk_add_page_parameters($params);
   }
 }
 

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -194,8 +194,8 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
         if (isset($button['#path']) && $button['#path'] == $entity_path . '/reserve') {
           $button['#options']['attributes']['class'][] = 'ding-webtrekk-event';
           $event_data = json_encode([
-            'type' => 'e_reserver',
-            'contentId' => $entity->getId(),
+            'linkId' => 'Reserver',
+            'customClickParameter' => [50 => $entity->getId()],
           ]);
           $button['#options']['attributes']['data-ding-webtrekk-event'] = $event_data;
         }
@@ -203,8 +203,8 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
         elseif (isset($button['#attributes']) && in_array('button-see-online', $button['#attributes']['class'])) {
           $button['#attributes']['class'][] = 'ding-webtrekk-event';
           $event_data = json_encode([
-            'type' => 'e_online',
-            'contentId' => $entity->getId(),
+            'linkId' => 'Se online',
+            'customClickParameter' => [51 => $entity->getId()],
           ]);
           $button['#attributes']['data-ding-webtrekk-event'] = $event_data;
         }
@@ -228,20 +228,31 @@ function ding_webtrekk_preprocess_ding_entity_rating_display(&$variables) {
 function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
   // We'll only attach the renew events if there's loans that can be renewed.
   // Ding loan form checks this and only sets this element if that's the case.
-  if (isset($form['actions_container']['select_all'])) {
+  if (!isset($form['actions_container']['select_all'])) {
     return;
   }
+
+  // Ding loan stores the loans in the this form element and we take advantage
+  // of that to get the material ids for the event data.
+  $loans = $form['items']['#value'];
+  $material_ids = [];
+  foreach ($loans as $loan) {
+    $material_ids[] = $loan->getEntity()->getId();
+  }
+  $material_ids = implode(';', $material_ids);
 
   $renew_all = &$form['actions_container']['actions_top']['renew_all'];
   $renew_all['#attributes']['class'][] = 'ding-webtrekk-event';
   $renew_all['#attributes']['data-ding-webtrekk-event'] = json_encode([
-    'type' => 'e_forny_alle_materialer',
+    'linkId' => 'Forny alle materialer',
+    'customClickParameter' => [56 => $material_ids],
   ]);
 
   $renew_selected = &$form['actions_container']['actions_top']['submit_first'];
   $renew_selected['#attributes']['class'][] = 'ding-webtrekk-event';
   $renew_selected['#attributes']['data-ding-webtrekk-event'] = json_encode([
-    'type' => 'e_forny_valgte_materialer',
+    'linkId' => 'Forny valgte materialer',
+    'customClickParameter' => [55 => $material_ids]
   ]);
 }
 

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -35,7 +35,7 @@ function ding_webtrekk_page_alter(&$page) {
   $params = [
     'pageTitle' => drupal_get_title(),
   ];
-  _ding_webtrekk_set_data_layer_values($params);
+  ding_webtrekk_add_page_parameters($params);
 
   // @codingStandardsIgnoreStart
   $tag_integration_logic = '/** start TagIntegration loader  */
@@ -66,7 +66,7 @@ function ding_webtrekk_page_alter(&$page) {
         'OSS' => $search_result->getSearchRequest()->getFullTextQuery(),
         'OSSr' => $search_result->getNumTotalObjects(),
       ];
-      _ding_webtrekk_set_data_layer_values($params);
+      ding_webtrekk_add_page_parameters($params);
     }
   }
 }
@@ -95,30 +95,54 @@ function ding_webtrekk_views_post_execute(&$view) {
       'pageTitle' => 'Search content',
     ];
 
-    _ding_webtrekk_set_data_layer_values($params);
+    ding_webtrekk_add_page_parameters($params);
   }
 }
 
 /**
- * Pass Tag Information variables to the inline js script.
+ * Adds Webtrekk page parameters to the current page.
  *
- * @param array $value_map
- *   Key, value collection of parameters to be considered.
+ * @see ding_webtrekk_preprocess_html().
  */
-function _ding_webtrekk_set_data_layer_values(array $value_map) {
-  $hook = 'ding_webtrekk_set_data_layer_values';
-  $modules = module_implements($hook);
-  foreach ($modules as $module) {
-    if (function_exists($module . '_' . $hook)) {
-      $params[] = module_invoke($module, $hook);
-    }
+function ding_webtrekk_add_page_parameters(array $parameters = NULL) {
+  $stored_parameters = &drupal_static(__FUNCTION__, array());
+
+  if (isset($parameters)) {
+    $stored_parameters = array_merge($stored_parameters, $parameters);
   }
 
+  return $stored_parameters;
+}
+
+/**
+ * Returns all the Webtrekk page parameteres collected during the request.
+ *
+ * @see ding_webtrekk_preprocess_html().
+ */
+function ding_webtrekk_get_page_parameters() {
+  $parameters = ding_webtrekk_add_page_parameters();
+  // Give other modules a last chance to alter the webtrekk page parameters
+  // before they are added to the current page load.
+  drupal_alter('ding_webtrekk_page_parameters', $parameters);
+  return $parameters;
+}
+
+/**
+ * Implements hook_process_html().
+ *
+ * If any Webtrekk page parameters was stored during the request, we'll apply
+ * them here. We use this hook since it's run late in the request.
+ */
+function ding_webtrekk_preprocess_html() {
+  $parameters = ding_webtrekk_get_page_parameters();
+
   $script_lines = array_map(function($key, $value) {
-    if ($value) {
+    // We require a non-empty value but would also like to track values such as
+    // 0 and '0'. For example if there was 0 search results.
+    if (!empty($value) || (string) $value === '0') {
       return "window._ti['$key'] = '$value'";
     }
-  }, array_keys($value_map), $value_map);
+  }, array_keys($parameters), $parameters);
 
   // Remove empty values.
   $script_lines = array_filter($script_lines);

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -85,6 +85,9 @@ function ding_webtrekk_page_alter(&$page) {
         $params['p_s_Facets'] = implode(',', $_GET['facets']);
       }
 
+      // Track the page of the search result.
+      $params['p_s_Page'] = $search_result->getSearchRequest()->getPage();
+
       ding_webtrekk_add_page_parameters($params);
     }
   }
@@ -112,6 +115,11 @@ function ding_webtrekk_views_post_execute(&$view) {
       'internalSearch' => array_shift($view->args),
       'numberSearchResults' => $view->total_rows,
     ];
+
+    // If using views pager; track the current search result page here also.
+    if (isset($view->query->pager->current_page)) {
+      $params['p_s_Page'] = ++$view->query->pager->current_page;
+    }
 
     ding_webtrekk_add_page_parameters($params);
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -46,7 +46,8 @@ function ding_webtrekk_page_alter(&$page) {
         'option: {}
       };' . $tag_integration_logic,
       'type' => 'inline',
-      'scope' => 'footer',
+      'group' =>  JS_LIBRARY,
+      'weight' => -21,
     ],
   ];
 
@@ -300,6 +301,8 @@ function ding_webtrekk_preprocess_html() {
   $script = implode(";\n", $script_lines);
   drupal_add_js($script, [
     'type' => 'inline',
+    'group' => JS_LIBRARY,
+    'weight' => -22,
   ]);
 
   // Add script that tracks Webtrekk events in client and adds URL parameters

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -152,8 +152,8 @@ function ding_webtrekk_views_post_execute(&$view) {
     $loaded = TRUE;
 
     $params = [
-      'internalSearch' => array_shift($view->args),
-      'numberSearchResults' => $view->total_rows,
+      'OSS' => array_shift($view->args),
+      'OSSr' => $view->total_rows,
     ];
 
     // If using views pager; track the current search result page here also.

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -4,6 +4,11 @@
  * Include basic hooks for the module functionality.
  */
 
+// Constants for Webtrekk tracking parameters.
+define('DING_WEBTREKK_PARAMETER_RESERVE', 50);
+define('DING_WEBTREKK_PARAMETER_SEE_ONLINE', 51);
+define('DING_WEBTREKK_PARAMETER_RENEW_ALL', 56);
+
 /**
  * Implements hook_menu().
  */
@@ -204,7 +209,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
           ding_webtrekk_attach_event(
             $button['#options']['attributes'],
             'Reserver',
-            [50 => $entity->getId()]
+            [DING_WEBTREKK_PARAMETER_RESERVE => $entity->getId()]
           );
         }
         // See online button.
@@ -212,7 +217,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
           ding_webtrekk_attach_event(
             $button['#attributes'],
             'Se online',
-            [51 => $entity->getId()]
+            [DING_WEBTREKK_PARAMETER_SEE_ONLINE => $entity->getId()]
           );
         }
       }
@@ -261,7 +266,7 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
   ding_webtrekk_attach_event(
     $form['actions_container']['actions_top']['renew_all']['#attributes'],
     'Forny alle materialer',
-    [56 => implode(';', $material_ids)]
+    [DING_WEBTREKK_PARAMETER_RENEW_ALL => implode(';', $material_ids)]
   );
 
   // The renew selected button is more complicated, since we need data about

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -221,6 +221,13 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function ding_webtrekk_form_search_block_form_alter(&$form, &$form_state) {
+  $form['#attributes']['class'][] = 'js-ding-webtrekk-autocomplete';
+}
+
+/**
  * Implements hook_preprocess_ding_entity_rating_display().
  */
 function ding_webtrekk_preprocess_ding_entity_rating_display(&$variables) {

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -156,6 +156,25 @@ function ding_webtrekk_views_post_execute(&$view) {
 }
 
 /**
+ * Implements hook_ding_entity_view().
+ */
+function ding_webtrekk_ding_entity_view($entity, $view_mode) {
+  // We're adding page parameters to material view, so we need to make sure this
+  // is the entity being viewed in full display mode.
+  if ($view_mode != 'full' && current_path() != entity_uri('ting_object', $entity)) {
+    return;
+  }
+
+  $params = [
+    'p_mat_type' => $entity->getType(),
+    'p_mat_indexno' => $entity->getClassification(),
+    'p_mat_lang' => $entity->getLanguage(),
+    'p_mat_source' => $entity->getAc_source(),
+  ];
+  ding_webtrekk_add_page_parameters($params);
+}
+
+/**
  * Adds Webtrekk page parameters to the current page.
  *
  * @see ding_webtrekk_preprocess_html().

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -81,9 +81,8 @@ function ding_webtrekk_page_alter(&$page) {
       // Looking for the special URL parameter that is added in these cases
       // seems to be more reliable than looking on the filters added to the
       // search request object.
-      if (!empty($_GET['facets'])) {
-        $facets = $_GET['facets'];
-        $test = $facets;
+      if (!empty($_GET['facets']) && is_array($_GET['facets'])) {
+        $params['p_s_Facets'] = implode(',', $_GET['facets']);
       }
 
       ding_webtrekk_add_page_parameters($params);

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -212,4 +212,10 @@ function ding_webtrekk_preprocess_html() {
   drupal_add_js($script, [
     'type' => 'inline',
   ]);
+
+  // Add script that tracks Webtrekk events in client and adds URL parameters
+  // to elements which is problematic to handle on the server.
+  drupal_add_js(drupal_get_path('module', 'ding_webtrekk') . '/ding_webtrekk.js', array(
+    'scope' => 'footer'
+  ));
 }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -46,7 +46,7 @@ function ding_webtrekk_page_alter(&$page) {
         'option: {}
       };' . $tag_integration_logic,
       'type' => 'inline',
-      'group' =>  JS_LIBRARY,
+      'group' => JS_LIBRARY,
       'weight' => -21,
     ],
   ];
@@ -259,7 +259,7 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
 /**
  * Adds Webtrekk page parameters to the current page.
  *
- * @see ding_webtrekk_preprocess_html().
+ * @see ding_webtrekk_preprocess_html()
  */
 function ding_webtrekk_add_page_parameters(array $parameters = NULL) {
   $stored_parameters = &drupal_static(__FUNCTION__, array());
@@ -274,7 +274,7 @@ function ding_webtrekk_add_page_parameters(array $parameters = NULL) {
 /**
  * Returns all the Webtrekk page parameteres collected during the request.
  *
- * @see ding_webtrekk_preprocess_html().
+ * @see ding_webtrekk_preprocess_html()
  */
 function ding_webtrekk_get_page_parameters() {
   $parameters = ding_webtrekk_add_page_parameters();
@@ -319,6 +319,6 @@ function ding_webtrekk_preprocess_html() {
   // Add script that tracks Webtrekk events in client and adds URL parameters
   // to elements which is problematic to handle on the server.
   drupal_add_js(drupal_get_path('module', 'ding_webtrekk') . '/ding_webtrekk.js', array(
-    'scope' => 'footer'
+    'scope' => 'footer',
   ));
 }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -267,7 +267,7 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
       // For all other elements, the key will be a loan id and we pass it to the
       // client if it's in our renewable list.
       if (isset($material_ids[$key])) {
-        $material_item['#attributes']['data-ding-webtrekk-event']= $material_ids[$key];
+        $material_item['#attributes']['data-ding-webtrekk-event'] = $material_ids[$key];
       }
     }
   }

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -388,15 +388,19 @@ function ting_ding_entity_buttons($type, $entity, $view_mode, $widget = 'default
       $settings = variable_get('ting_url_labels', _ting_default_url_labels());
       $type = drupal_strtolower($entity->type);
       $label = isset($settings[$type]) && $settings[$type] ? $settings[$type] : $settings['_default'];
-      $buttons[] = array(
-        // The link can't use l() as it will encode the url from ting_proxy. Use
-        // get online as the dc:identifier in $entity->online is not always the
-        // correct url.
-        array(
-          '#type' => 'markup',
-          '#markup' => '<a class="button-see-online action-button" target="_new" href="' . $entity->getOnline_url() . '">' . $label . '</a>',
-        ),
-      );
+      // The link can't use l() as it will encode the url from ting_proxy. Use
+      // get online as the dc:identifier in $entity->online is not always the
+      // correct url.
+      $buttons[] = [
+        '#type' => 'html_tag',
+        '#tag' => 'a',
+        '#value' => $label,
+        '#attributes' => [
+          'class' => ['button-see-online', 'action-button'],
+          'href' => $entity->getOnline_url(),
+          'target' => '_new',
+        ],
+      ];
     }
 
     // Loading collection (specially on empty cache is expensive). So only load


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3901

#### Description

In this PR the tracking capabilities of ding_webtrekk is extended to include several new Most Wanted Actions (MWAs) like reservation, rating, carousel click etc. The implementation follows the guidelines for parameter names and values from following spreadsheet, which also lists all the tracking that is added in this PR (those marked with "Skal implementeres"):

[Webtrekk 20171128 - MWA list](https://docs.google.com/spreadsheets/d/1OdUWGQc_hiY8F6BPViKRrBykSQfHLnhv4-YMdUzswSI/edit#gid=0)

With Webtrekk we have three methods of tracking:

**Page parameters**
These are used for information about the page that are known at load time and are only related to that page. For example what is the type of the material being shown or what sort was used on the current search result.
These are added as properties on the global _ti object. Example:
```
window._ti = window._ti || {};
window._ti['OSS'] = 'Krimi';
window._ti['OSSr'] = '5099';
window._ti['p_s_Page'] = '1';
window._ti['p_s_Sort'] = 'date_descending';
window._ti['p_OSSprofile'] = 'boeger'
```

**URL parameters**
These are used when we want track relations between pages. For example, did the material view originate from a carousel and if so which one? On the ting_search_carousel the "Read more"-button and Reserve-button will have following parameter appended to their URL:
/ting/object/870970-basis%3A29997829?u_navigatedby=Unge
Where "Unge" is the title of the carousel. 

**Events**
For user interactions that doesn't result in a page load Webtrekk's event functionality is used. Examples is the carousel prev/next buttons and the reserve button which uses AJAX to make the reservation. It's implemented by calling the push() method on the wts Webtrekk-object and passing JSON-formatted event data to the function. Example:
```
wts.push(['send', 'click', {
  linkId:'Karousel, click på næste knappen',
  customClickParameter:{ 59:'Biblioteket foreslår materialer til dig'}
}]);
```

I have tried to handle as much on the server as possible, since there's much more reliable and convienient access to data. Events can be completely setup and attached on the server using HTML data-attribute, and a single catch-all click-handler will take care of pushing the events in the client.

Some things like autocomplete events are dependant on dynamic data created when the user is interacting, and therefore needs to be handled in client JS. Other stuff proved very problematic to handle on the server and is also handled in the client. For example, the ding_carousel theme often doesn't even know the name of it's carousel and it would require a rework or a hacky approach, to get the needed value for tracking parameter.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
The PR also includes some fixes for some critical stuff:

1. The Webtrekk loading script was incorrectly placed in the footer of the page. I have moved it to the 
top of the head together with the page parameters as mentioned in the implementation guidelines: [Webtrekk-Implementation-Guidelines](https://support.webtrekk.com/hc/en-us/article_attachments/115007805409/Webtrekk-Implementation-Guidelines-v6-EN.PDF). Also mentioned  in this PR: https://github.com/ding2/ding2/pull/1274
2. The internal node search was never meant to be tracking with separate parameters, resulting in these parameters never being actually send to webtrekk. The same parameters that is used for ting search should be used (OSS and OSSr).
3. The code that was adding the page-parameter-script filterede out values zero-values and as a result important tracking of zero-hit searches has been lost and never tracked in Webtrekk. I have updated the code to still ensure no empty values, but make exceptions for the values 0 and '0'.