### PR TITLE
3043: Do not validate onhold values when dates do not change.

### DIFF
--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -568,8 +568,6 @@ function fbs_form_profile2_on_hold_validate(array $element, array &$form_state) 
 
   // Get the values that should be validated.
   $existing_on_hold = $wrapper->field_fbs_on_hold->value();
-  $new_on_hold = $form_state['values']['profile_provider_fbs']['field_fbs_on_hold'][LANGUAGE_NONE][0];
-
   // Existing value may return NULL lets convert that to an array.
   if (is_null($existing_on_hold)) {
     $existing_on_hold = array(
@@ -577,6 +575,12 @@ function fbs_form_profile2_on_hold_validate(array $element, array &$form_state) 
       'to' => NULL,
     );
   }
+
+  // New values are in the format Y-m-d while existing values are timestamps.
+  // Convert new values to timestamps to make them comparable.
+  $new_on_hold = array_map(function ($time_string) {
+    return _fbs_form_profile_validate_convert_time($time_string);
+  }, $form_state['values']['profile_provider_fbs']['field_fbs_on_hold'][LANGUAGE_NONE][0]);
 
   // Check if the values have been changed.
   if ($existing_on_hold['from'] != $new_on_hold['from'] || $existing_on_hold['to'] != $new_on_hold['to']) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3043

#### Description

Otherwise you will get a validation error when you try to update
other parts of your profile.

The current values are timestamps while new values are in string
format. Convert them to timestamps to make them comparable.

#### Screenshot of the result

The error:
![screencast 2018-12-14 17-27-02](https://user-images.githubusercontent.com/73966/50014941-9a781000-ffc5-11e8-95c9-6462af947bf7.gif)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
