### PR TITLE
3603: Ensure the right version of jQuery is used for update environments

### DIFF
--- a/modules/ding_base/ding_base.install
+++ b/modules/ding_base/ding_base.install
@@ -81,7 +81,7 @@ function ding_base_install() {
 /**
  * Implements hook_update_dependencies().
  */
-function ding_base_update_requirements() {
+function ding_base_update_dependencies() {
   // Update hook which sets the jQuery version to use for Seven (admin theme)
   // with jQuery Update to the site default version.
   $dependencies['ding_base'][7006] = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3603

#### Description

ding_base_update_dependencies was wrongly named
ding_base_update_requirements. Rename it to make it work.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Comments

Scrutinizer error is not related to the change.