### PR TITLE
3667: Enable dropdown function, for header search.

### DIFF
--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -441,8 +441,8 @@ function ting_field_search_preprocess_html(&$vars) {
     }
 
     // If the profile has visibility all always expand the search field.
-    if (ting_field_search_is_profile_visible($profile)) {
-      $vars['classes_array'][] = 'extended-search-is-open';
+    if (!ting_field_search_is_profile_visible($profile)) {
+      $vars['classes_array'][] = 'extended-search-is-not-open';
       break;
     }
   }

--- a/modules/ting_search/ting_search.module
+++ b/modules/ting_search/ting_search.module
@@ -211,14 +211,6 @@ function ting_search_form_search_block_form_alter(&$form, &$form_state, $form_id
     '#attributes' => array('id' => 'controls_search_size'),
   );
 
-  switch (variable_get('ting_search_form_style', TING_SEARCH_FORM_STYLE_NORMAL)) {
-    case TING_SEARCH_FORM_STYLE_EXTENDED:
-      $form['search_extended_open_button'] = array(
-        '#markup' => '<a href="#" class="search-extended-button">Search extended button</a>',
-      );
-      break;
-  }
-
   // Completely take over the search form submit flow, by removing the default
   // search_box_form_submit handler replacing it with our own as the first.
   // This prevents overriding other handlers and gives other modules a chance

--- a/themes/ddbasic/sass/base/standard.scss
+++ b/themes/ddbasic/sass/base/standard.scss
@@ -39,27 +39,35 @@ body {
     background-color: $charcoal;
     overflow: hidden;
   }
-  // When second level menu is visible
-  &.has-second-level-menu {
-    padding-top: $header-height + $second-level-menu-height; // Compensate for fixed header
-    // Tablet
+
+  &.has-second-level-menu,
+  &.search-form-extended {
     @include media($tablet) {
       padding-top: $header-height; // Compensate for fixed header
     }
   }
-  // When search form is extended
-  &.search-form-extended {
-    padding-top: $header-height + $search-form-extended-height; // Compensate for fixed header
-    // Tablet
-    @include media($tablet) {
-      padding-top: $header-height; // Compensate for fixed header
-    }
-    // When second level menu is visible & search form is extended
+
+  @include media($tablet-min-width) {
     &.has-second-level-menu {
-      padding-top: $header-height + $search-form-extended-height + $second-level-menu-height; // Compensate for fixed header
-      // Tablet
-      @include media($tablet) {
-        padding-top: $header-height; // Compensate for fixed header
+      padding-top: $header-height + $second-level-menu-height;
+    }
+  }
+
+
+  $_selectors-padding-top-values--body: (
+    '.search-form-extended': $header-height + $search-form-extended-height,
+    '.search-form-extended.extended-search-is-not-open': $header-height
+  );
+
+  @each $_selector, $_value in $_selectors-padding-top-values--body {
+    @include media($tablet-min-width) {
+
+      &#{$_selector} {
+        padding-top: $_value;
+      }
+
+      &#{$_selector}.has-second-level-menu {
+        padding-top: $_value + $second-level-menu-height;
       }
     }
   }

--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -246,7 +246,7 @@ a.topbar-link-user {
   @include button(profile);
   .pane-login-is-open & {
     &::after {
-      content: "\e907";
+      @extend %icon-close;
     }
   }
 }
@@ -261,7 +261,7 @@ a.topbar-link-menu {
   }
   .mobile-menu-is-open & {
     &::after {
-      content: "\e907";
+      @extend %icon-close;
     }
   }
 }
@@ -271,7 +271,7 @@ a.topbar-link-search {
   @include button(search, $white);
   .mobile-search-is-open & {
     &::after {
-      content: "\e907";
+      @extend %icon-close;
     }
   }
 }
