### PR TITLE
3985: Remove .slick-slide placeholder

### DIFF
--- a/modules/ding_carousel/js/ding_carousel.js
+++ b/modules/ding_carousel/js/ding_carousel.js
@@ -172,7 +172,7 @@
       dataType : 'json',
       success : function (data) {
         // Remove placeholders.
-        item.tab.find('.ding-carousel-item.placeholder').remove();
+        item.tab.find('.ding-carousel-item.placeholder').closest('.slick-slide').remove();
         item.tab.find('.carousel').slick('slickAdd', data.content);
         item.tab.data('offset', data.offset);
         item.tab.data('updating', false);

--- a/modules/p2/ding_list/plugins/content_types/public_lists.inc
+++ b/modules/p2/ding_list/plugins/content_types/public_lists.inc
@@ -7,6 +7,11 @@
 
 use DingList\DingList;
 
+/**
+ * The default lists per page.
+ */
+define('DING_LIST_PUBLIC_LISTS_PER_PAGE', 10);
+
 $plugin = array(
   'title' => t('Public lists'),
   'description' => t('Public lists'),
@@ -27,8 +32,12 @@ function ding_list_public_lists_content_type_render($subtype, $conf, $panel_args
 
   try {
     $lists = ding_provider_invoke('openlist', 'call_module', 'ListPermission', 'getPublicLists');
+    $total = count($lists);
 
-    foreach ($lists as $list) {
+    $elements_per_page = !empty($conf['elements_per_page']) ? $conf['elements_per_page'] : DING_LIST_PUBLIC_LISTS_PER_PAGE;
+    $current_page = pager_default_initialize($total, $elements_per_page);
+
+    foreach (array_slice($lists, $current_page * $elements_per_page, $elements_per_page) as $list) {
       $list = DingList::fromDataArray($list);
 
       if (ding_list_user_has_access($list)) {
@@ -39,6 +48,10 @@ function ding_list_public_lists_content_type_render($subtype, $conf, $panel_args
         );
       }
     }
+
+    $block->content['pager'] = array(
+      '#theme' => 'pager',
+    );
   }
   catch (Exception $e) {
     watchdog_exception('ding_list', $e);
@@ -52,5 +65,17 @@ function ding_list_public_lists_content_type_render($subtype, $conf, $panel_args
  * Edit form.
  */
 function ding_list_public_lists_content_type_edit_form($form, &$form_state) {
+  $form['elements_per_page'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Elements per page'),
+    '#default_value' => isset($form_state['conf']['elements_per_page']) ? $form_state['conf']['elements_per_page'] : DING_LIST_PUBLIC_LISTS_PER_PAGE,
+  );
   return $form;
+}
+
+/**
+ * Edit form submit.
+ */
+function ding_list_public_lists_content_type_edit_form_submit($form, &$form_state) {
+  $form_state['conf']['elements_per_page'] = $form_state['values']['elements_per_page'];
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3985

#### Description

Instead of removing the .placeholder in the slick slide, it now makes sure to remove the entire .sick-slide, if the placeholder is nested inside (it also removes the .slick-slide if the placeholder is not nested).

#### Screenshot of the result

![screenshot_2018-12-12 offentlige lister pbj ding virt b14cms dk](https://user-images.githubusercontent.com/163625/49862749-22f88400-fdff-11e8-8780-525e7331522d.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.