### PR TITLE
4100: Entities in a carousel should have a <h3> title.

### DIFF
--- a/modules/ding_carousel/ding_carousel.theme.inc
+++ b/modules/ding_carousel/ding_carousel.theme.inc
@@ -15,8 +15,19 @@ function template_preprocess_ding_carousel(&$vars) {
   $carousel = $vars['carousel'];
 
   $vars['items'] = array();
-  // Wrap items in ding_carousel_item.
+
   foreach ($carousel['#items'] as $item) {
+    // Making sure the prefix is a h3 instead of h2 for WCAG reasons.
+    // We need to use str_replace as its possible for the element to contain
+    // more than just a <h2> tag.
+    // @see: https://github.com/ding2/ding2/blob/16ee7ee2063ade17ed3c2efae255304f6828a61d/modules/ting/ting.field.inc#L410
+    if (!empty($item['ting_title'][0]['#prefix']) &&
+        !empty($item['ting_title'][0]['#suffix'])) {
+      $item['ting_title'][0]['#prefix'] = str_replace('<h2', '<h3', $item['ting_title'][0]['#prefix']);
+      $item['ting_title'][0]['#suffix'] = str_replace('</h2', '</h3', $item['ting_title'][0]['#suffix']);
+    }
+
+    // Wrap items in ding_carousel_item.
     $vars['items'][] = array(
       '#type' => 'ding_carousel_item',
       '#content' => $item,

--- a/modules/ding_carousel/templates/ding_carousel.tpl.php
+++ b/modules/ding_carousel/templates/ding_carousel.tpl.php
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * Defoult carousel template.
+ * Default carousel template.
  *
  * Available variables:
  * - $title: Title of carousel.
@@ -10,6 +10,7 @@
  * - $offset: Ajax callback offset to start at. -1 for no ajax.
  * - $path: Ajax path for getting more content.
  */
+
 ?>
 <div class="<?php print $classes; ?>"
   data-title="<?php print $title ?>"

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -100,6 +100,7 @@
         }
       }
       .field-name-ting-title {
+        h3,
         h2 {
           @include transition(width $speed $ease);
           @include font('display-small');
@@ -153,6 +154,7 @@
             @include transition(opacity $speed $hover-delay $ease);
             opacity: 0;
           }
+          .field-name-ting-title h3,
           .field-name-ting-title h2,
           .field-name-ting-author {
             @include transition (
@@ -225,6 +227,7 @@
         }
       }
       .field-name-ting-title {
+        h3,
         h2 {
           @include font('display-small');
           width: 100%;
@@ -324,6 +327,7 @@
       }
     }
     .field-name-ting-title {
+      h3,
       h2 {
         margin: 0;
       }
@@ -363,6 +367,7 @@
         @include omega();
       }
     }
+    h3,
     h2 {
       @include font('display-small');
       margin-bottom: 0;
@@ -463,6 +468,7 @@
     }
     .field-name-ting-title {
       margin-top: 5px;
+      h3,
       h2 {
         @include font('display-small');
         margin-bottom: 0;
@@ -676,7 +682,8 @@
           }
         }
       }
-      .field-name-ting-title h2 {
+      .field-name-ting-title h2,
+      .field-name-ting-title h3 {
         @include font('display');
         margin-bottom: 5px;
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4100

#### Description

For WCAG reasons, the elements within a carousel should use `<h3>` instead of `<h2>` for their titles.
We'll need to override a suffix/prefix element to achieve this.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
