### PR TITLE
4039: fix search overlay spinner

### DIFF
--- a/modules/ting/js/ting.js
+++ b/modules/ting/js/ting.js
@@ -6,14 +6,6 @@
   "use strict";
 
   $(document).ready(function() {
-    $('a.js-search-overlay').on('click', function() {
-      var link = $(this);
-      if (link.attr('href').charAt(0) !== '#') {
-        // Only show overlay for non-local links.
-        Drupal.TingSearchOverlay();
-      }
-    });
-
     // Ensure overlay on collection view links.
     $('.ting-collection-wrapper a[href*="/ting/"]').on('click', function() {
       if ($(this).not('[target="_blank"]').length) {

--- a/modules/ting/js/ting.js
+++ b/modules/ting/js/ting.js
@@ -6,15 +6,8 @@
   "use strict";
 
   $(document).ready(function() {
-    // Ensure overlay on collection view links.
-    $('.ting-collection-wrapper a[href*="/ting/"]').on('click', function() {
-      if ($(this).not('[target="_blank"]').length) {
-        Drupal.TingSearchOverlay();
-      }
-    });
-
-    // Ensure overlay on object view links.
-    $('.ting-object-wrapper a[href*="/ting/"]').on('click', function() {
+    // Ensure search overlay on search links in a ting object view.
+    $('.ting-object a[href^="/search/ting/"]').on('click', function() {
       if ($(this).not('[target="_blank"]').length) {
         Drupal.TingSearchOverlay();
       }

--- a/modules/ting_search/js/ting_search_overlay.js
+++ b/modules/ting_search/js/ting_search_overlay.js
@@ -51,9 +51,9 @@
   // Hook into the overlays "Cancel" link and stop page loading if clicked.
   $(document).ready(function () {
     if (!$('body').hasClass("page-admin")) {
-      $('.search-overlay--wrapper .cancel').on('click', function () {
-        window.stop();
+      $(document.body).on('click', '.search-overlay--wrapper .cancel', function () {
         Drupal.TingSearchOverlay(true);
+        window.location.reload();
       });
 
       // Remove overlay on page unload, so it's not shown when back button is


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4039

#### Description

The search overlay spinner suddenly started appearing when clicking the reserve-button. Investigating further I found these click-handlers from ting.js to be the culprit:

https://github.com/ding2/ding2/blob/7.x-4.6.0-rc5/modules/ting/js/ting.js#L18 
https://github.com/ding2/ding2/blob/7.x-4.6.0-rc5/modules/ting/js/ting.js#L25

These were not a problem before, since they were implemented with the jQuery `.live()` method, which for some reason wasn't fired (probably because of some code stopping event propagation). However, with the jQuery update, these were changed to `.on()` making them work and resulting in the search overlay incorrectly popping up when clicking on ding entity buttons (for example).

We only want these to pop up when users are clicking on actual search links, so I have made the selector more specific and removed some unused stuff (comments about this in commits).

I also discovered that the cancel button on the search overlay had stopped working for the same reason: the live-event was changed to an on-event. But in this case we need event delegation, since the overlay HTML is added dynamically. 

The `window.stop()` method, which we use to cancel the request when cancelling the overlay, apparently doesn't work in Chrome, but only on IE and Firefox (of the browsers I tested). Since a lot of users is on Chrome I tried to fix this and ended up using the `window.location.reload()` instead. It has the disadvantage that it will start a new page load of the current page instead of just stopping immediately. But at least it will work in all browsers, and these pages will also often be cached, so I don't think it's a big issue.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.