### PR TITLE
3043: Ensure on-hold dates are converted correctly in validation

### DIFF
--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -568,6 +568,7 @@ function fbs_form_profile2_on_hold_validate(array $element, array &$form_state) 
 
   // Get the values that should be validated.
   $existing_on_hold = $wrapper->field_fbs_on_hold->value();
+
   // Existing value may return NULL lets convert that to an array.
   if (is_null($existing_on_hold)) {
     $existing_on_hold = array(
@@ -575,11 +576,16 @@ function fbs_form_profile2_on_hold_validate(array $element, array &$form_state) 
       'to' => NULL,
     );
   }
+  else {
+    $existing_on_hold = array_map(function ($time_string) {
+      return is_null($time_string) ? NULL : _fbs_form_profile_validate_convert_time($time_string);
+    }, $existing_on_hold);
+  }
 
   // New values are in the format Y-m-d while existing values are timestamps.
   // Convert new values to timestamps to make them comparable.
   $new_on_hold = array_map(function ($time_string) {
-    return _fbs_form_profile_validate_convert_time($time_string);
+    return is_null($time_string) ? NULL : _fbs_form_profile_validate_convert_time($time_string);
   }, $form_state['values']['profile_provider_fbs']['field_fbs_on_hold'][LANGUAGE_NONE][0]);
 
   // Check if the values have been changed.
@@ -603,24 +609,22 @@ function fbs_form_profile2_on_hold_validate(array $element, array &$form_state) 
 
     // Get current data.
     $now = date('Y-m-d');
-
-    // Make comparision more readable with a function wrapper.
-    $convert = '_fbs_form_profile_validate_convert_time';
+    $now = _fbs_form_profile_validate_convert_time($now);
 
     // Start date must be higher than or equal to today.
-    if (!($convert($new_on_hold['from']) >= $convert($now))) {
+    if (!($new_on_hold['from'] >= $now)) {
       form_set_error('profile_provider_fbs][field_fbs_on_hold', t('Start date must be higher than or equal to today: %now', array('%now' => date('d-m-Y'))));
       return;
     }
 
     // To date must both be higher than or equal to today.
-    if (!($convert($new_on_hold['to']) >= $convert($now))) {
+    if (!($new_on_hold['to'] >= $now)) {
       form_set_error('profile_provider_fbs][field_fbs_on_hold', t('To date must both be higher than or equal to today: %now', array('%now' => date('d-m-Y'))));
       return;
     }
 
     // To date must higher than the from date.
-    if (!($convert($new_on_hold['to']) >= $convert($new_on_hold['from']))) {
+    if (!($new_on_hold['to'] >= $new_on_hold['from'])) {
       form_set_error('profile_provider_fbs][field_fbs_on_hold', t('To date must higher than the from date or equal to.'));
       return;
     }
@@ -639,6 +643,11 @@ function fbs_form_profile2_on_hold_validate(array $element, array &$form_state) 
  *   Unix timestamp.
  */
 function _fbs_form_profile_validate_convert_time($time) {
+  // Check that the format matches else return value.
+  if (!preg_match('/\d{4}-\d{2}-\d{2}/', $time)) {
+    return $time;
+  }
+
   $cache = &drupal_static(__FUNCTION__, array());
   if (isset($cache[$time])) {
     return $cache[$time];


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3043

#### Description

Ensure that the on-hold dates are convented correctly and only once.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
