### PR TITLE
3912: Underline links

### DIFF
--- a/themes/ddbasic/sass/components/node/event.scss
+++ b/themes/ddbasic/sass/components/node/event.scss
@@ -4,6 +4,11 @@
 @import '../../base.scss';
 
 .node-ding-event {
+  // Display links in body text with underline.
+  .field-name-field-ding-event-body a {
+    text-decoration: underline;
+  }
+
   // ==========================================================================
   // Teaser
   // ==========================================================================

--- a/themes/ddbasic/sass/components/node/group.scss
+++ b/themes/ddbasic/sass/components/node/group.scss
@@ -5,6 +5,11 @@
 
 .node-ding-group {
 
+  // Display links in body text with underline.
+  .field-name-field-ding-group-body a {
+    text-decoration: underline;
+  }
+
   // ==========================================================================
   // Teaser
   // ==========================================================================

--- a/themes/ddbasic/sass/components/node/news.scss
+++ b/themes/ddbasic/sass/components/node/news.scss
@@ -4,6 +4,11 @@
 @import '../../base.scss';
 
 .node-ding-news {
+  // Display links in body text with underline.
+  .field-name-field-ding-news-body a {
+    text-decoration: underline;
+  }
+
   // ==========================================================================
   // Teaser
   // ==========================================================================


### PR DESCRIPTION
https://platform.dandigbib.org/issues/3912

#### Description

Adds underline to links in body on event, news and groups.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/53725569-8fb67400-3e6c-11e9-9c38-5c1a536e9484.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.