### PR TITLE
4121: Make sure that language suffix is displayed.

### DIFF
--- a/modules/ting/ting.field.inc
+++ b/modules/ting/ting.field.inc
@@ -397,10 +397,11 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
         /* @var \TingEntity $entity */
         $title_suffix_types = variable_get('ting_language_type_title_suffix', []);
         $default_language = variable_get('ting_language_default');
-        $is_title_suffix_type = in_array($entity->getType(), $title_suffix_types);
+        $is_title_suffix_type = in_array(strtolower($entity->getType()), $title_suffix_types);
         $language = $entity->getLanguage();
         $has_language = !empty($language);
         $is_default_language = $language == $default_language;
+
         if ($is_title_suffix_type && $has_language && !$is_default_language) {
           $title .= " ($language)";
         }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4121

#### Description

The language suffix was never displayed, as `$entity->getType()` returned the type with an uppercase, whilst the `variable_get('ting_language_type_title_suffix', []);` array had lower case elements.

#### Screenshot of the result

It adds the "(Norsk)":

<img width="207" alt="screenshot 2019-01-29 at 11 43 41" src="https://user-images.githubusercontent.com/12376583/51902814-251c9f00-23bb-11e9-8d63-905ee4c64817.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.