### PR TITLE
4086: Replace search hidden heading with role attribute.

### DIFF
--- a/modules/ting_search/ting_search.module
+++ b/modules/ting_search/ting_search.module
@@ -167,6 +167,10 @@ function ting_search_theme($existing, $type, $theme, $path) {
  * For the form search_block_form.
  */
 function ting_search_form_search_block_form_alter(&$form, &$form_state, $form_id) {
+  // Screenreaders and SEO uses the role attribute to know that this is a
+  // search form. This means hidden headings are not necessary.
+  $form['#attributes']['role'] = 'search';
+
   // Remove the form token so the form becomes cachable. If we don't, all
   // pages with the search form becomes un-cachable, as drupal_validate_form()
   // will check the token and fail if the current user is not the same as the

--- a/themes/ddbasic/templates/search-block-form.tpl.php
+++ b/themes/ddbasic/templates/search-block-form.tpl.php
@@ -30,8 +30,5 @@
  */
 ?>
 <div>
-  <?php if (empty($variables['form']['#block']->subject)): ?>
-    <h2 class="element-invisible"><?php print t('Search form'); ?></h2>
-  <?php endif; ?>
   <?php print $search_form; ?>
 </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4086

#### Description

Screenreaders and SEO uses the role attribute to know that this is a search form. This means hidden headings are not necessary.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
