### PR TITLE
2147 better p2b migration

### DIFF
--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
@@ -8,12 +8,46 @@
  * Form handler for configuration service settings.
  */
 function ding_place2book_migrate_admin_form($form, &$form_state) {
+  // Test that some important settings is configured before allowing migration.
+  $failed_tests = [];
+  $ding_place2book_settings = variable_get('ding_place2book_settings', []);
+  if (empty($ding_place2book_settings['token'])) {
+    $failed_tests[] = t('Place2book API-token is missing. Please <a href="@configure-link">configure it here</a>.', [
+      '@configure-link' => url('admin/config/ding/place2book'),
+    ]);
+  }
+  if (empty(variable_get('ding_p2b_default_event_maker', NULL))) {
+    $failed_tests[] = t('Default event maker is missing. Please <a href="@configure-link">configure it here</a>.', [
+      '@configure-link' => url('admin/config/ding/place2book/defaults'),
+    ]);
+  }
+  if (empty(variable_get('ding_p2b_library_event_makers', []))) {
+    $failed_tests[] = t('Event maker mapping is missing. Please <a href="@configure-link">configure it here</a>.', [
+      '@configure-link' => url('admin/config/ding/place2book/mappings'),
+    ]);
+  }
+
+  $form['pre_migration_tests'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Pre-migration tests'),
+  );
+
+  $form['pre_migration_tests']['result'] = [
+    '#theme' => 'item_list',
+    '#list_type' => 'ul',
+    '#items' => !empty($failed_tests) ? $failed_tests : t('Configuration is OK! Migration is ready to be started.'),
+  ];
 
   $form['start'] = array(
     '#type' => 'submit',
     '#value' => t('Start'),
+    '#disabled' => !empty($failed_tests),
     '#suffix' => t('Starting migration event to new api. This operation can not be canceled.'),
   );
+
+  if (!empty($failed_tests)) {
+    $form['start']['#suffix'] =  t('Some tests failed which need to be sorted out before migration can be started. See above.');
+  }
 
   return $form;
 }

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
@@ -129,19 +129,41 @@ function ding_place2book_migrate_admin_form_submit($form, &$form_state) {
 }
 
 /**
- * Submit hanlder for approve migration button.
+ * Submit handler for the approve migration button.
  */
 function ding_placebook_migrate_approve_migration_submit($form, &$form_state) {
-  if (db_table_exists('ding_place2book')) {
-    db_drop_table('ding_place2book');
+  $form_state['redirect'] = 'admin/config/ding/place2book/migrate/approve';
+}
+
+/**
+ * Confirm form builder for approve migration confirm form.
+ */
+function ding_place2book_migrate_approve_form($form, &$form_state) {
+  return confirm_form($form,
+    t('Are you sure you want to approve migration?'),
+    'admin/config/ding/place2book/migrate',
+    '<strong>' . t('WARNING: This action cannot be undone. The old place2book data will be removed and it will not be possible to run the migration again.') . '</strong>',
+    t('Approve'),
+    t('Cancel')
+  );
+}
+
+/**
+ * Submit handler for approve migration confirm form.
+ */
+function ding_place2book_migrate_approve_form_submit($form, &$form_state) {
+  if ($form_state['values']['confirm']) {
+    if (db_table_exists('ding_place2book')) {
+      db_drop_table('ding_place2book');
+    }
+
+    // Disable and uninstall module.
+    module_disable(array('ding_place2book_migrate'), TRUE);
+    drupal_uninstall_modules(array('ding_place2book_migrate'));
+
+    // Rebuild to remove migration tab and redirect to the main page of p2b admin
+    // settings.
+    menu_rebuild();
+    $form_state['redirect'] = 'admin/config/ding/place2book';
   }
-
-  // Disable and uninstall module.
-  module_disable(array('ding_place2book_migrate'), TRUE);
-  drupal_uninstall_modules(array('ding_place2book_migrate'));
-
-  // Rebuild to remove migration tab and redirect to the main page of p2b admin
-  // settings.
-  menu_rebuild();
-  $form_state['redirect'] = 'admin/config/ding/place2book';
 }

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
@@ -88,14 +88,20 @@ function ding_place2book_migrate_admin_form($form, &$form_state) {
 
   $form['start'] = array(
     '#type' => 'submit',
-    '#value' => t('Start'),
+    '#value' => t('Start migration'),
     '#disabled' => !empty($failed_tests),
-    '#suffix' => t('Starting migration event to new api. This operation can not be canceled.'),
+    '#suffix' => t('Start migration of events to new api. You can re-run the migration as many times as you like until migration is approved below.') . '<br>',
   );
-
   if (!empty($failed_tests)) {
-    $form['start']['#suffix'] =  t('Some tests failed which need to be sorted out before migration can be started. See above.');
+    $form['start']['#suffix'] =  t('Some tests failed which need to be sorted out before migration can be started. See above.') . '<br>';
   }
+
+  $form['approve'] = [
+    '#type' => 'submit',
+    '#value' => t('Approve migration'),
+    '#suffix' => t(' WARNING: The old place2book data will be removed and it will not be possible to run the migration again.'),
+    '#submit' => ['ding_placebook_migrate_approve_migration_submit'],
+  ];
 
   return $form;
 }
@@ -120,4 +126,22 @@ function ding_place2book_migrate_admin_form_submit($form, &$form_state) {
   );
 
   batch_set($batch);
+}
+
+/**
+ * Submit hanlder for approve migration button.
+ */
+function ding_placebook_migrate_approve_migration_submit($form, &$form_state) {
+  if (db_table_exists('ding_place2book')) {
+    db_drop_table('ding_place2book');
+  }
+
+  // Disable and uninstall module.
+  module_disable(array('ding_place2book_migrate'), TRUE);
+  drupal_uninstall_modules(array('ding_place2book_migrate'));
+
+  // Rebuild to remove migration tab and redirect to the main page of p2b admin
+  // settings.
+  menu_rebuild();
+  $form_state['redirect'] = 'admin/config/ding/place2book';
 }

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.admin.inc
@@ -27,16 +27,64 @@ function ding_place2book_migrate_admin_form($form, &$form_state) {
     ]);
   }
 
