### PR TITLE
3916: Refactor event list filter to be independent of filter order

### DIFF
--- a/modules/ding_app_content_rss/ding_app_content_rss.views_default.inc
+++ b/modules/ding_app_content_rss/ding_app_content_rss.views_default.inc
@@ -314,6 +314,78 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['sorts']['field_ding_event_date_value']['id'] = 'field_ding_event_date_value';
   $handler->display->display_options['sorts']['field_ding_event_date_value']['table'] = 'field_data_field_ding_event_date';
   $handler->display->display_options['sorts']['field_ding_event_date_value']['field'] = 'field_ding_event_date_value';
+  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
+  $handler->display->display_options['filter_groups']['operator'] = 'OR';
+  $handler->display->display_options['filter_groups']['groups'] = array(
+    1 => 'AND',
+    2 => 'AND',
+  );
+  $handler->display->display_options['defaults']['filters'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type']['id'] = 'type';
+  $handler->display->display_options['filters']['type']['table'] = 'node';
+  $handler->display->display_options['filters']['type']['field'] = 'type';
+  $handler->display->display_options['filters']['type']['value'] = array(
+    'ding_event' => 'ding_event',
+  );
+  $handler->display->display_options['filters']['type']['group'] = 1;
+  /* Filter criterion: Content: Date -  start date (field_ding_event_date) */
+  $handler->display->display_options['filters']['field_ding_event_date_value']['id'] = 'field_ding_event_date_value';
+  $handler->display->display_options['filters']['field_ding_event_date_value']['table'] = 'field_data_field_ding_event_date';
+  $handler->display->display_options['filters']['field_ding_event_date_value']['field'] = 'field_ding_event_date_value';
+  $handler->display->display_options['filters']['field_ding_event_date_value']['operator'] = '>=';
+  $handler->display->display_options['filters']['field_ding_event_date_value']['group'] = 1;
+  $handler->display->display_options['filters']['field_ding_event_date_value']['default_date'] = 'now';
+  /* Filter criterion: Content: Date -  start date (field_ding_event_date) */
+  $handler->display->display_options['filters']['field_ding_event_date_value_1']['id'] = 'field_ding_event_date_value_1';
+  $handler->display->display_options['filters']['field_ding_event_date_value_1']['table'] = 'field_data_field_ding_event_date';
+  $handler->display->display_options['filters']['field_ding_event_date_value_1']['field'] = 'field_ding_event_date_value';
+  $handler->display->display_options['filters']['field_ding_event_date_value_1']['operator'] = '<=';
+  $handler->display->display_options['filters']['field_ding_event_date_value_1']['group'] = 1;
+  $handler->display->display_options['filters']['field_ding_event_date_value_1']['default_date'] = '+180 day';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status']['id'] = 'status';
+  $handler->display->display_options['filters']['status']['table'] = 'node';
+  $handler->display->display_options['filters']['status']['field'] = 'status';
+  $handler->display->display_options['filters']['status']['value'] = 1;
+  $handler->display->display_options['filters']['status']['group'] = 1;
+  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
+  /* Filter criterion: Content: Type */
+  $handler->display->display_options['filters']['type_1']['id'] = 'type_1';
+  $handler->display->display_options['filters']['type_1']['table'] = 'node';
+  $handler->display->display_options['filters']['type_1']['field'] = 'type';
+  $handler->display->display_options['filters']['type_1']['value'] = array(
+    'ding_event' => 'ding_event',
+  );
+  $handler->display->display_options['filters']['type_1']['group'] = 2;
+  /* Filter criterion: Content: Event list filter (field_ding_event_list_filter) */
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['id'] = 'field_ding_event_list_filter_value';
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['table'] = 'field_data_field_ding_event_list_filter';
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['field'] = 'field_ding_event_list_filter_value';
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['value'] = array(
+    'show_all' => 'show_all',
+  );
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['group'] = 2;
+  /* Filter criterion: Content: Date - end date (field_ding_event_date:value2) */
+  $handler->display->display_options['filters']['field_ding_event_date_value2']['id'] = 'field_ding_event_date_value2';
+  $handler->display->display_options['filters']['field_ding_event_date_value2']['table'] = 'field_data_field_ding_event_date';
+  $handler->display->display_options['filters']['field_ding_event_date_value2']['field'] = 'field_ding_event_date_value2';
+  $handler->display->display_options['filters']['field_ding_event_date_value2']['operator'] = '>=';
+  $handler->display->display_options['filters']['field_ding_event_date_value2']['group'] = 2;
+  $handler->display->display_options['filters']['field_ding_event_date_value2']['default_date'] = 'now';
+  /* Filter criterion: Content: Date -  start date (field_ding_event_date) */
+  $handler->display->display_options['filters']['field_ding_event_date_value_2']['id'] = 'field_ding_event_date_value_2';
+  $handler->display->display_options['filters']['field_ding_event_date_value_2']['table'] = 'field_data_field_ding_event_date';
+  $handler->display->display_options['filters']['field_ding_event_date_value_2']['field'] = 'field_ding_event_date_value';
+  $handler->display->display_options['filters']['field_ding_event_date_value_2']['operator'] = '<=';
+  $handler->display->display_options['filters']['field_ding_event_date_value_2']['group'] = 2;
+  $handler->display->display_options['filters']['field_ding_event_date_value_2']['default_date'] = '+180 day';
+  /* Filter criterion: Content: Published */
+  $handler->display->display_options['filters']['status_1']['id'] = 'status_1';
+  $handler->display->display_options['filters']['status_1']['table'] = 'node';
+  $handler->display->display_options['filters']['status_1']['field'] = 'status';
+  $handler->display->display_options['filters']['status_1']['value'] = '1';
+  $handler->display->display_options['filters']['status_1']['group'] = 2;
   $handler->display->display_options['path'] = 'ding-redia-rss/event';
   $translatables['ding_app_content_event_rss'] = array(
     t('Master'),

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -216,6 +216,13 @@ function ding_event_views_query_alter(&$view, &$query) {
     // SQL to the date filters.
     foreach ($query->where as &$condition_group) {
       foreach ($condition_group['conditions'] as &$condition) {
+        // Ensure that condition field is string to avoid "__toString() must
+        // return a string value" fatal PHP error.
+        // See: https://www.drupal.org/project/drupal/issues/3040999
+        if (!is_string($condition['field'])) {
+          continue;
+        }
+
         // Note that this field could also be the second exposed date filter,
         // which is used only on ding_event_list. It wont have any effect though
         // since this filters on start date less than input date.

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -187,6 +187,58 @@ function ding_event_install_menu_position($op = 'install') {
 }
 
 /**
+ * Implements hook_views_query_alter()
+ */
+function ding_event_views_query_alter(&$view, &$query) {
+  // Tweak the SQL of the start date filter on these views. We need to take into
+  // account the value of ding_event_list_filter, that decides whether we should
+  // also consider the end date. Under normal circumstances this could all be
+  // set up in views, but we need this work with the exposed filters on the
+  // ding_event_list also.
+  if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list', 'ding_event_list_frontpage'))) {
+    $join = new views_join();
+    $join->construct('field_data_field_ding_event_list_filter', 'node', 'nid', 'entity_id');
+    $join->extra = [
+      [
+        'field' => 'entity_type',
+        'value' => 'node',
+      ],
+    ];
+    $query->table_queue['fdelf'] = [
+      'table' => 'field_data_field_ding_event_list_filter',
+      'num' => 1,
+      'alias' => 'fdelf',
+      'join' => $join,
+      'relationship' => 'node',
+    ];
+
+    // In addition to joining the event_list_filter table we need to add some
+    // SQL to the date filters.
+    foreach ($query->where as &$condition_group) {
+      foreach ($condition_group['conditions'] as &$condition) {
+        // Note that this field could also be the second exposed date filter,
+        // which is used only on ding_event_list. It wont have any effect though
+        // since this filters on start date less than input date.
+        if (strpos($condition['field'], 'field_ding_event_date') !== FALSE) {
+          // First set up the conditions on our list filter field and the events
+          // end data, that we want to add.
+          $list_filter_condition = 'fdelf.field_ding_event_list_filter_value = :filter';
+          $condition['value'][':filter'] = 'show_all';
+          $end_date_condition = str_replace(
+            '.field_ding_event_date_value,',
+            '.field_ding_event_date_value2,',
+            $condition['field']
+          );
+          // Append our new filters to the existing SQL from the start date
+          // filter.
+          $condition['field'] .= " OR ($list_filter_condition AND $end_date_condition)";
+        }
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_views_pre_execute().
  *
  * Ensure that events tha are connected to more than one OG group or tag is only
@@ -196,33 +248,6 @@ function ding_event_views_pre_execute(&$view) {
   if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list'))) {
     $view->build_info['query']->groupBy('node.nid');
     $view->build_info['count_query']->groupBy('node.nid');
-  }
-
-  // Handle the "show_all" type of events, so they filter by end date instead of
-  // start date.
-  if ($view->name == 'ding_event' && in_array($view->current_display, array('ding_event_list', 'ding_event_list_frontpage'))) {
-    // Add the field_ding_event_list_filter field, so it can be used in the
-    // filter.
-    $view->build_info['query']->leftJoin(
-      'field_data_field_ding_event_list_filter',
-      'fdelf',
-      'fdelf.entity_id = node.nid AND fdelf.entity_type = :entity_type',
-      array(':entity_type' => 'node')
-    );
-
-    // We need to place the conditions inside the start date filter, which is
-    // referenced here. The reference is very specific, and changing the order
-    // of the view filters might break this functionality.
-    $date_condition = &$view->build_info['query']->conditions()[0]['field']->conditions()[0]['field']->conditions()[3];
-
-    // If the value is empty we assume the exposed combined search filter has
-    // content, this pushes the condition we want 1 further "down" in the array.
-    if (empty($date_condition['value'])) {
-      $date_condition = &$view->build_info['query']->conditions()[0]['field']->conditions()[0]['field']->conditions()[4];
-    }
-    $date_condition['field'] .= ' OR (fdelf.field_ding_event_list_filter_value = :filter'
-                              . ' AND ' . str_replace('.field_ding_event_date_value,', '.field_ding_event_date_value2,', $date_condition['field']) . ')';
-    $date_condition['value'][':filter'] = 'show_all';
   }
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3916

#### Description

The motivation for the changes in this PR started with the goal to support including multi day events in the app feed. 

In https://github.com/ding2/ding2/pull/871 the ability to show multi day events on the frontpage and on the event list was added. Normally events are only shown when start date is less than or equal to current date. But in above PR a settings was added to ding_event content type, that gives administrators the ability to show these events also when end date is less than or equal to current date.

Unfortunately, this was implemented in a way that is dependent on the order of the views filters from the view UI. Several issues with this has been reported. For example see: https://platform.dandigbib.org/issues/3442. I also found out that if you disable the "Show only promoted events" no events will be shown at all, since a filter is removed from the view messing up the order of the filters.

Now this can actually all be set up in Views UI with conditional groups (se my screenshot below), but on the event list we have an exposed filter on the start date, and we want the input from the exposed filter to also take the event **end** date into account, if the event is set up to be shown on multiple days. It's not possible to have an exposed filter which takes another field into account based on some condition.

So what I've done in this PR is:

1. Refactor our SQL-rewriting to support multi day events, so that it isn't dependent on the order of the filters. In connection with this, I have moved the rewriting to hook_views_query_alter() instead, since it seemed easier to get to the conditions this way. This fixes all the related problems mentioned above.
2. I have configured the ding_app_content_rss event feed, so that it can show multi day events if the event is set to do so. I have done this directly in the Views configuration in the UI, since for this view we don't need an exposed filter, so there's no need to deal with the complexity of SQL-rewriting.

#### Screenshot: multi day event configuration on Views UI

![3916-mutliday-setup-in-view](https://user-images.githubusercontent.com/5011234/53090291-3b77cf80-350f-11e9-8b37-1b5dbf523374.PNG)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.