### PR TITLE
3638 by Inlead: Require image share permission prior to BPI pushing.

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -817,27 +817,6 @@ function bpi_form_workflow_transition_form_alter(&$form, &$form_state, $form_id)
 }
 
 /**
- * Validates the push with images dropdown field prior pushing content.
- *
- * @param array $element
- *   The element to be validated.
- * @param array $form_state
- *   The form state.
- *
- * @see bpi_http_push_action_form()
- */
-function bpi_push_with_images_validate(array $element, array &$form_state) {
-  $allowed_values = array(
-    BPI_WITH_IMAGES,
-    BPI_WITHOUT_IMAGES,
-  );
-
-  if (!in_array($form_state['values']['bpi_push_images'], $allowed_values)) {
-    form_error($element, t('Please choose an option.'));
-  }
-}
-
-/**
  * Validate handler that will add custom submit handler.
  *
  * We add the submit handler here, because we need to add the submit handler,
@@ -855,10 +834,13 @@ function bpi_form_workflow_transition_form_validate(&$form, &$form_state) {
     // The 'Save and push' button has been chosen, so we will check if the BPI
     // values are correct.
     if (empty($form_state['values']['bpi_push_category'])) {
-      form_set_error('bpi_push_category', t('Category must be set when pushing to BPI'));
+      form_set_error('bpi_push_category', t('Category must be set when pushing to BPI.'));
     }
     if (empty($form_state['values']['bpi_push_audience'])) {
-      form_set_error('bpi_push_audience', t('Audience must be set when pushing to BPI'));
+      form_set_error('bpi_push_audience', t('Audience must be set when pushing to BPI.'));
+    }
+    if (empty($form_state['values']['bpi_push_images']) || '_none' == $form_state['values']['bpi_push_images']) {
+      form_set_error('bpi_push_images', t('Image permissions should be explicitly set when pushing to BPI.'));
     }
   }
   array_unshift($form_state['submit_handlers'], 'bpi_form_workflow_transition_form_submit');

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -839,9 +839,6 @@ function bpi_form_workflow_transition_form_validate(&$form, &$form_state) {
     if (empty($form_state['values']['bpi_push_audience'])) {
       form_set_error('bpi_push_audience', t('Audience must be set when pushing to BPI.'));
     }
-    if (empty($form_state['values']['bpi_push_images']) || '_none' == $form_state['values']['bpi_push_images']) {
-      form_set_error('bpi_push_images', t('Image permissions should be explicitly set when pushing to BPI.'));
-    }
   }
   array_unshift($form_state['submit_handlers'], 'bpi_form_workflow_transition_form_submit');
 }

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -63,7 +63,7 @@ function bpi_http_push_action_form($nid) {
     ),
     '#description' => t('You should have permission to publish the images before selecting this option.'),
     '#default_value' => '_none',
-    '#element_validate' => array('bpi_push_with_images_validate'),
+    '#required' => TRUE,
   );
 
   $form['configurations']['bpi_push_refs'] = array(

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -57,12 +57,12 @@ function bpi_http_push_action_form($nid) {
     '#type' => 'select',
     '#title' => t('Push with image'),
     '#options' => array(
-      '_none' => t('Choose'),
       BPI_WITHOUT_IMAGES => t('Not approved for sharing'),
       BPI_WITH_IMAGES => t('Approved for sharing'),
     ),
     '#description' => t('You should have permission to publish the images before selecting this option.'),
-    '#default_value' => '_none',
+    '#empty_option' => t('- choose -'),
+    '#empty_value' => '_none',
     '#required' => TRUE,
   );
 

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -62,7 +62,6 @@ function bpi_http_push_action_form($nid) {
     ),
     '#description' => t('You should have permission to publish the images before selecting this option.'),
     '#empty_option' => t('- choose -'),
-    '#empty_value' => '_none',
     '#required' => TRUE,
   );
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3638

#### Description

On top of the original 3638 requirement, is to explicitly mark the field required and only validate it's value prior to BPI push.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/574498/49799969-0270f100-fd4f-11e8-8301-45b6f5ea548f.png)

#### Checklist

- [x] My complies with [coding guidelines](../docs/code_guidelines.md).
- [x] My code passes static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process. 
_Scrutinizer issue is unrelated._
- [x] My code passes continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
