### PR TITLE
3901: Fix custom click parameters for several events

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -27,12 +27,19 @@
     return url + seperator + urlParameter;
   };
 
+  var pushEvent = function(event, eventData) {
+    // Ensure that the Webtrekk object is defined before pushing event.
+    if (typeof wts !== 'undefined') {
+      wts.push(['send', event, eventData]);
+    }
+  };
+
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
       // Send Webtrekk events attached in the backend.
       $('.js-ding-webtrekk-event', context).once('js-ding-webtrekk').click(function() {
         var eventData = $(this).data('ding-webtrekk-event');
-        wts.push(['send', 'click', eventData]);
+        pushEvent('click', eventData);
       });
 
       // Secial handling for ding entity rating event.
@@ -46,13 +53,13 @@
         $('.js-rating-symbol', this).each(function(index) {
           var rating = (index + 1) + '';
           $(this).click(function() {
-            var customClickParameter = {};
-            customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_RATING] = rating;
-            customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_RATING_ID] = contentId;
-            wts.push(['send', 'click', {
+            var eventData = {
               linkId: 'Materiale rating',
-              customClickParameter: customClickParameter
-            }]);
+              customClickParameter: {}
+            };
+            eventData.customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_RATING] = rating;
+            eventData.customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_RATING_ID] = contentId;
+            pushEvent('click', eventData);
           });
         });
       });
@@ -62,12 +69,12 @@
         .once('js-ding-webtrekk')
         .on('autocompleteSelect', function(e, selected) {
           if (($(selected).text())) {
-            var customClickParameter = {};
-            customClickParameter[DING_WEBTREKK_PARAMETER_AUTOCOMPLETE] = $(selected).text();
-            wts.push(['send', 'click', {
+            var eventData = {
               linkId: 'Autocomplete søgning clicks',
-              customClickParameter: customClickParameter
-            }]);
+              customClickParameter: {}
+            };
+            eventData.customClickParameter[DING_WEBTREKK_PARAMETER_AUTOCOMPLETE] = $(selected).text();
+            pushEvent('click', eventData);
           }
       });
 
@@ -92,12 +99,13 @@
             // attribute for each select box.
             selectedMaterials.push($(this).data('ding-webtrekk-event'));
           });
-          var customClickParameter = {};
-          customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_SELECTED] = selectedMaterials.join(';');
-          wts.push(['send', 'click', {
+
+          var eventData = {
             linkId: 'Forny valgte materialer',
-            customClickParameter: customClickParameter
-          }]);
+            customClickParameter: {}
+          };
+          eventData.customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_SELECTED] = selectedMaterials.join(';');
+          pushEvent('click', eventData);
       });
 
       // Special handling for ding_carousel.
@@ -141,12 +149,12 @@
             wtkId = DING_WEBTREKK_PARAMETER_CAROUSEL_NEXT;
           }
 
-          var customClickParameter = {};
-          customClickParameter[wtkId] = carouselTitle;
-          wts.push(['send', 'click', {
+          var eventData = {
             linkId: linkId,
-            customClickParameter: customClickParameter
-          }]);
+            customClickParameter: {}
+          };
+          eventData.customClickParameter[wtkId] = carouselTitle;
+          pushEvent('click', eventData);
         });
       });
     }

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -46,12 +46,12 @@
         $('.js-rating-symbol', this).each(function(index) {
           var rating = (index + 1) + '';
           $(this).click(function() {
+            var customClickParameter = {};
+            customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_RATING] = rating;
+            customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_RATING_ID] = contentId;
             wts.push(['send', 'click', {
               linkId: 'Materiale rating',
-              customClickParameter: {
-                DING_WEBTREKK_PARAMETER_RENEW_RATING: rating,
-                DING_WEBTREKK_PARAMETER_RENEW_RATING_ID: contentId
-              }
+              customClickParameter: customClickParameter
             }]);
           });
         });
@@ -62,12 +62,11 @@
         .once('js-ding-webtrekk')
         .on('autocompleteSelect', function(e, selected) {
           if (($(selected).text())) {
-            console.log($(selected).text());
+            var customClickParameter = {};
+            customClickParameter[DING_WEBTREKK_PARAMETER_AUTOCOMPLETE] = $(selected).text();
             wts.push(['send', 'click', {
               linkId: 'Autocomplete søgning clicks',
-              customClickParameter: {
-                DING_WEBTREKK_PARAMETER_AUTOCOMPLETE: $(selected).text()
-              }
+              customClickParameter: customClickParameter
             }]);
           }
       });
@@ -93,11 +92,11 @@
             // attribute for each select box.
             selectedMaterials.push($(this).data('ding-webtrekk-event'));
           });
+          var customClickParameter = {};
+          customClickParameter[DING_WEBTREKK_PARAMETER_RENEW_SELECTED] = selectedMaterials.join(';');
           wts.push(['send', 'click', {
             linkId: 'Forny valgte materialer',
-            customClickParameter: {
-              DING_WEBTREKK_PARAMETER_RENEW_SELECTED: selectedMaterials.join(';')
-            }
+            customClickParameter: customClickParameter
           }]);
       });
 
@@ -135,15 +134,15 @@
 
         $('.slick-arrow', this).once('js-ding-webtrekk').click(function() {
           var linkId = 'Karousel, click på forrige knappen';
-          var customClickParameter = {
-            DING_WEBTREKK_PARAMETER_CAROUSEL_PREV: carouselTitle
-          };
+          var wtkId = DING_WEBTREKK_PARAMETER_CAROUSEL_PREV;
+
           if ($(this).hasClass('slick-next')) {
             linkId = 'Karousel, click på næste knappen';
-            customClickParameter = {
-              DING_WEBTREKK_PARAMETER_CAROUSEL_NEXT: carouselTitle
-            };
+            wtkId = DING_WEBTREKK_PARAMETER_CAROUSEL_NEXT;
           }
+
+          var customClickParameter = {};
+          customClickParameter[wtkId] = carouselTitle;
           wts.push(['send', 'click', {
             linkId: linkId,
             customClickParameter: customClickParameter

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -34,6 +34,11 @@
     }
   };
 
+  // Other modules dealing with client side webtrekk tracking might find these
+  // functions useful, so make them available on the global Drupal object.
+  Drupal.dingWebtrekkAppendQueryParameter = appendQueryParameter;
+  Drupal.dingWebtrekkPushEvent = pushEvent;
+
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
       // Send Webtrekk events attached in the backend.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3901

#### Description

Apparently it's not supported to use variables in object literals.
As a consequence all of the webtrekk events handled client side were not
sending the correct wtk ID.

The easiest fix seemed to be to instantiate the object first and then use bracket notation with the variables.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
