### PR TITLE
1261: Fix errors for invalid logins

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -817,7 +817,7 @@ function ding_user_user_login_validate($form, &$form_state) {
     // in the form to prevent the default form validation from displaying the
     // reset password link, which would not make sens for provider users.
     foreach (array('name', 'pass') as $field) {
-      if (empty($form_state['user_login_container']['values'][$field])) {
+      if (empty($form_state['values'][$field])) {
         form_set_error($field, t('!name field is required.', array('!name' => $form[$field]['#title'])));
       }
     }
@@ -830,7 +830,7 @@ function ding_user_user_login_validate($form, &$form_state) {
     // form. If the provider defines its own authnames, this wont match the
     // username that the user would have, but we can't expect the provider
     // to supply it for invalid logins.
-    form_set_value($form['name'], ding_user_default_authname($form_state['values']['name']), $form_state);
+    form_set_value($form['user_login_container']['name'], ding_user_default_authname($form_state['values']['name']), $form_state);
   }
   catch (Exception $e) {
     // Exception thrown, log error and carry on.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1261

#### Description

The current usage of $form and $form_state seems to have been
mixed up in two instances. This results in a 500 error response when
logging in with invalid credentials:

“TypeError: Argument 2 passed to drupal_array_set_nested_value() must
be of the type array, null given”

Switch them around to fix this.

#### Screenshot of the result

The error:
![mozilla firefox 2018-12-14 17-00-05](https://user-images.githubusercontent.com/73966/50013560-c0031a80-ffc1-11e8-9e35-bc95ee2bb1b4.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The Scrutinizer error is irrelevant to the change at hand.