### PR TITLE
3905: Fixed uncached local ids in cache logic

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -416,7 +416,7 @@ function opensearch_execute(TingClientRequest $request) {
 
     // Ids that we still need to be fetched will not be appearing in the list of
     // cached objects.
-    $uncached_ids = array_diff_key($object_ids, $cached_objects);
+    $uncached_ids = array_diff_key($local_ids, $cached_objects);
     $request->setObjectIds(array_keys($uncached_ids));
 
     // If there are no ids to fetch then there is no need to issue a request.

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -401,7 +401,9 @@ function opensearch_execute(TingClientRequest $request) {
 
     // Try to retrieve a cached response for each request. Entries which does
     // not have cached data will get the value FALSE for easy subsequent
-    // filtering.
+    // filtering. Note that the input array to the map function uses "+" and not
+    // the array_merge function as merge will reset the keys when they are
+    // numeric which is the case with local_ids.
     $object_ids = array_map(function ($object_request) {
       if ($cached_response = _opensearch_cache($object_request)) {
         // A response for a single object is an array with a single object so
@@ -411,12 +413,12 @@ function opensearch_execute(TingClientRequest $request) {
       else {
         return FALSE;
       }
-    }, array_merge($object_id_requests, $local_id_requests));
+    }, $object_id_requests + $local_id_requests);
     $cached_objects = array_filter($object_ids);
 
     // Ids that we still need to be fetched will not be appearing in the list of
     // cached objects.
-    $uncached_ids = array_diff_key($local_ids, $cached_objects);
+    $uncached_ids = array_diff_key($object_ids, $cached_objects);
     $request->setObjectIds(array_keys($uncached_ids));
 
     // If there are no ids to fetch then there is no need to issue a request.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3905

#### Description

Ensure that the uncached ids array in opensearch client when working with local ids are the correct ids.

The issue is in php's array_merge which resets keys/index when the keys are numeric only, which they are when the request is for local ids only.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

See https://platform.dandigbib.org/issues/3905#note-27 for more information.