### PR TITLE
4116: Add clearfix so wrapper doesn't collapse

### DIFF
--- a/themes/ddbasic/templates/fields/field--ting-reference-reverse--ting-object.tpl.php
+++ b/themes/ddbasic/templates/fields/field--ting-reference-reverse--ting-object.tpl.php
@@ -17,7 +17,7 @@
 
   <div class="ting-reference-reverse-list">
     <div class="search-results">
-      <ul class="list floated">
+      <ul class="list floated clearfix">
         <?php foreach ($items as $delta => $item): ?>
           <li class="list-item search-result"><?php print render($item); ?></li>
         <?php endforeach; ?>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4116

#### Description

Add clearfix so wrapper doesn't collapse.

Not using so many 100% width and left floated divs would be better,
but no time for that.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
