### PR TITLE
3603: Patch localization client to support newer jQuery versions

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -198,6 +198,9 @@ projects[l10n_update][version] = "1.0"
 projects[l10n_client][type] = "module"
 projects[l10n_client][subdir] = "contrib"
 projects[l10n_client][version] = "1.3"
+; Support newer jQuery versions.
+; https://www.drupal.org/project/l10n_client/issues/2191771
+projects[l10n_client][patch][] = "https://www.drupal.org/files/issues/l10n_client-browser_is_undefined_jquery_gt_19-2191771-3.patch"
 
 projects[i18n][subdir] = "contrib"
 projects[i18n][version] = "1.11"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3603

#### Description

The latest version of the localization client module is ~5 years old
and has problems with newer versions of jQuery because $.browser has
been removed.

We patch the module to fix the problem. The chosen patch has also been
committed by the module maintainer.

#### Screenshot of the result

Faulty site:
<img width="896" alt="2018-12-04 11-40-19" src="https://user-images.githubusercontent.com/73966/49436417-67f63800-f7b9-11e8-83d0-831f9930404d.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.