### PR TITLE
3667: Move sub-menu to be above search.

### DIFF
--- a/themes/ddbasic/sass/components/header.scss
+++ b/themes/ddbasic/sass/components/header.scss
@@ -493,29 +493,14 @@
         @include transition(top $speed $ease);
         position: fixed;
         z-index: $z-header - 1;
-        top: $header-height;
         left: 0;
         width: 100%;
-        background-color: $charcoal;
+        background-color: $grey-darker;
         box-shadow: $box-shadow;
 
         // Tablet
         @include media($tablet) {
           display: none;
-        }
-        // Admin menu
-        .admin-menu & {
-          top: $header-height + $admin-menu-height;
-        }
-        // Admin menu with shortcuts or toolbar
-        .admin-menu-with-shortcut &,
-        .toolbar & {
-          top: $header-height + $toolbar-height;
-        }
-
-        .search-form-extended &,
-        .search-form-extended & {
-          top: $header-height + $search-form-extended-height;
         }
 
         &::before {
@@ -523,7 +508,6 @@
           display: block;
           height: 1px;
           width: 100%;
-          background-color: $black;
           box-shadow: 0 5px 10px 0 $black;
         }
         > .panel-pane-inner {
@@ -637,6 +621,21 @@
     .search-form-extended.toolbar &{
       top: $topbar-height + $search-form-extended-height + $toolbar-height;
     }
+
+    .search-form-extended.has-second-level-menu & {
+      top: $topbar-height + $search-form-extended-height + $second-level-menu-height;
+    }
+
+    // Search Form Extended with admin-menu
+    .search-form-extended.admin-menu.has-second-level-menu & {
+      top: $topbar-height + $search-form-extended-height + $admin-menu-height + $second-level-menu-height;
+    }
+
+    // Search Form Extended with admin menu shortcuts or toolbar
+    .search-form-extended.admin-menu-with-shortcuts.has-second-level-menu &,
+    .search-form-extended.toolbar.has-second-level-menu &{
+      top: $topbar-height + $search-form-extended-height + $toolbar-height + $second-level-menu-height;
+    }
   }
 
   .navigation-wrapper {
@@ -699,6 +698,20 @@
     // Mobile search open
     .mobile-search-is-open & {
       top: $header-height;
+    }
+
+    .pane-menu-block-main-menu-second-level {
+      top: $header-height;
+
+      // Admin menu
+      .admin-menu & {
+        top: $header-height + $admin-menu-height;
+      }
+      // Admin menu with shortcuts or toolbar
+      .admin-menu-with-shortcut &,
+      .toolbar & {
+        top: $header-height + $toolbar-height;
+      }
     }
   }
 }

--- a/themes/ddbasic/sass/configuration/_variables.scss
+++ b/themes/ddbasic/sass/configuration/_variables.scss
@@ -23,6 +23,7 @@ $grey-light: #f1f2f2;
 $grey: #e5e5e5;
 $grey-medium: #ccc;
 $grey-dark: #808285;
+$grey-darker: #505050;
 
 $green: #24d273;
 $green-text: darken($green, 10);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3667

#### Description

3667: Move sub-menu to be above search.
In a previous revision we moved the main menu links position.
We forgot to also move the sub-menu links, so this commit
moves the sub menu to be in connection with the main menu.

#### Screenshot of the result

![screenshot 2019-01-14 at 10 37 45](https://user-images.githubusercontent.com/12376583/51105133-7851f780-17e8-11e9-8986-c8eb7eb3babd.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
N/A