### PR TITLE
3936: Fix missing titles on loan and resevation list

### DIFF
--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -176,7 +176,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       // about the associated material.
       /** @var \TingEntity $entity */
       $entity = $loan->entity;
-      if (!is_object($entity) || NULL === $entity->getTingObject()->data) {
+      if (!is_object($entity)) {
         // Patron have this item in loans list, but the search provider can't
         // find this record for current agencyId, so we load it separately.
         $ting_object = ting_search_object_load($loan->ding_entity_id);
@@ -192,7 +192,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       // Initialize variables so that they don't carry over if this entity can't
       // be searched.
       $creators = $mat_type = $cover = NULL;
-      if (is_object($entity) && NULL !== $entity->getTingObject()->data) {
+      if (is_object($entity)) {
         $raw_title = $entity->getTitle();
 
         // Add title link.

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -176,7 +176,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       // about the associated material.
       /** @var \TingEntity $entity */
       $entity = $loan->entity;
-      if (!is_object($entity) || NULL === $entity->getTingObject()) {
+      if (!is_object($entity) || NULL === $entity->getTingObject()->data) {
         // Patron have this item in loans list, but the search provider can't
         // find this record for current agencyId, so we load it separately.
         $ting_object = ting_search_object_load($loan->ding_entity_id);
@@ -192,7 +192,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
       // Initialize variables so that they don't carry over if this entity can't
       // be searched.
       $creators = $mat_type = $cover = NULL;
-      if (is_object($entity) && NULL !== $entity->getTingObject()) {
+      if (is_object($entity) && NULL !== $entity->getTingObject()->data) {
         $raw_title = $entity->getTitle();
 
         // Add title link.

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -492,7 +492,7 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
   foreach ($reservations as $reservation) {
     /** @var \TingEntity $entity */
     $entity = $reservation->entity;
-    if (!is_object($entity) || NULL === $entity->getTingObject()->data) {
+    if (!is_object($entity)) {
       $entity = ding_provider_get_pseudo_entity($reservation->ding_entity_id);
       // Don't link the title as the data well do not known this title. It may
       // be a inter library loan.

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -492,7 +492,7 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
   foreach ($reservations as $reservation) {
     /** @var \TingEntity $entity */
     $entity = $reservation->entity;
-    if (!is_object($entity) || NULL === $entity->getTingObject()) {
+    if (!is_object($entity) || NULL === $entity->getTingObject()->data) {
       $entity = ding_provider_get_pseudo_entity($reservation->ding_entity_id);
       // Don't link the title as the data well do not known this title. It may
       // be a inter library loan.

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -79,8 +79,8 @@ function opensearch_get_object($object_id, $collection = FALSE, $with_relations 
  * @param bool $local
  *   Flag to indicate whether $ids contains pids or local ids (fausts).
  *
- * @return bool|\TingClientSearchResult
- *   The objects fetched from the data-well.
+ * @return array
+ *   An array of TingClientObject. Empty array if nothing was found.
  *
  * @throws \TingClientException
  *   This may throw this exception if the search request fails.

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -58,7 +58,14 @@ function opensearch_get_object($object_id, $collection = FALSE, $with_relations 
     // Execute the request.
     $result = opensearch_execute($request);
 
-    return $collection || is_null($result) ? $result : reset($result);
+    if ($collection) {
+      return $result;
+    }
+
+    // An object request wil return an array.
+    if (!empty($result)) {
+      return reset($result);
+    }
   }
 
   return NULL;


### PR DESCRIPTION
#### Link to issue

This PR is dependant on: https://github.com/ding2/ting-client/pull/27

https://platform.dandigbib.org/issues/3936

#### Description

In https://github.com/ding2/ding2/pull/1147 we switched from using a rec.id search to using a getObject request, when fetching multiple objects from opensearch. This has led to a change in the way the system is handling unknown/missing/inaccessible objects.

When using a rec.id search to fetch objects, opensearch will just return an empty search result set if nothing was found. But getObject behaves differently and will return a "fake" search result record:

```
<searchResult>
  <collection>
    <resultPosition>1</resultPosition>
    <numberOfObjects>1</numberOfObjects>
      <object>
        <dkabm:record>
          <dc:title>
            Error: unknown/missing/inaccessible record: 456456456
          </dc:title>
        </dkabm:record>
        <identifier>456456456</identifier>
        <primaryObjectIdentifier/>
        <formatsAvailable>
          <format>dkabm</format>
        </formatsAvailable>
      </object>
  </collection>
</searchResult>
```

As a consequence the system will try to display these objects. For example on the loan/reservation list for non-searchable ILL-loans it will display a material with the title "Error: unknown/missing/inaccessible record: ...".

It's also possible to show fake material views by just choosing some random namespace/faust. Example:

https://vanilla-fbs.ddbcms.dk/ting/object/870970-basis:123123123123

Instead of passing these fake objects to Drupal, it's better to handle in the opensearch client, so that these objects are discarded early. That is what is done in https://github.com/ding2/ting-client/pull/27.

This PR mainly just removes some unnecessary checks and updates some code/comment to handle array from TingClientObjectRequest.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
