### PR TITLE
4049 by Inlead: Fix misspelling.

### DIFF
--- a/modules/p2/ding_list/include/form.inc
+++ b/modules/p2/ding_list/include/form.inc
@@ -590,7 +590,7 @@ function ding_list_list_permissions_form_share_callback($form, &$form_state) {
     '#commands' => array(),
   );
   if (empty($form_state['values']['email'])) {
-    $response['#commands'][] = ajax_command_ding_popup('ding_list', t('The emails field is required to send out invitations.'), t('No mails send.'));
+    $response['#commands'][] = ajax_command_ding_popup('ding_list', t('The emails field is required to send out invitations.'), t('No mails sent.'));
     return $response;
   }
   $list = $form_state['build_info']['args'][0];


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4049

#### Description

Within the sourcecode there is misspellings of "No mails sent", which is given as "No mails send". This string is presented/displayed to the user.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.