### PR TITLE
4159: Antibot prevents WAYF login

### DIFF
--- a/modules/ding_contact/ding_contact.strongarm.inc
+++ b/modules/ding_contact/ding_contact.strongarm.inc
@@ -16,7 +16,6 @@ function ding_contact_strongarm() {
   $strongarm->name = 'antibot_form_ids';
   $strongarm->value = 'comment_node_*
 user_login
-user_login_block
 user_pass
 user_register_form
 contact_site_form


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4159

#### Description

Ding Gate WAYF submits the login_block_form as part of it's login process. Which get's flags by antibot module as spam.

So NemID login succeeds, but drupal login fails and the user ends up at the registry as new user page.  

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.