### PR TITLE
4041: Fix fatal error on reservation delete

### DIFF
--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -252,13 +252,13 @@ function fbs_reservation_update($account, array $reservation_ids, array $options
  *
  * @param object $account
  *   User to delete reservations for.
- * @param array $reservation_id
- *   Reservations to delete.
+ * @param string $reservation_id
+ *   ID of the reservation to delete.
  *
  * @return bool
  *   TRUE if no errors else FALSE.
  */
-function fbs_reservation_delete($account, array $reservation_id) {
+function fbs_reservation_delete($account, $reservation_id) {
   try {
     fbs_service()->Reservations->deleteReservations(fbs_service()->agencyId, fbs_patron_id($account), $reservation_id);
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4041

#### Description

A small change in https://platform.dandigbib.org/issues/1261 has led to a fatal error, when trying to delete reservations:

`Recoverable fatal error: Argument 2 passed to fbs_reservation_delete() must be of the type array, string given i fbs_reservation_delete()`

An array PHP typehint was added to FBS delete_reservation function. ding_reservation has always passed the reservations ids one by one and not in an array. See:

`ding_reservation_delete_reservations_form_ajax_submit()`
`ding_reservation_reservations_delete_submit()`

Now, FBS API does actually support deletion of more reservations at a time, but to support this we need to change the provider API and this will also effect other library providers.

So I think the best action right now, is to just remove the type hint again.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.