-  $form['pre_migration_tests'] = array(
+  $form['pre_migration_tests'] = [
     '#type' => 'fieldset',
     '#title' => t('Pre-migration tests'),
-  );
+  ];
 
   $form['pre_migration_tests']['result'] = [
     '#theme' => 'item_list',
     '#list_type' => 'ul',
-    '#items' => !empty($failed_tests) ? $failed_tests : t('Configuration is OK! Migration is ready to be started.'),
+    '#items' => !empty($failed_tests) ? $failed_tests : [t('Configuration is OK! Migration is ready to be started.')],
   ];
+
+  $query = db_select('ding_place2book', 'd');
+  $query->join('node', 'n', 'n.nid=d.nid');
+  $query->fields('n', ['nid', 'title'])
+    ->fields('d', ['place2book_id'])
+    ->condition('d.migration_status', 0);
+
+  $migration_count = $query->countQuery()->execute()->fetchField();
+
+  $migration_status_text = format_plural(
+    $migration_count,
+    'One node to be migrated. You can see it below.',
+    '@count nodes to be migrated. You can browse them below.'
+  );
+
+  $form['migration_status'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Migration status'),
+    '#description' => $migration_status_text,
+  ];
+
+  $header = [
+    ['data' => t('Event')],
+    ['data' => t('Place2book ID')],
+  ];
+
+  $pager_query = $query->extend('PagerDefault');
+  $results = $pager_query
+    ->limit(10)
+    ->orderBy('n.created')
+    ->execute();
+
+  $rows = [];
+  foreach ($results as $result) {
+    $row = [];
+    $row['event'] = l($result->title, 'node/' . $result->nid . '/edit', ['query' => drupal_get_destination()]);
+    $row['place2book_id'] = $result->place2book_id;
+    $rows[] = ['data' => $row];
+  }
+
+  $form['migration_status']['table'] = [
+    '#theme' => 'table',
+    '#header' => $header,
+    '#rows' => $rows,
+    '#empty' => t('Migration complete.'),
+  ];
+
+  $form['migration_status']['pager'] = ['#theme' => 'pager'];
 
   $form['start'] = array(
     '#type' => 'submit',

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.install
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.install
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * Install file for the ding_place2book migrate module.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function ding_place2book_migrate_install() {
+  db_add_field('ding_place2book', 'migration_status', [
+    'type' => 'int',
+    'unsigned' => TRUE,
+    'not null' => TRUE,
+    'size' => 'tiny',
+    'default' => 0,
+  ]);
+}

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
@@ -105,17 +105,6 @@ function _ding_place2book_migrate_batch($events, &$context) {
  * @see ding_place2book_migrate_admin_form_submit()
  */
 function _ding_place2book_migrate_batch_finished($success, $results, $operations) {
-  $message = t('Finished with an error.');
-  if ($success) {
-    $message = t('Events migration completed.');
-    // Drop table.
-    if (db_table_exists('ding_place2book')) {
-      db_drop_table('ding_place2book');
-    }
-
-    // Disable module.
-    module_disable(array('ding_place2book_migrate'), TRUE);
-  }
-
+  $message = $success ? t('Events migration completed.') : t('Finished with an error.');
   drupal_set_message($message);
 }

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
@@ -20,6 +20,14 @@ function ding_place2book_migrate_menu() {
     'file' => 'ding_place2book_migrate.admin.inc',
   );
 
+  $items['admin/config/ding/place2book/migrate/approve'] = array(
+    'title' => 'Approve migration',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ding_place2book_migrate_approve_form'),
+    'access arguments' => array('administer place2book settings'),
+    'file' => 'ding_place2book_migrate.admin.inc',
+  );
+
   return $items;
 }
 

--- a/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
+++ b/modules/ding_place2book/modules/ding_place2book_migrate/ding_place2book_migrate.module
@@ -71,7 +71,20 @@ function _ding_place2book_migrate_batch($events, &$context) {
         }
       }
 
-      node_save($node);
+      try {
+        node_save($node);
+        // If we get here it means that no exception was thrown and we update
+        // the migation status to TRUE which indicates completed.
+        db_update('ding_place2book')
+          ->fields(['migration_status' => 1])
+          ->condition('nid', $node->nid)
+          ->execute();
+      }
+      catch(Exception $e) {
+        // No need to do anything here really. The node module logs a watchdog
+        // exception if something went wrong, so we just continue with the
+        // migration and display a status when it's done.
+      }
     }
     $context['message'] = t('Processing: <em>@title</em> (@current/@total).', array(
       '@title' => $node->title,


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/2147 

#### Description

Improves migration by adding pre-migration tests, migrations status and the ability to re-run the migration until it's approved by the new "Approve migration" button.

#### Screenshot of the result

![2147-failed-pre-migration-tests](https://user-images.githubusercontent.com/5011234/52862230-0b0deb00-3135-11e9-87f7-e08b20acc34a.PNG)

![2147-passed-pre-migration-tests](https://user-images.githubusercontent.com/5011234/52862243-15c88000-3135-11e9-9c94-748e17ce473b.PNG)

![2147-migration-complete](https://user-images.githubusercontent.com/5011234/52862234-0cd7ae80-3135-11e9-9636-045fe1f9cb9f.PNG)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
