### PR TITLE
4092 cover link title

### DIFF
--- a/modules/ding_ting_frontend/ding_ting_frontend.features.field_instance.inc
+++ b/modules/ding_ting_frontend/ding_ting_frontend.features.field_instance.inc
@@ -583,7 +583,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting_covers',
         'settings' => array(
           'image_style' => 'ding_list_medium',
-          'link_type' => 'none',
+          'link_type' => 'object',
         ),
         'type' => 'ting_cover_default',
         'weight' => 1,
@@ -619,7 +619,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting_covers',
         'settings' => array(
           'image_style' => 'ding_list_medium',
-          'link_type' => 'none',
+          'link_type' => 'object',
         ),
         'type' => 'ting_cover_default',
         'weight' => 0,
@@ -629,7 +629,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting_covers',
         'settings' => array(
           'image_style' => 'ding_list_medium',
-          'link_type' => 'none',
+          'link_type' => 'collection',
         ),
         'type' => 'ting_cover_default',
         'weight' => 1,
@@ -639,7 +639,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting_covers',
         'settings' => array(
           'image_style' => 'ding_list_medium',
-          'link_type' => 'none',
+          'link_type' => 'object',
         ),
         'type' => 'ting_cover_default',
         'weight' => 0,
@@ -649,7 +649,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting_covers',
         'settings' => array(
           'image_style' => 'ding_list_medium',
-          'link_type' => 'none',
+          'link_type' => 'object',
         ),
         'type' => 'ting_cover_default',
         'weight' => 0,
@@ -659,7 +659,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting_covers',
         'settings' => array(
           'image_style' => 'ding_list_medium',
-          'link_type' => 'none',
+          'link_type' => 'object',
         ),
         'type' => 'ting_cover_default',
         'weight' => 0,

--- a/modules/ting_covers/ting_covers.theme.inc
+++ b/modules/ting_covers/ting_covers.theme.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Theme function default implementation for the module.
@@ -26,6 +27,8 @@ function template_preprocess_ting_object_cover(&$variables) {
   );
   $variables['image'] = '';
 
