### PR TITLE
3908: Fix DB error on searches without keywords

### DIFF
--- a/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
+++ b/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
@@ -165,21 +165,31 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
         break;
 
       case 'search_term':
-        // Get current search query and split it into array of terms.
-        $current = ting_search_current_results();
-        $value = drupal_strtolower($current->getSearchRequest()->getFullTextQuery());
-        $terms = preg_split('/,|\s/', $value);
-        $terms = array_filter($terms);
+        $nids = [];
 
-        // Check if any active campaigns matches the search terms.
-        $query = db_select('ding_campaign_plus_basic', 'dcpb')
-          ->fields('dcpb', array('nid'))
-          ->condition('dcpb.type', $key)
-          ->condition('value', $terms, 'IN');
-        $query->join('node', 'n', 'dcpb.nid = n.nid');
-        $nids = $query->condition('status', 1)
-          ->execute()
-          ->fetchCol();
+        // Get current search query and split it into array of terms.
+        $value = ting_search_current_results()
+          ->getSearchRequest()
+          ->getFullTextQuery();
+
+        // If the search string is empty we just return an empty array, since
+        // executing the query with an empty array in the IN-condition throws
+        // a PDO syntax error exception.
+        if (!empty($value)) {
+          $value = drupal_strtolower($value);
+          $terms = preg_split('/,|\s/', $value);
+          $terms = array_filter($terms);
+
+          // Check if any active campaigns matches the search terms.
+          $query = db_select('ding_campaign_plus_basic', 'dcpb')
+            ->fields('dcpb', array('nid'))
+            ->condition('dcpb.type', $key)
+            ->condition('value', $terms, 'IN');
+          $query->join('node', 'n', 'dcpb.nid = n.nid');
+          $nids = $query->condition('status', 1)
+            ->execute()
+            ->fetchCol();
+        }
 
         $matches['search_term'] = is_array($nids) ? $nids : array();
         break;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3908

#### Description

When there's no search string the array to match against becomes empty, since FALSE and empty values are filtered out. db_select condition throws a [syntax error exception](https://platform.dandigbib.org/issues/3908#note-17) when using an empty array with 'IN'. The query doesn't make much sense anyway, since it will always return 0 rows. 
More info: https://www.drupal.org/project/drupal/issues/1976666 

So instead we just skip the select-query when the search string is empty and return empty array.

Alternatively, we should not filter out empty strings in array_filter, so that it would be possible to make campaign triggers that matches against empty strings, but I didn't think this was the right way to go. However, my knowledge about this module is limited, so I may be in the wrong here?

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

