### PR TITLE
4050: Ensure ding_webtrekk is activated on existing installs

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -702,3 +702,10 @@ function ding2_update_7060() {
   variable_del('webtrends_onsitedoms');
   variable_del('webtrends_dcs_id');
 }
+
+/**
+ * Ensure ding_webtrekk is activated on existing installs.
+ */
+function ding2_update_7061() {
+  module_enable(array('ding_webtrekk'));
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4050

#### Description

Apparently the business also wants to ensure that ding_webtrekk is activated on existing installs.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.