### PR TITLE
3860 by Inlead: Make original and copy messages the same.

### DIFF
--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -69,18 +69,21 @@ function ding_contact_contact_form_stop_redirect($form, &$form_state) {
  * Implements hook_mail_alter().
  */
 function ding_contact_mail_alter(&$message) {
-  if ('contact_page_mail' == $message['id']) {
-    $subject = $message['subject'];
-    $sitename = variable_get('site_name', 'DDB CMS');
-    $default_from = variable_get('site_mail', ini_get('sendmail_from'));
-    $from_value = t('"!subject via !site_name" <!site_mail>', array(
-      '!subject' => $subject,
-      '!site_name' => $sitename,
-      '!site_mail' => $default_from,
-    ));
-    $message['from'] = $from_value;
-    $message['headers']['From'] = $from_value;
-    $message['headers']['Reply-To'] = $message['params']['mail'];
-    $message['headers']['Sender'] = $sitename;
+  switch ($message['id']) {
+    case 'contact_page_mail':
+    case 'contact_page_copy':
+      $subject = $message['subject'];
+      $sitename = variable_get('site_name', 'DDB CMS');
+      $default_from = variable_get('site_mail', ini_get('sendmail_from'));
+      $from_value = t('"!subject via !site_name" <!site_mail>', array(
+        '!subject' => $subject,
+        '!site_name' => $sitename,
+        '!site_mail' => $default_from,
+      ));
+      $message['from'] = $from_value;
+      $message['headers']['From'] = $from_value;
+      $message['headers']['Reply-To'] = $message['params']['mail'];
+      $message['headers']['Sender'] = $sitename;
+      break;
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3860

#### Description

Original message and copy message sent from contact form had different headers. This commit fixes this issue so now the original and copy messages have the same headers.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.