### PR TITLE
3603: Prevent access to changing jQuery version

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -165,6 +165,9 @@ projects[job_scheduler][version] = "2.0-alpha3"
 
 projects[jquery_update][subdir] = "contrib"
 projects[jquery_update][version] = "3.0-alpha5"
+; Add permission for changing jQuery versions
+; https://www.drupal.org/project/jquery_update/issues/2621436
+projects[jquery_update][patch][] = "https://www.drupal.org/files/issues/2018-12-13/jquery_update_permissions-2621436-13.patch"
 
 projects[languageicons][subdir] = "contrib"
 projects[languageicons][version] = "1.0"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3603

#### Description

The version of jQuery that we use can have significant impact on the
functionality of the site and break other JavaScript elements.
Consequently normal users should not be able to change this.

To address this we patch jQuery Update to add a new permission which is
used to determine access to functionality provided by jQuery Update.

The new permission is intentionally not assigned to any roles. This
prevents access to everyone except user 1.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Comments

I do not know why Scrutinizer fails for this PR. It is not related to the change at hand.