### PR TITLE
3603: Update definition of js.cookie library

### DIFF
--- a/modules/ding_libs/ding_libs.module
+++ b/modules/ding_libs/ding_libs.module
@@ -60,12 +60,12 @@ function ding_libs_libraries_info() {
       'vendor url' => 'https://github.com/js-cookie/js-cookie',
       'download url' => 'https://github.com/js-cookie/js-cookie/releases',
       'version arguments' => array(
-        'file' => 'js.cookie-2.1.4.min.js',
+        'file' => 'js.cookie-2.2.0.min.js',
         'pattern' => '/js-cookie v(\d+\.+\d+\.\d+)/',
       ),
       'files' => array(
         'js' => array(
-          'js.cookie-2.1.4.min.js',
+          'js.cookie-2.2.0.min.js',
         ),
       ),
     ),


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3603

#### Description

As a part of #1243 we now download js.cookie 2.20 for jQuery 3 compatibility.

We have to update the library definition accordingly for the library to
get loaded properly.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The Scrutinizer error is irrelevant to the change at hand and should be disregarded.