### PR TITLE
3739: Availability optimization

### DIFF
--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -62,7 +62,11 @@ function fbs_availability_holdings($provider_ids) {
   $entities = [];
   $suffix_type = variable_get('fbs_holdings_suffix_type', 'shelf_mark');
   if ($suffix_type == 'simple') {
-    $entities = ding_entity_load_multiple($datawell_pids);
+    // Here the entities are keyed by local entity id, so build an array keyed
+    // by datawell pids for easier access.
+    foreach (ding_entity_load_multiple($datawell_pids) as $entity) {
+      $entities[$entity->ding_entity_id] = $entity;
+    }
   }
   elseif ($suffix_type == 'shelf_mark') {
     $entities = opensearch_get_objects_marcxchange($datawell_pids);
@@ -112,8 +116,8 @@ function fbs_availability_holdings($provider_ids) {
         $result_holding['placement'][] = $material_description[0]->materialGroupName;
       }
 
-      if ($suffix_type == 'simple' && isset($entities[$item->recordId])) {
-        $entity = $entities[$item->recordId];
+      if ($suffix_type == 'simple' && isset($entities[$datawell_pids[$item->recordId]])) {
+        $entity = $entities[$datawell_pids[$item->recordId]];
         // Get DK5 classification.
         if ($classification = $entity->getClassification()) {
           $result_holding['placement'][] = $classification;

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -53,6 +53,21 @@ function fbs_availability_holdings($provider_ids) {
     watchdog_exception('fbs', $e);
   }
 
+  module_load_include('inc', 'opensearch', 'opensearch.client');
+
+  // Translate all the fausts to datawell pids at once.
+  $datawell_pids = ding_provider_build_entity_id($provider_ids);
+
+  // Find out with the types of objects we need and load them all at once.
+  $entities = [];
+  $suffix_type = variable_get('fbs_holdings_suffix_type', 'shelf_mark');
+  if ($suffix_type == 'simple') {
+    $entities = ding_entity_load_multiple($datawell_pids);
+  }
+  elseif ($suffix_type == 'shelf_mark') {
+    $entities = opensearch_get_objects_marcxchange($datawell_pids);
+  }
+
   $result = array();
   $tmp_issues = array();
   foreach ($holdings as $item) {
@@ -97,11 +112,8 @@ function fbs_availability_holdings($provider_ids) {
         $result_holding['placement'][] = $material_description[0]->materialGroupName;
       }
 
-      module_load_include('client.inc', 'opensearch');
-      $entity_id = ding_provider_build_entity_id($provider_ids[0]);
-      $suffix_type = variable_get('fbs_holdings_suffix_type', 'shelf_mark');
-
-      if ($suffix_type == 'simple' && $entity = ding_entity_load($entity_id)) {
+      if ($suffix_type == 'simple' && isset($entities[$item->recordId])) {
+        $entity = $entities[$item->recordId];
         // Get DK5 classification.
         if ($classification = $entity->getClassification()) {
           $result_holding['placement'][] = $classification;
@@ -112,7 +124,9 @@ function fbs_availability_holdings($provider_ids) {
           $result_holding['placement'][] = $creator[0];
         }
       }
-      elseif ($suffix_type == 'shelf_mark' && $entity = opensearch_get_object_marcxchange($entity_id)) {
+      elseif ($suffix_type == 'shelf_mark' && isset($entities[$datawell_pids[$item->recordId]])) {
+        $entity = $entities[$datawell_pids[$item->recordId]];
+
         $field652m = fbs_get_marc_field($entity, '652', 'm');
         $field652o = fbs_get_marc_field($entity, '652', 'o');
 

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -252,10 +252,10 @@ function opensearch_do_search($query, $page = 1, $results_per_page = 10, $option
 }
 
 /**
- * Get a ting object from the well in marcxchange format.
+ * Get ting objects from the well in marcxchange format.
  *
- * @param string $object_id
- *   Object identifier.
+ * @param array $object_ids
+ *   Object identifiers.
  *
  * @return bool|\TingClientSearchResult
  *   The search result.
@@ -263,12 +263,12 @@ function opensearch_do_search($query, $page = 1, $results_per_page = 10, $option
  * @throws \TingClientException
  *   This may throw this exception if the search request fails.
  */
-function opensearch_get_object_marcxchange($object_id) {
+function opensearch_get_objects_marcxchange($object_ids) {
   $request = opensearch_get_request_factory()->getMarcXchangeRequest();
 
   $request->setAgency(variable_get('ting_agency'));
   $request->setProfile(variable_get('opensearch_search_profile'));
-  $request->setIdentifier($object_id);
+  $request->setIdentifier($object_ids);
 
   return opensearch_execute($request);
 }

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -257,13 +257,13 @@ function opensearch_do_search($query, $page = 1, $results_per_page = 10, $option
  * @param array $object_ids
  *   Object identifiers.
  *
- * @return bool|\TingClientSearchResult
- *   The search result.
+ * @return array
+ *   An array of TingMarchResult objects. Empty array if nothing was found.
  *
  * @throws \TingClientException
  *   This may throw this exception if the search request fails.
  */
-function opensearch_get_objects_marcxchange($object_ids) {
+function opensearch_get_objects_marcxchange(array $object_ids) {
   $request = opensearch_get_request_factory()->getMarcXchangeRequest();
 
   $request->setAgency(variable_get('ting_agency'));

--- a/modules/ting/ting.client.inc
+++ b/modules/ting/ting.client.inc
@@ -66,7 +66,11 @@ function ting_do_search($query, $page = 1, $results_per_page = 10, $options = ar
  */
 function ting_get_object_marcxchange($object_id) {
   module_load_include('inc', 'opensearch', 'opensearch.client');
-  return opensearch_get_object_marcxchange($object_id);
+  $result = opensearch_get_objects_marcxchange([$object_id]);
+  if (!empty($result)) {
+    return reset($result);
+  }
+  return $result;
 }
 
 /**


### PR DESCRIPTION
This PR is dependant on https://github.com/ding2/ting-client/pull/26

#### Link to issue

https://platform.dandigbib.org/issues/3739

#### Description

Adds support for fetching multiple marc-objects from opensearch at once and use this when generating shelfmark for holdings in FBS. The translation of faust to pid is also moved out of the loop, to also translate them all at once.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The process could in theory be optimized even further by avoiding the translation of faust completely. I do not think this is worth pursuing, since in all cases the holdings are fetched in a subsequent AJAX-request and doesn't prolong the initial request. Also, the translation is also done in a single getObject request now, which is very fast.