### PR TITLE
3603: Downgrade jQuery to 1.7 for the administration interface/theme

### DIFF
--- a/modules/ding_base/ding_base.install
+++ b/modules/ding_base/ding_base.install
@@ -74,6 +74,8 @@ function ding_base_install() {
   variable_set('date_format_long', 'l, j. F, Y H:i');
   variable_set('date_format_medium', 'D, d-m-Y H:i');
   variable_set('date_format_short', 'd-m-Y H:i');
+
+  _jquery_update_set_theme_version('seven', '1.7');
 }
 
 /**
@@ -191,4 +193,11 @@ function ding_base_update_7005() {
 function ding_base_update_7006() {
   // Use the default version by setting an falsy value.
   _jquery_update_set_theme_version('seven', '');
+}
+
+/**
+ * Use jQuery 1.7 for admin theme.
+ */
+function ding_base_update_7007() {
+  _jquery_update_set_theme_version('seven', '1.7');
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3603

#### Description

The latest version of jQuery causes problems for the Module Filter
module: https://www.drupal.org/project/module_filter/issues/2986511

There is no immediate fix for this and the problem which originally
caused the upgrade is only relevant for patron actions performed in the 
DDBasic theme.

Consequently we downgrade the version of jQuery used to 1.7 (in practice
1.7.2) which is the same version currently used.

We need to ensure that the correct version is set on current and new
sites so we implement both hook_update and update hook_install to
make this change.

#### Screenshot of the result

Current version for new sites is actually 1.4 because the previous version only included a hook_update:
<img width="896" alt="jquery update 2018-12-04 11-43-30" src="https://user-images.githubusercontent.com/73966/49436741-2ade7580-f7ba-11e8-9683-c46417466456.png">

When updating the site to 3.1.1 for the admin theme the module filter breaks:
<img width="896" alt="moduler 2018-12-04 11-44-09" src="https://user-images.githubusercontent.com/73966/49436762-3cc01880-f7ba-11e8-8702-6a8db99793bf.png">

Downgrading to 1.7.2 fixes the module filer:
<img width="896" alt="moduler 2018-12-04 11-44-50" src="https://user-images.githubusercontent.com/73966/49436796-4ea1bb80-f7ba-11e8-91d0-ba6461ddec63.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.