### PR TITLE
1604 by Inlead: Default enable Nodelist and Section.

### DIFF
--- a/ding2.info
+++ b/ding2.info
@@ -43,6 +43,8 @@ dependencies[] = ding_p2_installer
 dependencies[] = ding_ddbasic
 dependencies[] = ding_ddbasic_opening_hours
 dependencies[] = ding_social_links
+dependencies[] = ding_sections
+dependencies[] = ding_nodelist
 
 ; Cache/performance modules
 dependencies[] = entitycache

--- a/ding2.install
+++ b/ding2.install
@@ -716,3 +716,13 @@ function ding2_update_7061() {
 function ding2_update_7062() {
   ding2_translation_update();
 }
+
+/**
+ * Enable Section and Nodelist modules.
+ */
+function ding2_update_7063() {
+  module_enable(array(
+    'ding_sections',
+    'ding_nodelist',
+  ));
+}

--- a/modules/ding_sections/ding_sections.install
+++ b/modules/ding_sections/ding_sections.install
@@ -20,7 +20,7 @@ function ding_sections_install() {
   ));
 
   $submodules = array(
-    'ding_sections_header_image',
+    'ding_sections_custom_css',
     'ding_sections_term_menu',
     'ding_sections_term_panel',
   );


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1604

#### Description

Enable ding_sections and ding_nodelist by default.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.