### PR TITLE
3966 by Inlead: Define mobile flags for CTs.

### DIFF
--- a/modules/ding_event/ding_event.info
+++ b/modules/ding_event/ding_event.info
@@ -114,6 +114,7 @@ features[variable][] = comment_preview_ding_event
 features[variable][] = comment_subject_ding_event
 features[variable][] = comment_subject_field_ding_event
 features[variable][] = field_bundle_settings_node__ding_event
+features[variable][] = flag_mobile_app_default_ding_event
 features[variable][] = flag_push_to_mongo_default_ding_event
 features[variable][] = language_content_type_ding_event
 features[variable][] = menu_options_ding_event

--- a/modules/ding_event/ding_event.strongarm.inc
+++ b/modules/ding_event/ding_event.strongarm.inc
@@ -161,6 +161,13 @@ function ding_event_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
+  $strongarm->name = 'flag_mobile_app_default_ding_event';
+  $strongarm->value = 1;
+  $export['flag_mobile_app_default_ding_event'] = $strongarm;
+
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
   $strongarm->name = 'flag_push_to_mongo_default_ding_event';
   $strongarm->value = 1;
   $export['flag_push_to_mongo_default_ding_event'] = $strongarm;

--- a/modules/ding_news/ding_news.info
+++ b/modules/ding_news/ding_news.info
@@ -61,6 +61,7 @@ features[variable][] = comment_form_location_ding_news
 features[variable][] = comment_preview_ding_news
 features[variable][] = comment_subject_field_ding_news
 features[variable][] = field_bundle_settings_node__ding_news
+features[variable][] = flag_mobile_app_default_ding_news
 features[variable][] = flag_push_to_mongo_default_ding_news
 features[variable][] = language_content_type_ding_news
 features[variable][] = menu_options_ding_news

--- a/modules/ding_news/ding_news.strongarm.inc
+++ b/modules/ding_news/ding_news.strongarm.inc
@@ -172,16 +172,16 @@ function ding_news_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
-  $strongarm->name = 'flag_push_to_mongo_default_ding_news';
+  $strongarm->name = 'flag_mobile_app_default_ding_news';
   $strongarm->value = 1;
-  $export['flag_push_to_mongo_default_ding_news'] = $strongarm;
+  $export['flag_mobile_app_default_ding_news'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
-  $strongarm->name = 'flag_mobile_app_default_ding_news';
+  $strongarm->name = 'flag_push_to_mongo_default_ding_news';
   $strongarm->value = 1;
-  $export['flag_mobile_app_default_ding_news'] = $strongarm;
+  $export['flag_push_to_mongo_default_ding_news'] = $strongarm;
 
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */


### PR DESCRIPTION
#### Link to issue

http://platform.dandigbib.org/issues/3966

#### Description

In https://github.com/ding2/ding2/pull/1095 the mobile viewing was enabled by default for News and Events.

However, the change did not include a definition that this configuration is part of the respective modules' configuration. It should be added to the info file of the modules so that we ensure that the configuration is not removed inadvertently through Feature Updates eg. https://github.com/ding2/ding2/pull/1266.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.