### PR TITLE
4088: Screenreader / focus tweaks for userlogin.

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -311,7 +311,7 @@ function ding_user_form_alter(&$form, $form_state, $form_id) {
 
       // Only add a close button to the block form.
       if ($form_id === 'user_login_block') {
-        $form['user_login_container']['close']['#markup'] = '<div class="close-user-login"></div>';
+        $form['user_login_container']['close']['#markup'] = '<a class="close-user-login" href="#"></a>';
       }
 
       $form['user_login_container']['name'] = $form['name'];

--- a/themes/ddbasic/sass/components/form/form-user-login.scss
+++ b/themes/ddbasic/sass/components/form/form-user-login.scss
@@ -17,6 +17,7 @@
   }
   .close-user-login {
     @include place-icon(close);
+    display: block;
     width: 24px;
     height: 24px;
     float: right;

--- a/themes/ddbasic/scripts/menu.js
+++ b/themes/ddbasic/scripts/menu.js
@@ -49,7 +49,22 @@
           search_extended_btn = $('a.search-extended-button', context),
           first_level_expanded = $('.main-menu-wrapper > .main-menu > .expanded > a .main-menu-expanded-icon', context),
           second_level_expanded = $('.main-menu-wrapper > .main-menu > .expanded > .main-menu > .expanded > a .main-menu-expanded-icon', context),
-          body = $('body');
+          body = $('body'),
+          userPaneForm = $('.js-topbar-user.pane-user-login #user-login-form'),
+          userPaneFocusElements = userPaneForm.find(':focusable'),
+          userPaneFirstInput = userPaneForm.find('input:focusable').first();
+
+      // By default, the user login pane is hidden, so focusable elements should
+      // not be allowed to have tab-focus.
+      userPaneFocusElements.attr('tabindex', '-1');
+
+      // By default the user form is hidden, so we need to tell that to screen
+      // readers too.
+      // We're adding this through Javascript rather than PHP because the
+      // aria-hidden property is controlled by Javascript and if for some reason
+      // this Javascript file doesnt get added/triggered, the form is still
+      // accessible for screenreaders.
+      userPaneForm.attr('aria-hidden', true);
 
       // Scope fixes for inner functions.
       var thisScope = this;
@@ -88,12 +103,29 @@
       topbar_link_user.on('click', function(evt) {
         evt.preventDefault();
         ddbasic.openLogin();
+
+        // Showing the pane for screenreaders also.
+        userPaneForm.removeAttr('aria-hidden');
+
+        // Making sure the inputs are tab-able.
+        userPaneFocusElements.removeAttr('tabindex');
+
+        // Setting tab focus to the first input element in the login form.
+        if (userPaneFirstInput.length) {
+          userPaneFirstInput.focus();
+        }
       });
 
       close_user_login.on('click', function(evt) {
         evt.preventDefault();
         body.removeClass('pane-login-is-open');
         body.removeClass('overlay-is-active');
+
+        // Hiding the pane for screenreaders also.
+        userPaneForm.attr('aria-hidden', 'true');
+
+        // Making sure the inputs are not tab-able (As they are by default)
+        userPaneFocusElements.attr('tabindex', '-1');
       });
 
       first_level_expanded.on('click', function(evt) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4088

#### Description

- Makes sure the hidden login form is also hidden for screenreaders when it's closed, using aria-hidden
- When the login form is hidden, remove ability to tabbing to it
- When it is open, set focus on first element

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
