### PR TITLE
3832: Added result count after search result

### DIFF
--- a/modules/ting_search/templates/ting-search-results-count.tpl.php
+++ b/modules/ting_search/templates/ting-search-results-count.tpl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @file
+ * Default theme implementation for displaying search results count.
+ *
+ * @see template_preprocess_ting_search_results()
+ */
+?>
+<div class="search-results-count">
+  <span class="count"><?php print format_plural($count, '1 Result', '@count Results'); ?></span>
+</div>

--- a/modules/ting_search/templates/ting-search-results.tpl.php
+++ b/modules/ting_search/templates/ting-search-results.tpl.php
@@ -14,6 +14,11 @@
     <ol class="search-results <?php print $module; ?>-results">
       <?php print $search_results; ?>
     </ol>
+
+    <?php if (isset($search_results_count)): ?>
+      <?php print $search_results_count; ?>
+    <?php endif ?>
+
     <?php print $pager; ?>
   </div>
 <?php else : ?>

--- a/modules/ting_search/ting_search.module
+++ b/modules/ting_search/ting_search.module
@@ -133,6 +133,10 @@ function ting_search_theme($existing, $type, $theme, $path) {
       'file'      => 'ting_search.pages.inc',
       'template'  => 'templates/ting-search-results',
     ),
+    'ting_search_results_count' => array(
+      'variables' => array('count' => NULL),
+      'template'  => 'templates/ting-search-results-count',
+    ),
     'ting_search_mini_pager' => array(
       'variables' => array(
         'tags' => array(),

--- a/modules/ting_search/ting_search.pages.inc
+++ b/modules/ting_search/ting_search.pages.inc
@@ -13,5 +13,15 @@ function template_preprocess_ting_search_results(&$variables) {
     $variables['search_results'] .= theme('search_result', array('result' => $result, 'module' => $variables['module']));
   }
   $variables['pager'] = theme('ting_search_pager', array('tags' => NULL));
-}
 
+  $search_result = ting_search_current_results();
+  if (isset($search_result)) {
+    $count = $search_result->hasMoreResults() ?
+      $search_result->getNumTotalObjects() :
+      $search_result->getNumCollections();
+
+    $variables['search_results_count'] = theme('ting_search_results_count', array(
+      'count' => $count,
+    ));
+  }
+}

--- a/themes/ddbasic/templates/ting_search/ting-search-results.tpl.php
+++ b/themes/ddbasic/templates/ting_search/ting-search-results.tpl.php
@@ -26,6 +26,11 @@
     <ol class="search-results <?php print $module; ?>-results">
       <?php print $search_results; ?>
     </ol>
+
+    <?php if (isset($search_results_count)): ?>
+      <?php print $search_results_count; ?>
+    <?php endif ?>
+
     <?php print $pager; ?>
   </div>
 <?php else : ?>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3832

#### Description

Adds display of result count after actual search result (cf. https://github.com/ding2/ding2/pull/1287)

#### Screenshot of the result

<img width="1065" alt="3832" src="https://user-images.githubusercontent.com/11267554/49452171-f29e5d80-f7e0-11e8-87f5-abe4350fba7e.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

Note: Scrutinizer complains about issues with linebreaks in template files, but these issues are not related to the code in this pull request.