### PR TITLE
153 by Inlead: Disable form actions when syndicating own content.

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1086,3 +1086,18 @@ function bpi_features_views_default_views_alter(&$views) {
     $display_options['exposed_form']['options']['autosubmit'] = TRUE;
   }
 }
+
+/**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Decide whether to show the syndication link when previewing content.
+ */
+function bpi_preprocess_bpi_preview_item(&$variables) {
+  $bpi_item = $variables['item'];
+
+  $variables['hide_syndicate_link'] = FALSE;
+  $bpi_agency_id = variable_get('bpi_agency_id', '');
+  if ($bpi_agency_id === $bpi_item['agency_id']) {
+    $variables['hide_syndicate_link'] = TRUE;
+  }
+}

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -253,20 +253,30 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
     $form_state['node']->bpi_id = $bpi_id;
     try {
       $bpi = bpi_client_instance();
+      /** @var \Bpi\Sdk\Item\Node $bpi_node */
       $bpi_node = $bpi->getNode($bpi_id);
       $bpi_content = $bpi_node->getProperties();
       $bpi_assets = $bpi_node->getAssets();
 
-      drupal_set_message(
-        t(
-          'Syndicating content <strong>@title</strong>, from category <strong>@category</strong> and audience <strong>@audience</strong>.',
-          array(
-            '@title' => $bpi_content['title'],
-            '@category' => $bpi_content['category'],
-            '@audience' => $bpi_content['audience'],
+      $bpi_agency_id = variable_get('bpi_agency_id', '');
+
+      // Avoid the ability to syndicate own content.
+      if ($bpi_agency_id === $bpi_node->getProperties()['agency_id']) {
+        bpi_error_message(new \Exception('', 406), 'error');
+        unset($form['actions']);
+      }
+      else {
+        drupal_set_message(
+          t(
+            'Syndicating content <strong>@title</strong>, from category <strong>@category</strong> and audience <strong>@audience</strong>.',
+            array(
+              '@title' => $bpi_content['title'],
+              '@category' => $bpi_content['category'],
+              '@audience' => $bpi_content['audience'],
+            )
           )
-        )
-      );
+        );
+      }
     }
     catch (Exception $e) {
       watchdog_exception('bpi', $e);

--- a/modules/bpi/templates/bpi-preview-item.tpl.php
+++ b/modules/bpi/templates/bpi-preview-item.tpl.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Single item preview template.
@@ -35,7 +36,9 @@
       </p>
     </div>
   </div>
+  <?php if (!$hide_syndicate_link): ?>
   <p class="item-action item-action-syndicate">
     <?php echo l(t('Syndicate'), 'admin/bpi/syndicate/' . $item['id']); ?>
   </p>
+  <?php endif; ?>
 </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/153

#### Description

Disable the ability to save the node form, when syndicating own content. Even-though the original link is removed from the bpi content overview it is still possible to use the node syndication URI by manually pasting it into the browser url bar. For such cases show a message and disable form actions at all.
Also, remove the syndication when previewing when previewing own content.

#### Screenshot of the result

Node form:
![image](https://user-images.githubusercontent.com/574498/50967334-88b05c80-14e0-11e9-9e5c-e4c5c7053846.png)
![image](https://user-images.githubusercontent.com/574498/50967343-90700100-14e0-11e9-8b70-eed9f900564a.png)

Preview (own content):
![image](https://user-images.githubusercontent.com/574498/50969478-4dfdf280-14e7-11e9-9933-94a73dd7fb2d.png)

#### Checklist

- [x] My complies with [coding guidelines](../docs/code_guidelines.md).
- [x] My code passes static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions