### PR TITLE
4121: Fix check for language suffix.

### DIFF
--- a/modules/ting/ting.field.inc
+++ b/modules/ting/ting.field.inc
@@ -397,7 +397,7 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
         /* @var \TingEntity $entity */
         $title_suffix_types = variable_get('ting_language_type_title_suffix', []);
         $default_language = variable_get('ting_language_default');
-        $is_title_suffix_type = in_array(strtolower($entity->getType()), $title_suffix_types);
+        $is_title_suffix_type = (!empty($title_suffix_types[strtolower($entity->getType())]));
         $language = $entity->getLanguage();
         $has_language = !empty($language);
         $is_default_language = $language == $default_language;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4121#change-41165

#### Description

The old code appears to always return true.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
