### PR TITLE
3910: Remove padding and change font-style

### DIFF
--- a/themes/ddbasic/sass/components/ding-carousel.scss
+++ b/themes/ddbasic/sass/components/ding-carousel.scss
@@ -14,6 +14,9 @@
     width: auto;
     padding-top: 0;
   }
+  ul {
+    padding-left: 0;
+  }
   .carousel-list-tabs {
     margin: 0;
     text-align: left;
@@ -87,7 +90,9 @@
   &.hidden {
     display: none;
   }
-
+  ul {
+    padding-left: 0;
+  }
   .slick-slider {
     position: relative;
     clear: left;
@@ -125,7 +130,7 @@
         margin-right: 28px;
         text-align: left;
         margin-bottom: 0;
-				
+
         &:last-child {
           margin-right: 0;
         }

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -226,9 +226,9 @@
       }
       .field-name-ting-title {
         h2 {
-          @include font('display');
+          @include font('display-small');
           width: 100%;
-          margin-bottom: 4px;
+          margin-bottom: 0;
           color: $color-standard-text;
         }
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3910#change-39903

#### Description

Padding-left removed from ul in ding-carousel. Font-style changed for ting-object with no overlay

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/22191849/50008445-7b24b700-ffb4-11e8-8881-be8275b04e52.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No further comments or questions.