@@ -303,7 +303,7 @@ a.topbar-link-user-account {
 
 // Search extended open button
 a.search-extended-button {
-  @include button(search, $white, $charcoal);
+  @include button(close, $white, $charcoal);
   width: 54px;
   height: 54px;
   padding: 0;
@@ -312,13 +312,10 @@ a.search-extended-button {
     text-indent: 0;
     right: 0;
   }
-  .extended-search-is-open & {
+  .extended-search-is-not-open & {
     &::after {
-      content: "\e907";
+      @extend %icon-search;
     }
-  }
-  .front & {
-    display: none;
   }
 }
 

--- a/themes/ddbasic/sass/components/header.scss
+++ b/themes/ddbasic/sass/components/header.scss
@@ -33,6 +33,19 @@
     .toolbar & {
       top: $toolbar-height;
     }
+
+    .search-extended-button {
+      @include media($tablet) {
+        display: block;
+      }
+
+      display: none;
+      position: absolute;
+      // 15px to position it in the middle of the bar.
+      top: $topbar-height + 15px;
+      right: 5%;
+      z-index: 5;
+    }
   }
   .topbar-inner {
     @include wrapper;
@@ -105,7 +118,6 @@
       }
     }
     .topbar-menu {
-
       // Tablet
       @include media($tablet) {
         width: 100%;
@@ -116,7 +128,6 @@
         background-color: $color-primary;
         box-shadow: $box-shadow;
       }
-
     }
     .pane-current-user-name {
       float: right;
@@ -177,7 +188,8 @@
     .pane-search-form {
       @include transition(
         transform $speed $ease,
-        top 0ms $ease $speed
+        top 0ms $ease $speed,
+        margin 0ms $ease $speed
       );
       @include span-columns(3);
       @include omega;
@@ -254,7 +266,7 @@
           box-shadow $speed $ease
         );
         position: fixed;
-        z-index: $z-header - 1;
+        z-index: $z-header - 10;
         width: 100%;
         background-color: $charcoal;
 
@@ -272,16 +284,6 @@
           @include media($tablet) {
             position: relative;
             width: 100%;
-          }
-        }
-        .search-extended-button {
-          position: absolute;
-          right: 0;
-          top: $search-form-extended-height;
-
-          // Tablet
-          @include media($tablet) {
-            display: none;
           }
         }
 
