### PR TITLE
3638 by Inlead: Validate image dropdown only on BPI push.

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -839,6 +839,9 @@ function bpi_form_workflow_transition_form_validate(&$form, &$form_state) {
     if (empty($form_state['values']['bpi_push_audience'])) {
       form_set_error('bpi_push_audience', t('Audience must be set when pushing to BPI.'));
     }
+    if (empty($form_state['values']['bpi_push_images'])) {
+      form_set_error('bpi_push_images', t('Image permissions should be explicitly set when pushing to BPI.'));
+    }
   }
   array_unshift($form_state['submit_handlers'], 'bpi_form_workflow_transition_form_submit');
 }

--- a/modules/bpi/bpi.push.inc
+++ b/modules/bpi/bpi.push.inc
@@ -62,7 +62,6 @@ function bpi_http_push_action_form($nid) {
     ),
     '#description' => t('You should have permission to publish the images before selecting this option.'),
     '#empty_option' => t('- choose -'),
-    '#required' => TRUE,
   );
 
   $form['configurations']['bpi_push_refs'] = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3638

#### Description

Removed the visible requirement of a field, and moved it to error message upon push to BPI is clicked.

#### Screenshot of the result

![pasted_image_at_2019-01-29__4_57_pm](https://user-images.githubusercontent.com/570630/51917671-5196e200-23e0-11e9-9998-4bcc6a55d9a7.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.