### PR TITLE
4036: Make star not overlap the search button

### DIFF
--- a/themes/ddbasic/sass/p2/p2-list.scss
+++ b/themes/ddbasic/sass/p2/p2-list.scss
@@ -121,6 +121,9 @@
       left: 0;
       margin: 0;
       background: transparent;
+      // Override the default 80px padding of buttons so the star
+      // doesn't overlap the search button.
+      padding-right: 15px;
 
       &:hover {
         background: transparent;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4036

#### Description

Make the "add to list" star not overlap the search button.