@@ -378,9 +380,6 @@
       // Search form extended
       .search-form-extended & {
         box-shadow: $box-shadow;
-        .search-extended-button {
-          display: none;
-        }
 
         // Tablet
         @include media($tablet) {
@@ -440,6 +439,7 @@
     .navigation-inner {
       @include wrapper;
       position: relative;
+      min-height: $search-form-extended-height;
 
       // Tablet
       @include media($tablet) {
@@ -451,6 +451,31 @@
           box-shadow: $box-shadow;
         }
       }
+
+      // Leaving space for .search-extended-button button.
+      .has-search-dropdown & {
+        padding-right: 69px;
+
+        @include media($tablet) {
+          padding-right: 0;
+        }
+      }
+
+      .search-extended-button {
+        .has-search-dropdown & {
+          display: block;
+
+          @include media($tablet) {
+            display: none;
+          }
+        }
+
+        display: none;
+        position: absolute;
+        top: 15px;
+        right: 0;
+      }
+
       .main-menu-wrapper {
         @include transition(
           transform $speed $ease,
@@ -471,12 +496,14 @@
         }
       }
       .secondary-menu-wrapper {
+        position: relative;
         display: none;
+
         // Search Form Extended
         .show-secondary-menu & {
           display: block;
           float: right;
-          padding-right: 69px;
+
 
           // Tablet
           @include media($tablet) {
@@ -484,10 +511,8 @@
             background-color: $grey;
           }
         }
-        // Search Form Extended
-        .search-form-extended & {
-          padding-right: 0;
-        }
+
+
       }
       .pane-menu-block-main-menu-second-level {
         @include transition(top $speed $ease);
@@ -556,153 +581,89 @@
   // These elements are placed on the page using fixed positioning, and because
   // of this they need to have a set height from the top.
   .pane-search-form {
+    // There is a lot of combinations of classes which effect the "top" property.
+    // This mixin solution was made as an alternative to having a bunch of
+    // {codeblocks} which all did basically the same thing.
+    // Using this mixin allows it to be more maintainable also.
+    // @NOTICE: for pane-search-form, it adds a base value to the values.
+    // $_base-top-value below.
+    $_base-top-value: $topbar-height;
+
+    $_selectors-top-values--search-form: (
+      // .admin-menu does not need the base value added.
+      '.admin-menu': $admin-menu-height - $_base-top-value,
+      '.admin-menu-with-shortcuts': $toolbar-height,
+      '.toolbar': $toolbar-height,
+      '.search-form-extended': $search-form-extended-height,
+      '.search-form-extended.admin-menu': $search-form-extended-height + $admin-menu-height,
+      '.search-form-extended.admin-menu-with-shortcuts': $search-form-extended-height + $toolbar-height,
+      '.search-form-extended.toolbar': $search-form-extended-height + $toolbar-height,
+      '.search-form-extended.admin-menu.has-second-level-menu': $search-form-extended-height + $admin-menu-height + $second-level-menu-height,
+      '.search-form-extended.admin-menu-with-shortcuts.has-second-level-menu': $search-form-extended-height + $toolbar-height + $second-level-menu-height,
+      '.search-form-extended.toolbar.has-second-level-menu': $search-form-extended-height + $toolbar-height + $second-level-menu-height,
+      // When the search bar is  extended, the search form will be moved out
+      // of view, below the menu above.
+      '.search-form-extended.extended-search-is-not-open': 0,
+    );
+
+    @each $_selector, $_value in $_selectors-top-values--search-form {
+      #{$_selector} & {
+        top: $_base-top-value + $_value;
+      }
+
+      @include media($tablet-min-width) {
+        #{$_selector}.has-second-level-menu & {
+          top: $_base-top-value + $_value + $second-level-menu-height;
+        }
+      }
+    }
+
     top: 0;
 
+    // For readability, we'll leave media queries out of the mixin above.
     @include media($tablet) {
       top: $header-height;
 
       .mobile-menu-is-open & {
         padding-bottom: $header-height;
       }
-    }
 
-    // Admin menu
-    .admin-menu & {
-      top: $admin-menu-height;
-    }
-
-    @include media($tablet) {
-      top: $header-height;
-
-      // Admin menu
       .admin-menu & {
         top: $header-height + $admin-menu-height;
       }
-    }
 
-    // Admin menu with shortcuts or toolbar
-    .admin-menu-with-shortcuts &,
-    .toolbar & {
-      top: $topbar-height + $toolbar-height;
-    }
-
-    // Search Form Extended
-    .search-form-extended & {
-      top: $topbar-height;
-
-      // Tablet
-      @include media($tablet) {
+      .search-form-extended.extended-search-is-not-open &,
+      .search-form-extended & {
         top: $header-height;
       }
-    }
-
-    // Search Form Extended with admin-menu
-    .search-form-extended.admin-menu & {
-      top: $topbar-height + $admin-menu-height;
-    }
-
-    // Search Form Extended with admin menu shortcuts or toolbar
-    .search-form-extended.admin-menu-with-shortcuts &,
-    .search-form-extended.toolbar & {
-      top: $topbar-height + $toolbar-height;
-    }
-
-    .search-form-extended & {
-      top: $topbar-height + $search-form-extended-height;
-    }
-
-    // Search Form Extended with admin-menu
-    .search-form-extended.admin-menu & {
-      top: $topbar-height + $search-form-extended-height + $admin-menu-height;
-    }
-
-    // Search Form Extended with admin menu shortcuts or toolbar
-    .search-form-extended.admin-menu-with-shortcuts &,
-    .search-form-extended.toolbar &{
-      top: $topbar-height + $search-form-extended-height + $toolbar-height;
-    }
-
-    .search-form-extended.has-second-level-menu & {
-      top: $topbar-height + $search-form-extended-height + $second-level-menu-height;
-    }
-
-    // Search Form Extended with admin-menu
-    .search-form-extended.admin-menu.has-second-level-menu & {
-      top: $topbar-height + $search-form-extended-height + $admin-menu-height + $second-level-menu-height;
-    }
-
-    // Search Form Extended with admin menu shortcuts or toolbar
-    .search-form-extended.admin-menu-with-shortcuts.has-second-level-menu &,
-    .search-form-extended.toolbar.has-second-level-menu &{
-      top: $topbar-height + $search-form-extended-height + $toolbar-height + $second-level-menu-height;
     }
   }
 
   .navigation-wrapper {
+    // There is a lot of combinations of classes which effect the "top" property.
+    // This mixin solution was made as an alternative to having a bunch of
+    // {codeblocks} which all did basically the same thing.
+    // Using this mixin allows it to be more maintainable also.
+    $_selectors-top-values--navigation-wrapper: (
+      '.mobile-search-is-open': $header-height,
+      '.admin-menu': $topbar-height + $admin-menu-height,
+      '.admin-menu-with-shortcuts': $toolbar-height,
+      '.toolbar': $toolbar-height,
+      '.search-form-extended.admin-menu': $topbar-height + $admin-menu-height,
+      '.search-form-extended.admin-menu-with-shortcuts': $topbar-height + $toolbar-height,
+      '.search-form-extended.toolbar': $topbar-height + $toolbar-height
+    );
+
+    @each $_selector, $_value in $_selectors-top-values--navigation-wrapper {
+      #{$_selector} & {
+        top: $_value;
+      }
+    }
+
     top: $topbar-height;
-
-    @include media($mobile) {
-      top: $header-height - $topbar-height;
-      .mobile-usermenu-is-open & {
-        padding-bottom: $header-height - $topbar-height;
-      }
-    }
-
-    .search-form-extended & {
-      top: -20px;
-    }
-
-    // Admin menu
-    .admin-menu & {
-      top: $topbar-height + $admin-menu-height;
-    }
-
-    // Admin menu with shortcuts and toolbar.
-    .admin-menu-with-shortcuts &,
-    .toolbar & {
-      top: $toolbar-height;
-    }
-
-    // Search Form Extended & admin menu
-    .search-form-extended.admin-menu & {
-      top: $admin-menu-height - 20px;
-    }
-
-    // Search Form Extended with admin menu shortcuts or toolbar
-    .search-form-extended.admin-menu-with-shortcuts &,
-    .search-form-extended.toolbar & {
-      top: $toolbar-height - 20px;
-    }
-
-    // Search Form Extended
-    .search-form-extended & {
-      top: $topbar-height;
-
-      // Tablet
-      @include media($tablet) {
-        top: $header-height;
-      }
-    }
-
-    // Search Form Extended with admin-menu
-    .search-form-extended.admin-menu & {
-      top: $topbar-height + $admin-menu-height;
-    }
-
-    // Search Form Extended with admin menu shortcuts or toolbar
-    .search-form-extended.admin-menu-with-shortcuts &,
-    .search-form-extended.toolbar &  {
-      top: $topbar-height + $toolbar-height;
-    }
-
-    // Mobile search open
-    .mobile-search-is-open & {
-      top: $header-height;
-    }
 
     .pane-menu-block-main-menu-second-level {
       top: $header-height;
-
       // Admin menu
       .admin-menu & {
         top: $header-height + $admin-menu-height;
@@ -712,6 +673,18 @@
       .toolbar & {
         top: $header-height + $toolbar-height;
       }
+    }
+
+    // For readability, we'll leave media queries out of the mixin above.
+    @include media($mobile) {
+      top: $header-height - $topbar-height;
+      .mobile-usermenu-is-open & {
+        padding-bottom: $header-height - $topbar-height;
+      }
+    }
+
+    @include media($tablet) {
+      top: $header-height;
     }
   }
 }

--- a/themes/ddbasic/sass/components/menu.scss
+++ b/themes/ddbasic/sass/components/menu.scss
@@ -442,10 +442,12 @@ ul.topbar-menu {
 
       // Tablet
       @include media($tablet) {
-        width: 54px;
+        $_topbar-link-width: 54px;
+
+        width: $_topbar-link-width;
         a {
           width: 100%;
-          height: 54px;
+          height: $_topbar-link-width;
           padding: 0;
           text-indent: -9999px;
           &::after {

--- a/themes/ddbasic/sass/configuration/_extend.scss
+++ b/themes/ddbasic/sass/configuration/_extend.scss
@@ -84,6 +84,10 @@
   content: "\e90c";
 }
 
+%icon-close {
+  content: "\e907";
+}
+
 %icon-arrow-right-small {
   content: "\e903";
 }

--- a/themes/ddbasic/sass/configuration/_grid-settings.scss
+++ b/themes/ddbasic/sass/configuration/_grid-settings.scss
@@ -10,5 +10,6 @@ $grid-columns: 12;
 $max-width: 1124px;
 
 $notebook: new-breakpoint(max-width 1100px 12);
+$tablet-min-width: new-breakpoint(min-width 950px 12);
 $tablet: new-breakpoint(max-width 950px 12);
 $mobile: new-breakpoint(max-width 600px 12);

--- a/themes/ddbasic/scripts/menu.js
+++ b/themes/ddbasic/scripts/menu.js
@@ -104,7 +104,7 @@
 
       search_extended_btn.on('click', function(evt) {
         evt.preventDefault();
-        body.toggleClass('extended-search-is-open');
+        body.toggleClass('extended-search-is-not-open');
       });
 
       // Tablet/mobile menu logout

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -34,14 +34,14 @@ function ddbasic_preprocess_html(&$vars) {
       $vars['classes_array'][] = 'search-form-extended';
       $vars['classes_array'][] = 'show-secondary-menu';
 
+      // The search form should only be expanded on certain pages.
       $path = menu_get_item()['path'];
-      switch ($path) {
-        case 'search/ting/%';
-        case 'search/ting';
-        case 'search/node/%';
-        case 'ding_frontpage':
-          $vars['classes_array'][] = 'extended-search-is-open';
+
+      if (!in_array($path, ['search/ting/%', 'search/ting', 'search/node/%', 'ding_frontpage'])) {
+        $vars['classes_array'][] = 'extended-search-is-not-open';
+        $vars['classes_array'][] = 'has-search-dropdown';
       }
+
       break;
   }
 

--- a/themes/ddbasic/templates/panel-layout/ding2-site-template.tpl.php
+++ b/themes/ddbasic/templates/panel-layout/ding2-site-template.tpl.php
@@ -20,6 +20,7 @@
         <section class="navigation-wrapper js-topbar-menu">
           <div class="navigation-inner">
             <?php print render($content['navigation']); ?>
+            <a href="#" class="search-extended-button"></a>
           </div>
         </section>
       <?php endif; ?>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3667

#### Description
In relation to a previous revision where the header
structure was moved around, the functionality of
being able to fold/unfold the search line disappeared.

This commit looks to fix that, and also tries to clean up
all the mess in regards to the various combinations that
the header can be displayed in.
#### Screenshot of the result

The biggest issue of these changes was making sure that everything worked across all the various combinations.
Taking screenshots of all of that would take forever, but essentially it should just look like the production sites - except the two elements should finally be switched in the header.

See here:
https://github.com/ding2/ding2/pull/1322
and
https://platform.dandigbib.org/issues/3667

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you test this (and you are very welcome!!) then make sure to test it across all the different combinations - here are some:
- There are 3 different styles of the search bar, which can be set at admin/config/ting/search
- If you are on a search or frontpage, the bar will always be visible
- If you are on any other page, the extended search bars will be hidden with a fold out
- ... and then you need to test all of the above across responsiveness
- ... AND THEN you need to test it if it also works with a submenu
- ... AND THEN you need to test all of the above again, to see if it also works with sub-links in the main menu