### PR TITLE
1744: Set default carousels on frontpage

### DIFF
--- a/modules/ding_frontpage/ding_frontpage.pages_default.inc
+++ b/modules/ding_frontpage/ding_frontpage.pages_default.inc
@@ -106,6 +106,21 @@ function ding_frontpage_default_page_manager_pages() {
     $pane->configuration = array(
       'override_title' => 1,
       'override_title_text' => '',
+      'searches' => array(
+        0 => array(
+          'title' => 'Unge',
+          'subtitle' => 'Nye bøger til unge',
+          'query' => '870970-basis:29983739 OR 870970-basis:29983585 OR 870970-basis:29989702 OR 870970-basis:29997829 OR  870970-basis:29997918 OR 870970-basis:29986215 OR 870970-basis:50532615 OR 870970-basis:50613038 OR 870970-basis:50618374',
+        ),
+        1 => array(
+          'title' => 'Børn',
+          'subtitle' => 'Nye bøger til de små',
+          'query' => '870970-basis:50612910  OR 870970-basis:29981299 OR  870970-basis:29967326  OR 870970-basis:50561488 OR 870970-basis:29618518 OR 870970-basis:50530671 OR 870970-basis:50577384  OR 870970-basis:50561445 OR 870970-basis:50587177 OR  870970-basis:50618404  ',
+        ),
+      ),
+      'settings' => array(
+        'transition' => 'fade',
+      ),
     );
     $pane->cache = array();
     $pane->style = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1744

#### Description

The default export of the frontpage didn't have any carousels defined.
