### PR TITLE
3914: Enable all campaign plus modules

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -672,3 +672,16 @@ function ding2_update_7056() {
 function ding2_update_7057() {
   module_enable(array('ding_campaign_plus'));
 }
+
+/**
+ * Enable Campaign plus extra modules.
+ */
+function ding2_update_7058() {
+  module_enable(array(
+    'ding_campaign_plus_auto',
+    'ding_campaign_plus_basic',
+    'ding_campaign_plus_facet',
+    'ding_campaign_plus_object',
+    'ding_campaign_plus_search',
+  ));
+}

--- a/ding2.profile
+++ b/ding2.profile
@@ -658,7 +658,7 @@ function ding2_module_list_as_operations($module_list) {
  */
 function ding2_module_enable(&$install_state) {
   $modules = variable_get('ding_module_selected', array());
-  // Modules we dont have an explicit dependency on but still want enabled by
+  // Modules we don't have an explicit dependency on but still want enabled by
   // default. If the user later on does not need the module it can be disabled
   // manually.
   $modules = array_merge(array(
@@ -670,6 +670,12 @@ function ding2_module_enable(&$install_state) {
     'ding_eresource',
     'ding_app_content_rss',
     'ding_app_variables',
+    'ding_campaign_plus',
+    'ding_campaign_plus_auto',
+    'ding_campaign_plus_basic',
+    'ding_campaign_plus_facet',
+    'ding_campaign_plus_object',
+    'ding_campaign_plus_search',
   ), $modules);
 
   $operations = ding2_module_list_as_operations($modules);

--- a/modules/ding_campaign_plus/ding_campaign_plus.install
+++ b/modules/ding_campaign_plus/ding_campaign_plus.install
@@ -50,33 +50,6 @@ function ding_campaign_plus_schema() {
     ),
   );
 
-  $schema['ding_campaign_plus_auto'] = array(
-    'description' => 'Linked auto generated campaigns',
-    'fields' => array(
-      'id' => array(
-        'type' => 'serial',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-      ),
-      'nid' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'default' => 0,
-      ),
-      'campaign_nid' => array(
-        'type' => 'int',
-        'unsigned' => TRUE,
-        'not null' => TRUE,
-        'default' => 0,
-      ),
-    ),
-    'primary key' => array('id'),
-    'indexes' => array(
-      'nid' => array('nid'),
-    ),
-  );
-
   return $schema;
 }
 


### PR DESCRIPTION
#### Link to issue

See https://platform.dandigbib.org/issues/3914

#### Description

Enabled all campaign plus "extra" modules but only with soft dependency, so libraries that don't want theme can disable theme again.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.
