### PR TITLE
4159: Check if WAYF was used in pin validation

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -428,7 +428,21 @@ function ding_user_get_pincode_length() {
 function ding_user_element_validate_pincode($element, &$form_state, $form) {
   $pincode_length = ding_user_get_pincode_length();
   $pincode = $element['#value'];
+  $error = FALSE;
   if (!empty($pincode) && !preg_match('/^\d{' . $pincode_length . '}$/', $pincode)) {
+    // Check that this is not an WAYF login as is uses a non pin-code type
+    // login token.
+    if (module_exists('ding_gatewayf')) {
+      if (!_ding_gatewayf_is_logged_in_with_gatewayf()) {
+        $error = TRUE;
+      }
+    }
+    else {
+      $error = TRUE;
+    }
+  }
+
+  if ($error) {
     form_error($element, t('The pincode must consist of exactly %number digits and only contain integers.', array('%number' => $pincode_length)));
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4159

#### Description

Check if the user was logged in with WAYF and disable pin-code length check. If not WAYF login will not be possible.

This may not be the bedst solution in relation to other SSO. So other than removing the validation I'm open for other suggestions.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments