### PR TITLE
1353: Use hash on carousel id when generating lock and cache id

### DIFF
--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -79,7 +79,10 @@ function ting_search_carousel_ctools_plugin_directory($module, $plugin) {
  *   'next_offset', which is the next offset to use or -1.
  */
 function ting_search_carousel_get_entities(TingSearchCarouselQuery $query, $start, $count, $query_only = FALSE) {
-  $query_id = (string) $query;
+  // Extract an id representing the carousel query to use in lock and cache id.
+  // These are restricted to 255 characters in the DB, so we use a sha1 hash
+  // which is fast and always 40 characters.
+  $query_id = sha1((string) $query);
   $cache_data = array(
     // All found covers.
     'pool' => array(),


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1353

#### Description

TingSearchCarouselQuery is converted to a string ID by taking the configuration, converting it to JSON and base64 encoding it.

This string ID is then used as suffix for the lock and cache ids, when fetching items for the carousel. The problem is that these IDs can get very long preventing the module from obtaining a lock, since lock ids are restricted to 255 characters in the DB. As a consequence the search was never actually performed and the carousel just kept requesting new items because it always returned offset 0. (See screenshot).

Another effect was that the carousel items was never cached, but the problem with lock id is much more serious since it prevents the carousel from functioning at all.

I propose that we instead use a hash of the TingSearchCarouselQuery string id as suffix for the lock and cache id, to prevent it form getting to long,

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/5011234/51539426-42e68300-1e54-11e9-9aef-8679cd6f92c8.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
