### PR TITLE
3962: Hide 4th level menu

### DIFF
--- a/themes/ddbasic/sass/components/menu.scss
+++ b/themes/ddbasic/sass/components/menu.scss
@@ -296,8 +296,12 @@ ul.main-menu-third-level {
             color: $charcoal;
           }
         }
+        > ul.menu {
+	        display: block;
+        }
       }
       ul.menu {
+	      display: none;
         margin-top: 20px;
         padding-left: 20px;
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3962

#### Description

Hide nested menu items on expandend li on third level menu. Display when parent li element is active.

#### Screenshot of the result

<img width="1178" alt="skaermbillede 2019-02-25 kl 16 49 53" src="https://user-images.githubusercontent.com/30495061/53349481-787fff80-391d-11e9-820c-c006844faa75.png">
<img width="1152" alt="skaermbillede 2019-02-25 kl 16 50 05" src="https://user-images.githubusercontent.com/30495061/53349485-7a49c300-391d-11e9-9c8a-811aca98c39d.png">

