### PR TITLE
4153: Removed messages border

### DIFF
--- a/themes/ddbasic/sass/components/messages.scss
+++ b/themes/ddbasic/sass/components/messages.scss
@@ -28,7 +28,6 @@
         padding: 5px 0;
         margin: 5px 0;
         color: $color-standard-text;
-        border-bottom: 1px solid $grey;
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4153

#### Description

Removed border-bottom from messages li.

#### Screenshot of the result

<img width="1156" alt="skaermbillede 2019-02-25 kl 13 44 03" src="https://user-images.githubusercontent.com/30495061/53338216-73ae5200-3903-11e9-9140-5fd562aa303e.png">

