### PR TITLE
3982: Use Views lite pager on admin node view

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -431,6 +431,9 @@ projects[views][version] = "3.20"
 projects[views_bulk_operations][subdir] = "contrib"
 projects[views_bulk_operations][version] = "3.3"
 
+projects[views_litepager][subdir] = "contrib"
+projects[views_litepager][version] = "3.0"
+
 projects[views_responsive_grid][subdir] = "contrib"
 projects[views_responsive_grid][version] = "1.3"
 

--- a/modules/ding_base/ding_base.info
+++ b/modules/ding_base/ding_base.info
@@ -16,6 +16,7 @@ dependencies[] = pathauto
 dependencies[] = strongarm
 dependencies[] = token
 dependencies[] = transliteration
+dependencies[] = views_litepager
 configure = admin/config/ding
 features[ctools][] = page_manager:pages_default:1
 features[ctools][] = strongarm:strongarm:1

--- a/modules/ding_base/ding_base.install
+++ b/modules/ding_base/ding_base.install
@@ -201,3 +201,10 @@ function ding_base_update_7006() {
 function ding_base_update_7007() {
   _jquery_update_set_theme_version('seven', '1.7');
 }
+
+/**
+ * Enable Views litepager.
+ */
+function ding_base_update_7008() {
+  module_enable(array('views_litepager'));
+}

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -792,6 +792,11 @@ function ding_base_views_default_views_alter(&$views) {
       // There is no such filter so we have to add it.
       $views['admin_views_node']->display['default']->display_options['filters']['name'] = $filter_options;
     }
+
+    // Use Views lite pager for better performance. Especially on large innodb
+    // databases the COUNT(*) query performed by standard pager can become slow.
+    // See: https://www.drupal.org/project/views_litepager
+    $views['admin_views_node']->display['default']->display_options['pager']['type'] = 'lite';
   }
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3982

#### Description

The bpi and ding_base module is adding additional filters to the admin_views_node view resulting in the associated queries getting more complex and slow. Some of the larger libraries has even experienced timeouts.

The main problem appears to be the count-query performed by the pager as reported in the issue. Appearently these queries have scalability problems on innodb databases. I found a module which tries to solve this problem:

https://www.drupal.org/project/views_litepager

With the changes in this PR the pager provided by this module is used on admin_views_node.

The main disadvantage is that you can only navigate one page at a time, where before you could jump five pages a time. The description in the module also mentions that you can't navigate to the last page, but I don't think this is an issue, since you can just sort by asc/desc depending on which sort is currently used.

#### Screenshot of the result

![skaermbillede fra 2019-01-16 23 04 36](https://user-images.githubusercontent.com/5011234/51281617-4658b500-19e3-11e9-8927-1e7f10622a09.png)
#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Alternatively, we could look at the bpi_status filter added in `bpi_features_views_default_views_alter()`. In my tests, I found this filter to be the main culprit in the performance issues. After removing this, the performance was consistently much better  (from 200-300ms to  <  10ms). The filter could be removed or we could try to improve the perfomance. 

So if the business decides that the tradeoffs are not worth it, the next step would be to improve the perfomance of this filter or remove it. I also noticed that the workflow module, which supplies this filter, is a bit outdated.
