### PR TITLE
3667: Support multi-lines in main menu.

### DIFF
--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -434,6 +434,8 @@ function ting_field_search_ting_search_settings_submit($form, &$form_state) {
 function ting_field_search_preprocess_html(&$vars) {
   $profiles = ting_field_search_profiles_load_all();
 
+  $vars['display_extended_search'] = FALSE;
+
   foreach ($profiles as $profile) {
     // Expended search box not checked go to the next profile.
     if (!array_key_exists('search_box', $profile->config['user_interaction']) || !$profile->config['user_interaction']['search_box']) {
@@ -441,8 +443,8 @@ function ting_field_search_preprocess_html(&$vars) {
     }
 
     // If the profile has visibility all always expand the search field.
-    if (!ting_field_search_is_profile_visible($profile)) {
-      $vars['classes_array'][] = 'extended-search-is-not-open';
+    if (ting_field_search_is_profile_visible($profile)) {
+      $vars['display_extended_search'] = TRUE;
       break;
     }
   }

--- a/themes/ddbasic/sass/base/standard.scss
+++ b/themes/ddbasic/sass/base/standard.scss
@@ -73,14 +73,14 @@ body {
 
       &#{$_selector}.has-second-level-menu {
         padding-top: $_value + $second-level-menu-height;
-
-        // If there are too many links, we need to add even more padding.
-        &.secondary-menu-below-main {
-          padding-top: $_value + $second-level-menu-height + $search-form-extended-height;
-        }
       }
 
-
+      // If there are too many links, we need to add even more padding.
+      &#{$_selector}.has-second-level-menu.secondary-menu-below-main,
+      &#{$_selector}.has-second-level-menu.has-multiline-main-menu,
+      &#{$_selector}.secondary-menu-below-main {
+        padding-top: $_value + $second-level-menu-height + $search-form-extended-height;
+      }
     }
   }
 }

--- a/themes/ddbasic/sass/components/header.scss
+++ b/themes/ddbasic/sass/components/header.scss
@@ -486,8 +486,6 @@
           width: 100%;
         }
 
-        min-height: $search-form-extended-height;
-
         // Search form extended
         .search-form-extended & {
           width: auto;
@@ -519,6 +517,11 @@
           .secondary-menu-below-main.has-second-level-menu & {
             margin-top: $second-level-menu-height;
           }
+
+          .has-multiline-main-menu &,
+          .has-multiline-main-menu.has-second-level-menu & {
+            margin-top: -$search-form-extended-height;
+          }
         }
 
       }
@@ -534,6 +537,12 @@
         // Tablet
         @include media($tablet) {
           display: none;
+        }
+
+        @include media($tablet-min-width) {
+          .has-multiline-main-menu & {
+            margin-top: $search-form-extended-height;
+          }
         }
 
         &::before {
@@ -606,9 +615,6 @@
       '.search-form-extended.admin-menu': $search-form-extended-height + $admin-menu-height,
       '.search-form-extended.admin-menu-with-shortcuts': $search-form-extended-height + $toolbar-height,
       '.search-form-extended.toolbar': $search-form-extended-height + $toolbar-height,
-      '.search-form-extended.admin-menu.has-second-level-menu': $search-form-extended-height + $admin-menu-height + $second-level-menu-height,
-      '.search-form-extended.admin-menu-with-shortcuts.has-second-level-menu': $search-form-extended-height + $toolbar-height + $second-level-menu-height,
-      '.search-form-extended.toolbar.has-second-level-menu': $search-form-extended-height + $toolbar-height + $second-level-menu-height,
       // When the search bar is  extended, the search form will be moved out
       // of view, below the menu above.
       '.search-form-extended.extended-search-is-not-open': 0,
@@ -629,9 +635,14 @@
           top: $_base-top-value + $_value + $second-level-menu-height;
         }
 
-        // If there are too many links, we need to add even more padding.
-        #{$_selector}.has-second-level-menu.secondary-menu-below-main & {
+        #{$_selector}.has-second-level-menu.secondary-menu-below-main &,
+        #{$_selector}.has-second-level-menu.has-multiline-main-menu & {
           top: $_base-top-value + $_value + $second-level-menu-height + $search-form-extended-height;
+        }
+
+        // If there are too many links, we need to add even more padding.
+        #{$_selector}.has-multiline-main-menu & {
+          top: $_base-top-value + $_value  + $search-form-extended-height;
         }
       }
     }

--- a/themes/ddbasic/sass/components/menu.scss
+++ b/themes/ddbasic/sass/components/menu.scss
@@ -77,10 +77,12 @@ ul {
     }
 
     > li {
+      min-height: $search-form-extended-height;
       padding: 30px 0;
 
       // Tablet
       @include media($tablet) {
+        min-height: 0;
         width: 100%;
         padding: 0;
         > a {

--- a/themes/ddbasic/scripts/menu.js
+++ b/themes/ddbasic/scripts/menu.js
@@ -54,12 +54,14 @@
       // Scope fixes for inner functions.
       var thisScope = this;
 
-      // We need to check this initially.
+      // We need to check these initially.
       thisScope.checkMainSecondaryMenusOffset(context);
+      thisScope.checkMainLinksOffset(context);
 
       // We also need to check it everytime we resize the screen.
       $(window).resize(function() {
         thisScope.checkMainSecondaryMenusOffset(context);
+        thisScope.checkMainLinksOffset(context);
       });
 
       mobile_menu_btn.on('click', function(evt){
@@ -155,6 +157,24 @@
         $('body').addClass('secondary-menu-below-main');
       } else {
         $('body').removeClass('secondary-menu-below-main');
+      }
+    },
+
+    // If there are too many links in the main menu, so it breaks into
+    // two lines, we need to tell CSS to adjust.
+    checkMainLinksOffset: function(context) {
+      var main_menu_links = $('.main-menu > li', context);
+
+      // We have less than 2 elements, it doesnt make sense to compare anything.
+      if (main_menu_links.length < 2) {
+        return;
+      }
+
+      // Checking if the first and last elements are on the same line.
+      if (main_menu_links.first().offset().top != main_menu_links.last().offset().top) {
+        $('body').addClass('has-multiline-main-menu');
+      } else {
+        $('body').removeClass('has-multiline-main-menu');
       }
     }
   };

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -37,7 +37,8 @@ function ddbasic_preprocess_html(&$vars) {
       // The search form should only be expanded on certain pages.
       $path = menu_get_item()['path'];
 
-      if (!in_array($path, ['search/ting/%', 'search/ting', 'search/node/%', 'ding_frontpage'])) {
+      if (empty($vars['display_extended_search']) &&
+          !in_array($path, ['search/ting/%', 'search/ting', 'search/node/%', 'ding_frontpage'])) {
         $vars['classes_array'][] = 'extended-search-is-not-open';
         $vars['classes_array'][] = 'has-search-dropdown';
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3667

#### Description
If there are too many links in the main menu, so it breaks into two lines, we need to tell CSS to adjust.

See:
https://platform.dandigbib.org/issues/3667

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
