### PR TITLE
4107 by Inlead: Improvements to IPE.

### DIFF
--- a/modules/ding_carousel/js/ding_carousel.js
+++ b/modules/ding_carousel/js/ding_carousel.js
@@ -269,7 +269,7 @@
         // (obviously in hindsight).
         $('.carousel', this).on('init reInit afterChange', carousel, update_handler)
           .on('setPosition', carousel, update_slides_to_scroll)
-          .slick(settings);
+          .not('.slick-initialized').slick(settings);
       });
 
       // Initialize tab behavior on tabbed carousels.

--- a/modules/ding_ipe_filter/css/ding_ipe_filter.css
+++ b/modules/ding_ipe_filter/css/ding_ipe_filter.css
@@ -22,9 +22,6 @@ div.ipe-popup ul {
 .ding-ipe-popup-left {
   left: 245px;
 }
-.ding-ipe-popup-top {
-  top: -48px !important;
-}
 
 div.ipe-popup .item-list ul li {
   margin: 0;
@@ -40,4 +37,8 @@ div.ipe-popup .item-list ul li {
 .ding-ipe-menu-item {
   width: 100%;
   height: auto;
+}
+
+.ajax-progress-throbber {
+  display: block !important;
 }

--- a/modules/p2/ding_serendipity/ding_serendipity.module
+++ b/modules/p2/ding_serendipity/ding_serendipity.module
@@ -1135,7 +1135,7 @@ function ding_serendipity_form_base_keys($form_state) {
     '#title' => t('Selected'),
     '#options' => array_unique($options),
     '#multiple' => TRUE,
-    '#default_value' => !empty($form_state['conf']['selected_keys']) ? $form_state['conf']['selected_keys'] : array('ting_object' => TRUE, 'frontpage' => TRUE),
+    '#default_value' => !empty($form_state['conf']['selected_keys']) ? $form_state['conf']['selected_keys'] : array('ting_object' => 'ting_object', 'frontpage' => 'frontpage'),
     '#description' => t('Select any additional keys which apply to the serendipity display you wish to present.'),
     '#access' => user_access('administer serendipity panes'),
   );


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4107

#### Description

There was observed some logic and UI issues in process of using IPE functionality provided by ding_ipe_filter module.
This PR fixes described issues:
1. UX issue for editors: In Primary Content there is elemnts that is very hard to insert. It happens because the menu with options is sliding up "behind" the main menu, and therefore you can't see all elements.
2. It is impossible to Insert and Save the "Ding Serendipitet med TingObject (Materialer)" widget.
3. When saving, there is no indication what is going on and it can take several minutes for it to save - letting editors click other links in the waiting time. There should be an indication that panel is saving.

#### Screenshot of the result
![menu](https://user-images.githubusercontent.com/800338/52421888-a253bc80-2afd-11e9-9947-d82c14a366ec.png)
![loader](https://user-images.githubusercontent.com/800338/52421901-a5e74380-2afd-11e9-8797-6ab8f6d1b49c.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.