+  $variables['title'] = implode(', ', $object->creators) . ': ' . $object->title;
+
   if (cache_get('ting_covers:' . $object->id)) {
     // We know that there is no cover available for this object so avoid
     // further javascript processing.
@@ -34,17 +37,15 @@ function template_preprocess_ting_object_cover(&$variables) {
   else {
     $path = ting_covers_object_path($object->id);
     if (file_exists($path)) {
-      // Generate an alt tag.
-      $alt = implode(', ', $object->creators) . ': ' . $object->title;
-
       // Render the img element.
-      $variables['image'] = theme('image_style', array(
-                              'style_name' => $variables['image_style'],
-                              'path' => $path,
-                              'alt' => $alt,
-                            ));
+      $params = array(
+        'style_name' => $variables['image_style'],
+        'path' => $path,
+        'alt' => $variables['title'],
+      );
+      $variables['image'] = theme('image_style', $params);
 
-      // Avoid further javascript processing. Just load the image.
+      // Avoid further javascriqpt processing. Just load the image.
       $variables['classes'][] = 'ting-cover-processed';
     }
   }
@@ -57,13 +58,20 @@ function template_preprocess_ting_object_cover(&$variables) {
  */
 function theme_ting_object_cover($variables) {
   $data = "";
+  $attributes = array(
+    'class' => $variables['classes'],
+  );
   foreach ($variables['data'] as $name => $value) {
     $data .= 'data-' . $name . '="' . htmlentities($value) . '" ';
+    $attributes['data-' . $name] = $value;
   }
 
   if ($variables['link'] === FALSE) {
-    return '<div class="' . implode(' ', $variables['classes']) . '" ' . trim($data) . '>' . $variables['image'] . '</div>';
+    return '<div ' . drupal_attributes($attributes) . '>' . $variables['image'] . '</div>';
   }
 
-  return '<a href="' . url($variables['link']) . '" class="' . implode(' ', $variables['classes']) . '" ' . trim($data) . '>' . $variables['image'] . '</a>';
+  $attributes['href'] = url($variables['link']);
+  $attributes['title'] = $variables['title'];
+
+  return '<a ' . drupal_attributes($attributes) . '>' . $variables['image'] . '</a>';
 }

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -250,7 +250,7 @@
   &.view-mode-reference-teaser {
     padding: 15px 0;
     background-color: $grey;
-    .cover {
+    .ting-cover {
       @include span-columns(2 of 7);
       padding-left: 15px;
       min-height: 1px;
@@ -343,7 +343,7 @@
   &.view-mode-ting-reference-preview {
     padding: 0;
     background-color: transparent;
-    .cover {
+    .ting-cover {
       @include span-columns(1 of 6);
       padding-left: 0;
       min-height: 1px;

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -767,6 +767,8 @@ function ddbasic_process_ting_object(&$vars) {
       break;
 
     case 'ting_object':
+      $uri_object = entity_uri('ting_object', $vars['object']);
+
       switch ($vars['elements']['#view_mode']) {
 
         // Teaser.

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -767,13 +767,6 @@ function ddbasic_process_ting_object(&$vars) {
       break;
 
     case 'ting_object':
-
-      $uri_collection = entity_uri('ting_collection', $vars['object']);
-      $vars['ting_object_url_collection'] = url($uri_collection['path']);
-
-      $uri_object = entity_uri('ting_object', $vars['object']);
-      $vars['ting_object_url_object'] = url($uri_object['path']);
-
       switch ($vars['elements']['#view_mode']) {
 
         // Teaser.

--- a/themes/ddbasic/templates/material-item.tpl.php
+++ b/themes/ddbasic/templates/material-item.tpl.php
@@ -7,7 +7,6 @@
  * Variables available:
  * - $zebra: odd/even class
  * - $checkbox: Checkbox
- * - $ting_object_url_object: Url to Ting object
  * - $cover: Cover-image for material
  * - $information: Array of informations
  * - $material_message: Material message.

--- a/themes/ddbasic/templates/ting_object/ting-object--view-mode--collection-list.tpl.php
+++ b/themes/ddbasic/templates/ting_object/ting-object--view-mode--collection-list.tpl.php
@@ -11,9 +11,7 @@
 ?>
 <div class="<?php print $classes; ?> list-item-style clearfix"<?php print $attributes; ?>>
   <div class="inner">
-    <a href="<?php print $ting_object_url_object; ?>">
-      <?php print render($content['group_ting_left_col_collection']); ?>
-    </a>
+    <?php print render($content['group_ting_left_col_collection']); ?>
     <?php print render($content); ?>
   </div>
 </div>

--- a/themes/ddbasic/templates/ting_object/ting-object--view-mode--reference-teaser.tpl.php
+++ b/themes/ddbasic/templates/ting_object/ting-object--view-mode--reference-teaser.tpl.php
@@ -10,8 +10,6 @@
  */
 ?>
 <div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
-  <a href="<?php print $ting_object_url_object; ?>" class="cover">
-    <?php print render($content['ting_cover']); ?>
-  </a>
+  <?php print render($content['ting_cover']); ?>
   <?php print render($content); ?>
 </div>

--- a/themes/ddbasic/templates/ting_object/ting-object--view-mode--search-result.tpl.php
+++ b/themes/ddbasic/templates/ting_object/ting-object--view-mode--search-result.tpl.php
@@ -11,9 +11,7 @@
 ?>
 <div class="<?php print $classes; ?> list-item-style clearfix"<?php print $attributes; ?>>
   <div class="inner">
-    <a href="<?php print $ting_object_url_collection; ?>">
-      <?php print render($content['group_ting_left_col_search']); ?>
-    </a>
+    <?php print render($content['group_ting_left_col_search']); ?>
     <?php print render($content); ?>
   </div>
 </div>

--- a/themes/ddbasic/templates/ting_object/ting-object--view-mode--teaser-no-overlay.tpl.php
+++ b/themes/ddbasic/templates/ting_object/ting-object--view-mode--teaser-no-overlay.tpl.php
@@ -13,9 +13,7 @@
 ?>
 <div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
   <div class="inner">
-    <a href="<?php print $ting_object_url_object; ?>">
-      <?php print render($content['ting_cover']); ?>
-    </a>
+    <?php print render($content['ting_cover']); ?>
     <?php print render($content); ?>
 
   </div>

--- a/themes/ddbasic/templates/ting_object/ting-object--view-mode--teaser.tpl.php
+++ b/themes/ddbasic/templates/ting_object/ting-object--view-mode--teaser.tpl.php
@@ -12,9 +12,7 @@
 ?>
 <div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
   <div class="inner">
-    <a href="<?php print $ting_object_url_object; ?>">
-      <?php print render($content['ting_cover']); ?>
-    </a>
+    <?php print render($content['ting_cover']); ?>
     <?php print render($content); ?>
 
   </div>

--- a/themes/ddbasic/templates/ting_object/ting-object--view-mode--ting-reference-preview.tpl.php
+++ b/themes/ddbasic/templates/ting_object/ting-object--view-mode--ting-reference-preview.tpl.php
@@ -10,9 +10,7 @@
  */
 ?>
 <div class="<?php print $classes; ?> clearfix"<?php print $attributes; ?>>
-  <a href="<?php print $ting_object_url_object; ?>" class="cover">
-    <?php print render($content['ting_cover']); ?>
-  </a>
+  <?php print render($content['ting_cover']); ?>
   <?php print render($content); ?>
   <div class="ting-object-new-in-list"><?php print t('New in list'); ?></div>
 </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4092

#### Description

Adds title attribute to cover links.

First commit fixes the ting_cover field formatter.

The second re-activates the link on teaser display modes and removes the link generated by `ddbasic_process_ting_object()` and added to all ting_object teaser templates.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/51830492-4795b600-22f0-11e9-851d-216a70ebf752.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
