### PR TITLE
3984: Removed leading slash from node link

### DIFF
--- a/modules/ding_campaign_plus/modules/ding_campaign_plus_auto/ding_campaign_plus_auto.module
+++ b/modules/ding_campaign_plus/modules/ding_campaign_plus_auto/ding_campaign_plus_auto.module
@@ -155,7 +155,7 @@ function ding_campaign_plus_auto_node_insert($node) {
     $campaign_wrapper->field_ding_campaign_plus_type->set('campaign_text_and_image');
     $campaign_wrapper->field_ding_campaign_plus_style->set('ribbon');
     $campaign_wrapper->field_ding_campaign_plus_link->set(array(
-      'url' => '/node/' . $node->nid,
+      'url' => 'node/' . $node->nid,
     ));
 
     $field = 'field_' . $node_wrapper->getBundle() . '_title_image';


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3984

#### Description

Remove leading slash from auto generated campaign plus node links.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The Scrutinizer error is in code not related to this PR.