### PR TITLE
3668: Make arrow clickable for search sort select.

### DIFF
--- a/themes/ddbasic/sass/components/form/form-search-sort.scss
+++ b/themes/ddbasic/sass/components/form/form-search-sort.scss
@@ -35,20 +35,39 @@
     overflow: visible;
     cursor: pointer;
 
+    // A pseudo grey underline under the select.
+    // By making it pseudo, we can control it more with padding.
     &::before {
-      display: none;
+      display: block;
+      position: absolute;
+      height: auto;
+      width: auto;
+      bottom: 0;
+      left: 0;
+
+      // Making sure the line doesnt expand underneath
+      // the .select-wrapper::before icon.
+      right: 20px;
+
+      border-bottom: 1px solid $grey-medium;
+      background: none;
+      z-index: 1;
     }
 
     &::after {
       position: absolute;
+
       line-height: 15px;
-      right: -40px;
+      right: -20px;
     }
 
     > select {
       cursor: pointer;
       text-decoration: none;
-      border-bottom: 1px solid $grey-medium;
+      box-sizing: content-box;
+
+      // Leaving space for .select-wrapper::before icon.
+      padding-right: 20px;
     }
   }
 
@@ -59,6 +78,16 @@
 
     > label {
       display: inline;
+
+      // Some browsers, such as firefox, adds a unstyleable left padding on
+      // <select>'s which is around 4px wide.
+      // We add a little extra spacing on the right of the labels, so the
+      // JS includes this width.
+      // By doing this hack in CSS, we atleast keep the labels and select
+      // size consistent.
+      // We don't need to make this hack browser-specific, as the extra 4px
+      // only really is visible when its missing, rather than when its there.
+      padding-right: 4px;
     }
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3668

#### Description

Tests found out that clicking on the select arrow on the form sort didnt open the select.
This also fixes an issue in firefox where the text was cut off.

#### Screenshot of the result
<img width="401" alt="screenshot 2018-12-17 at 21 29 30" src="https://user-images.githubusercontent.com/12376583/50113657-dc61ba00-0242-11e9-83d0-89638430a3d0.png">


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
