### PR TITLE
3901: Webtrekk MWA fixes

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -117,6 +117,9 @@ function ding_webtrekk_page_alter(&$page) {
       // Track the page of the search result.
       $params['p_s_Page'] = $search_result->getSearchRequest()->getPage();
 
+      // Trak the size of the search result.
+      $params['p_s_Size'] = $search_result->getNumCollections();
+
       // Track the sort used in the search request.
       if (!empty(ting_search_current_results()->getSearchRequest()->getSorts())) {
         $current_sort = $search_result->getSearchRequest()->getSorts()[0];

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -117,7 +117,9 @@ function ding_webtrekk_page_alter(&$page) {
       // Track the page of the search result.
       $params['p_s_Page'] = $search_result->getSearchRequest()->getPage();
 
-      // Trak the size of the search result.
+      // Track the size of the search result. We already track the total size
+      // of the search result in OSSr parameter, but this is the number of
+      // results on the current search page.
       $params['p_s_Size'] = $search_result->getNumCollections();
 
       // Track the sort used in the search request.

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -189,12 +189,30 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
   // The page parametes for the ting object view should only be added on the
   // full page view for the material.
   if ($view_mode == 'full' && current_path() == $entity_path) {
+    // Get classification now as we also need it to determine category.
+    $classification = $entity->getClassification();
+
+    // Here category refers to whether the material is fiction/non-fiction. The
+    // only reliable way to determine this, is by using the 'sk' marker from
+    // the DK5 classification.
+    $category = FALSE;
+    // If classification is 'sk' OpenSearchTingObject returns empty string.
+    // See: OpenSearchTingObject::getClassification().
+    if ($classification === '') {
+      $category = 'fiktion';
+    }
+    // Else, if not FALSE, the material has a DK5 classification and is
+    // nonfiction.
+    elseif ($classification !== FALSE) {
+      $category = 'nonfiktion';
+    }
+
     $params = [
       'p_mat_type' => $entity->getType(),
-      'p_mat_indexno' => $entity->getClassification(),
+      'p_mat_indexno' => $classification,
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
-      'p_mat_category' => implode(';', $entity->getTingObject()->getGenre()),
+      'p_mat_category' => $category,
     ];
     ding_webtrekk_add_page_parameters($params);
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3901

#### Description

Some small changes was requested by the business:

1. The Page parameter p_mat_category was incorrectly using a dc:subject DKABM field for the value. Instead it should only show whether the material is fiction or nonfiction (or none at all).

The only reliable way to check this, is by using the 'sk' marker in the DK5-classification. This value gets stripped in OpenSearchTingObject::getClassification(), so it's going to be a bit "hacky" to get to this. Either go directly to the record or look for empty string/FALSE. I choose the latter approach in this PR.

Alternatively, we should add a new getCategory() method to the TingObjectInterface, which purpose is to return fiction/nonfiction or FALSE if not applicable.

2. We have chosen to also track the size of current search-page in the parameter p_s_Size.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process
