### PR TITLE
4194: opensearch cache local ids

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -447,6 +447,16 @@ function opensearch_execute(TingClientRequest $request) {
       $request->setLocalIds(array_keys($uncached_local_ids));
     }
 
+    // The $cached_local_ids array is now keyed by local id and we needed that
+    // to get the uncached local ids. But in the response all objects should be
+    // keyed PID, so here we convert the array of cached "local" objects to be
+    // keyed by their PID.
+    $local_object_pids = [];
+    foreach ($cached_local_ids as $object) {
+      $local_object_pids[] = $object->id;
+    }
+    $cached_local_ids = array_combine($local_object_pids, $cached_local_ids);
+
     $cached_objects = $cached_object_ids + $cached_local_ids;
 
     // If there are no ids to fetch then there is no need to issue a request.
@@ -455,10 +465,6 @@ function opensearch_execute(TingClientRequest $request) {
       _opensearch_cache($request, $cached_objects);
       return $cached_objects;
     }
-
-    // Re-set uncached ids in the request so the missing will be fetched from
-    // the data-well.
-    $request->setObjectIds(array_keys($uncached_ids));
   }
 
   try {

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -92,13 +92,6 @@ function opensearch_get_objects(array $ids, $local = FALSE) {
     $request->setProfile($profile);
   }
 
-  if ($local) {
-    // Ensure local ids are integer values and not strings. Else we will not
-    // hit the cache, since they will be converted to integers in our caching
-    // logic in opensearch_execute(), if they are passed as strings.
-    $ids = array_map('intval', $ids);
-  }
-
   // Opensearch getObject complains if it has to return more than 200 records,
   // with the message 'getObject can fetch up to 200 records. '. But it seems
   // it also have trouble fething over 169 records, which appears to be a bug.
@@ -450,7 +443,16 @@ function opensearch_execute(TingClientRequest $request) {
     }
     $uncached_local_ids = array_diff_key($local_ids, $cached_local_ids);
     if (!empty($uncached_local_ids)) {
-      $request->setLocalIds(array_keys($uncached_local_ids));
+      $uncached_local_ids = array_keys($uncached_local_ids);
+      // Datawell ids needs to be strings, since for example the id '06606059'
+      // is not the same as '6606059'. But PHP might have converted some of the
+      // local ids to integers when using them as array keys. For example the id
+      // '20174870' would be converted to integer when using as key. It's
+      // important that the request object is exactly the same when using it as
+      // a base for cache ID, so here we ensure that all local ids are added to
+      // the request as string values.
+      $uncached_local_ids = array_map('strval', $uncached_local_ids);
+      $request->setLocalIds($uncached_local_ids);
     }
 
     // The $cached_local_ids array is now keyed by local id and we needed that

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -118,15 +118,15 @@ function opensearch_get_objects(array $ids, $local = FALSE) {
  * Performs a search against the well.
  *
  * @param string $query
- *   The search query
+ *   The search query.
  * @param int $page
- *   The page number to retrieve search results for
+ *   The page number to retrieve search results for.
  * @param int $results_per_page
- *   The number of results to include per page
+ *   The number of results to include per page.
  * @param array $options
  *   Options to pass to the search. Possible options are:
  *    - facets: Array of facet names for which to return results. Default:
- *      facet.subject, facet.creator, facet.type, facet.date, facet.language
+ *      facet.subject, facet.creator, facet.type, facet.date, facet.language.
  *    - numFacets: The number of terms to include with each facet. Default: 10
  *    - sort: The key to sort the results by. Default: "" (corresponds to
  *      relevance). The possible values are defined by the sortType type

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -360,8 +360,14 @@ function opensearch_get_request_factory() {
  * @param \TingClientRequest $request
  *   The request.
  *
- * @return \TingClientSearchResult|bool
+ * @return \TingClientSearchResult|\TingClientObjectCollection|array|bool|null
  *   Result of the request or false if an error occurs.
+ *   If $request is a TingClientSearchRequest a TingClientSearchResult result
+ *   object is returned.
+ *   If $request is a TingClientCollectionRequest a TingClientObjectCollection
+ *   result object is returned.
+ *   If $request is a TingClientObjectRequest an array of TingClientObject
+ *   result objects is returned or NULL if nothing was found.
  */
 function opensearch_execute(TingClientRequest $request) {
   // Get additional parameters from other modules.

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -497,18 +497,19 @@ function opensearch_execute(TingClientRequest $request) {
       }
     }
 
-    // This have to be execute after the post_execute hook as the $res and
-    // $response may not match i size and give some strange requirements in the
-    // hooks.
-    if ($request instanceof TingClientObjectRequest) {
-      // Merge in any cached objects. The map uses ids as keys. The order does
-      // not matter for object requests.
-      $response = array_merge($cached_objects, $response);
-    }
-
     // Update the cache with the raw response object from the data well for
     // faster processing. Also set the static cache.
     _opensearch_cache($request, $response);
+
+    // Merge any cached objecst that we found earlier with the result from the
+    // request. Note that we do this after invoking post_execute and setting the
+    // cache. When invoking post_execute() the $response and $res need to
+    // correspond. When setting cache the $response needs to match $request, so
+    // that futures requests doesn't get the wrong response from cache.
+    if ($request instanceof TingClientObjectRequest) {
+      // The map uses ids as keys. Order does not matter for object requests.
+      $response = array_merge($cached_objects, $response);
+    }
 
     // To speed up the entity module, which will trigger an search for each
     // collection. Try and predict the search request an warm up the cache.

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -401,9 +401,7 @@ function opensearch_execute(TingClientRequest $request) {
 
     // Try to retrieve a cached response for each request. Entries which does
     // not have cached data will get the value FALSE for easy subsequent
-    // filtering. Note that the input array to the map function uses "+" and not
-    // the array_merge function as merge will reset the keys when they are
-    // numeric which is the case with local_ids.
+    // filtering.
     $object_ids = array_map(function ($object_request) {
       if ($cached_response = _opensearch_cache($object_request)) {
         // A response for a single object is an array with a single object so
@@ -413,16 +411,33 @@ function opensearch_execute(TingClientRequest $request) {
       else {
         return FALSE;
       }
-    }, $object_id_requests + $local_id_requests);
-    $cached_objects = array_filter($object_ids);
+    }, $object_id_requests);
+    $cached_object_ids = array_filter($object_ids);
 
-    // Ids that we still need to be fetched will not be appearing in the list of
-    // cached objects.
-    $uncached_ids = array_diff_key($object_ids, $cached_objects);
+    $local_ids = array_map(function ($object_request) {
+      if ($cached_response = _opensearch_cache($object_request)) {
+        // A response for a single object is an array with a single object so
+        // just return the object.
+        return array_shift($cached_response);
+      }
+      else {
+        return FALSE;
+      }
+    }, $local_id_requests);
+    $cached_local_ids = array_filter($local_ids);
+
+    // Ids that we still need to be fetched will not be appearing in the lists
+    // of cached objects.
+    $uncached_object_ids = array_diff_key($object_ids, $cached_object_ids);
+    $request->setObjectIds(array_keys($uncached_object_ids));
+    $uncached_local_ids = array_diff_key($local_ids, $cached_local_ids);
+    $request->setLocalIds(array_keys($uncached_local_ids));
+
+    $cached_objects = $cached_object_ids + $cached_local_ids;
 
     // If there are no ids to fetch then there is no need to issue a request.
     // Just return the array of cached objects.
-    if (empty($uncached_ids)) {
+    if (empty($uncached_object_ids) && empty($uncached_local_ids)) {
       _opensearch_cache($request, $cached_objects);
       return $cached_objects;
     }

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -390,9 +390,23 @@ function opensearch_execute(TingClientRequest $request) {
   // request for all these objects combined in the cache but they might be
   // cached individually.
   $cached_objects = [];
+  $original_object_ids = [];
+  $original_local_ids = [];
   if ($request instanceof TingClientObjectRequest) {
-    // Build maps of singular requests for objects by id or local id.
     $object_ids = !empty($request->getObjectIds()) ? $request->getObjectIds() : array();
+    $local_ids = !empty($request->getLocalIds()) ? $request->getLocalIds() : array();
+
+    // Store the original object_ids and local_ids identifier arrays, so that we
+    // can reconstruct the original request later on when genrating cache key
+    // for the response.
+    if ($object_ids) {
+      $original_object_ids = $request->getObjectIds();
+    }
+    if ($local_ids) {
+      $original_local_ids = $request->getLocalIds();
+    }
+
+    // Build maps of singular requests for objects by id or local id.
     $object_ids = array_combine($object_ids, $object_ids);
     $object_id_requests = array_map(function($id) use ($request) {
       $object_request = clone $request;
@@ -400,7 +414,6 @@ function opensearch_execute(TingClientRequest $request) {
       return $object_request;
     }, $object_ids);
 
-    $local_ids = !empty($request->getLocalIds()) ? $request->getLocalIds() : array();
     $local_ids = array_combine($local_ids, $local_ids);
     $local_id_requests = array_map(function($id) use ($request) {
       $object_request = clone $request;
@@ -443,16 +456,7 @@ function opensearch_execute(TingClientRequest $request) {
     }
     $uncached_local_ids = array_diff_key($local_ids, $cached_local_ids);
     if (!empty($uncached_local_ids)) {
-      $uncached_local_ids = array_keys($uncached_local_ids);
-      // Datawell ids needs to be strings, since for example the id '06606059'
-      // is not the same as '6606059'. But PHP might have converted some of the
-      // local ids to integers when using them as array keys. For example the id
-      // '20174870' would be converted to integer when using as key. It's
-      // important that the request object is exactly the same when using it as
-      // a base for cache ID, so here we ensure that all local ids are added to
-      // the request as string values.
-      $uncached_local_ids = array_map('strval', $uncached_local_ids);
-      $request->setLocalIds($uncached_local_ids);
+      $request->setLocalIds(array_keys($uncached_local_ids));
     }
 
     // The $cached_local_ids array is now keyed by local id and we needed that
@@ -497,19 +501,26 @@ function opensearch_execute(TingClientRequest $request) {
       }
     }
 
-    // Update the cache with the raw response object from the data well for
-    // faster processing. Also set the static cache.
-    _opensearch_cache($request, $response);
-
     // Merge any cached objecst that we found earlier with the result from the
-    // request. Note that we do this after invoking post_execute and setting the
-    // cache. When invoking post_execute() the $response and $res need to
-    // correspond. When setting cache the $response needs to match $request, so
-    // that futures requests doesn't get the wrong response from cache.
+    // request. Note that we do this after invoking post_execute, since the
+    // $response and $res need to correspond.
     if ($request instanceof TingClientObjectRequest) {
       // The map uses ids as keys. Order does not matter for object requests.
       $response = array_merge($cached_objects, $response);
+
+      // Restore the original ids on the request so that our generated cache id
+      // will point to the correct response.
+      if ($original_object_ids) {
+        $request->setObjectIds($original_object_ids);
+      }
+      if ($original_local_ids) {
+        $request->setLocalIds($original_local_ids);
+      }
     }
+
+    // Update the cache with the raw response object from the data well for
+    // faster processing. Also set the static cache.
+    _opensearch_cache($request, $response);
 
     // To speed up the entity module, which will trigger an search for each
     // collection. Try and predict the search request an warm up the cache.

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -92,6 +92,13 @@ function opensearch_get_objects(array $ids, $local = FALSE) {
     $request->setProfile($profile);
   }
 
+  if ($local) {
+    // Ensure local ids are integer values and not strings. Else we will not
+    // hit the cache, since they will be converted to integers in our caching
+    // logic in opensearch_execute(), if they are passed as strings.
+    $ids = array_map('intval', $ids);
+  }
+
   // Opensearch getObject complains if it has to return more than 200 records,
   // with the message 'getObject can fetch up to 200 records. '. But it seems
   // it also have trouble fething over 169 records, which appears to be a bug.

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -105,7 +105,10 @@ function opensearch_get_objects(array $ids, $local = FALSE) {
     else {
       $request->setObjectIds($chunk);
     }
-    $objects += opensearch_execute($request);
+    $result = opensearch_execute($request);
+    if (is_array($result)) {
+      $objects += $result;
+    }
   }
 
   return $objects;

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -439,9 +439,13 @@ function opensearch_execute(TingClientRequest $request) {
     // Ids that we still need to be fetched will not be appearing in the lists
     // of cached objects.
     $uncached_object_ids = array_diff_key($object_ids, $cached_object_ids);
-    $request->setObjectIds(array_keys($uncached_object_ids));
+    if (!empty($uncached_object_ids)) {
+      $request->setObjectIds(array_keys($uncached_object_ids));
+    }
     $uncached_local_ids = array_diff_key($local_ids, $cached_local_ids);
-    $request->setLocalIds(array_keys($uncached_local_ids));
+    if (!empty($uncached_local_ids)) {
+      $request->setLocalIds(array_keys($uncached_local_ids));
+    }
 
     $cached_objects = $cached_object_ids + $cached_local_ids;
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4194

#### Description

The uncached id's were always passed to setObjectIds(). As a result requests based on local ids will fail.

An example is when we translate local ids from the status lists to PID by finding the namespace after looking up the local ids in getObject. These will always end up here:

https://github.com/ding2/ding2/blob/master/modules/opensearch/includes/opensearch.search.inc#L631 

As a consequence we are currently using the wrong namespace for a lot of materials in status lists.

There were also some additional problems were wouldn't hit the cache, and the objects returned wasn't keyed by PID when local ids was used in the request.

I realize that I'm setting both setObjectIds() and setLocalIds() when TingObjectRequest doesn't actually support requests with a mix of both types of identifiers. But currently I think no request are made with a mix. It's either full local or full pid. So it's no problem. But opensearch getObject does actually support it, so we could make it work if need be. The code should be ready for it if TingObjectRequest is modified to support it.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

I also sneaked in a small correction to opensearch_get_objects(). Opensearch execute doesn't return empty array when no results, but NULL, giving rise to "Unsupported operand" error in the current state.