### PR TITLE
3936: Fix missing titles for ILL on loan/reservation

### DIFF
--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -171,7 +171,8 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
     }
 
     foreach ($group['loans'] as $loan) {
-      $title = $creators = $mat_type = $cover = NULL;
+      $title = t('Title not available');
+      $creators = $mat_type = $cover = NULL;
 
       // If the provider was able to produce an entity we'll use that since we can
       // show more information and link to the entity.
@@ -189,18 +190,15 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
         $title = $loan->display_name;
         $creators = $loan->author;
       }
-      else {
-        $title = t('Title not available');
-      }
 
       $item = array(
         '#type' => 'material_item',
         '#loan' => $loan,
         '#id' => $loan->id,
-        '#creators' => isset($creators) ? $creators : NULL,
-        '#material_type' => isset($mat_type) ? $mat_type : NULL,
+        '#creators' => $creators,
+        '#material_type' => $mat_type,
         '#title' => $title,
-        '#cover' => isset($cover) ? $cover : NULL,
+        '#cover' => $cover,
         '#information' => array(
           'loan_date' => array(
             'label' => t('Loan date'),

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -343,14 +343,14 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
     '#type' => 'html_tag',
     '#tag' => 'div',
     '#value' => '<a href="#">' . t('Renew all') . '</a>',
-    '#attributes' => [
-      'class' => [
+    '#attributes' => array(
+      'class' => array(
         'renew-all',
         'action-all',
         'action-button',
         'js-renew-all',
-      ],
-    ],
+      ),
+    ),
   );
 
   return $form;

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -49,7 +49,9 @@ function ding_loan_loans_content_type_render($subtype, $conf, $panel_args, $cont
         continue;
       }
 
-      $ids[] = $item->ding_entity_id;
+      if (isset($item->ding_entity_id)) {
+        $ids[] = $item->ding_entity_id;
+      }
     }
     ding_entity_load_multiple($ids);
 
@@ -169,46 +171,27 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
     }
 
     foreach ($group['loans'] as $loan) {
-      // The default title from loan object.
-      $title = $loan->display_name;
+      $title = $creators = $mat_type = $cover = NULL;
 
-      // Try to get entity for the loan to make a better title and provide info
-      // about the associated material.
-      /** @var \TingEntity $entity */
-      $entity = $loan->entity;
-      if (!is_object($entity) || NULL === $entity->getTingObject()) {
-        // Patron have this item in loans list, but the search provider can't
-        // find this record for current agencyId, so we load it separately.
-        $ting_object = ting_search_object_load($loan->ding_entity_id);
+      // If the provider was able to produce an entity we'll use that since we can
+      // show more information and link to the entity.
+      if (!empty($loan->ding_entity_id)) {
+        $entity = $loan->entity;
 
-        if (!empty($ting_object)) {
-          // But we need TingEntity instance, so here we are populating this.
-          $ting_entity = new TingEntity();
-          $ting_entity->ding_entity_id = $entity->ding_entity_id;
-          $ting_entity->setTingObject($ting_object);
-        }
-      }
-
-      // Initialize variables so that they don't carry over if this entity can't
-      // be searched.
-      $creators = $mat_type = $cover = NULL;
-      if (is_object($entity) && NULL !== $entity->getTingObject()) {
-        $raw_title = $entity->getTitle();
-
-        // Add title link.
         $uri = entity_uri('ting_object', $entity);
-        $title = l($raw_title, $uri['path']);
-
-        // Add creator(s).
-        $creators = $entity->creators;
-
-        // Add type.
-        $mat_type = $entity->type;
-
-        // Attempt to render a cover.
+        $title = l($entity->getTitle(), $uri['path']);
+        $creators = $entity->getCreators();
+        $mat_type = $entity->getType();
         $cover = field_view_field('ting_object', $entity, 'ting_cover', 'user_list');
       }
-
+      // Else the provider has the option to supply a display name and author.
+      elseif (!empty($loan->display_name)) {
+        $title = $loan->display_name;
+        $creators = $loan->author;
+      }
+      else {
+        $title = t('Title not available');
+      }
 
       $item = array(
         '#type' => 'material_item',

--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -176,7 +176,7 @@ function ding_loan_loans_form($form, &$form_state, $account, $loans = array()) {
 
       // If the provider was able to produce an entity we'll use that since we can
       // show more information and link to the entity.
-      if (!empty($loan->ding_entity_id)) {
+      if (is_object($loan->entity)) {
         $entity = $loan->entity;
 
         $uri = entity_uri('ting_object', $entity);

--- a/modules/ding_provider/ding_provider.loan.inc
+++ b/modules/ding_provider/ding_provider.loan.inc
@@ -130,7 +130,7 @@ class DingProviderLoan extends DingEntityBase {
 
   function getEntity() {
     if (!isset($this->entity) || $this->entity === self::NULL) {
-      if (!empty($this->ding_entity_id)) {
+      if (!empty($this->ding_entity_id) && $this->ding_entity_id !== self::NULL) {
         $this->entity = ding_entity_load($this->ding_entity_id);
       }
       else {

--- a/modules/ding_provider/ding_provider.reservation.inc
+++ b/modules/ding_provider/ding_provider.reservation.inc
@@ -199,7 +199,7 @@ class DingProviderReservation extends DingEntityBase {
 
   function getEntity() {
     if (!isset($this->entity) || $this->entity === self::NULL) {
-      if (!empty($this->ding_entity_id)) {
+      if (!empty($this->ding_entity_id) && $this->ding_entity_id !== self::NULL) {
         $this->entity = ding_entity_load($this->ding_entity_id);
       }
       else {

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -490,7 +490,8 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
   }
 
   foreach ($reservations as $reservation) {
-    $mat_type = $creators = $title = NULL;
+    $title = t('Title not available');
+    $creators = $mat_type = $cover = NULL;
 
     // If the provider was able to produce an entity we'll use that since we can
     // show more information and link to the entity.
@@ -501,6 +502,7 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
       $title = l($entity->getTitle(), $uri['path']);
       $creators = $entity->getCreators();
       $mat_type = $entity->getType();
+      $cover = field_view_field('ting_object', $entity, 'ting_cover', 'user_list');
     }
     // Else the provider has the option to supply a display name and author.
     elseif (!empty($reservation->display_name)) {
@@ -521,7 +523,7 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
           '#creators' => $creators,
           '#material_type' => $mat_type,
           '#title' => $title,
-          '#cover' => field_view_field('ting_object', $entity, 'ting_cover', 'user_list'),
+          '#cover' => $cover,
           '#information' => array(
             'pickup_id' => array(
               'label' => t('Pickup id'),

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -561,7 +561,7 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
           '#creators' => $creators,
           '#material_type' => $mat_type,
           '#title' => $title,
-          '#cover' => field_view_field('ting_object', $entity, 'ting_cover', 'user_list'),
+          '#cover' => $cover,
           '#information' => array(
             'queue_number' => array(
               'label' => t('Queue number'),
@@ -609,7 +609,7 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
           '#creators' => $creators,
           '#material_type' => $mat_type,
           '#title' => $title,
-          '#cover' => field_view_field('ting_object', $entity, 'ting_cover', 'user_list'),
+          '#cover' => $cover,
           '#information' => array(
             'ill_status' => array(
               'label' => t('Status'),

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -495,7 +495,7 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
 
     // If the provider was able to produce an entity we'll use that since we can
     // show more information and link to the entity.
-    if (!empty($reservation->ding_entity_id)) {
+    if (is_object($reservation->entity)) {
       $entity = $reservation->entity;
 
       $uri = entity_uri('ting_object', $entity);

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -509,9 +509,6 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
       $title = $reservation->display_name;
       $creators = $reservation->author;
     }
-    else {
-      $title = t('Title not available');
-    }
 
     $pickup_branch = ding_provider_invoke('reservation', 'branch_name', $reservation->pickup_branch_id);
     switch ($reservation->reservation_type) {

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -490,25 +490,26 @@ function ding_reservation_reservations_form($form, &$form_state, $reservations, 
   }
 
   foreach ($reservations as $reservation) {
-    /** @var \TingEntity $entity */
-    $entity = $reservation->entity;
-    if (!is_object($entity) || NULL === $entity->getTingObject()) {
-      $entity = ding_provider_get_pseudo_entity($reservation->ding_entity_id);
-      // Don't link the title as the data well do not known this title. It may
-      // be a inter library loan.
-      $title = (!empty($entity) && $entity->getTitle()) ? $entity->getTitle() : $reservation->display_name;
-    }
-    else {
-      // Create title that links to the object.
+    $mat_type = $creators = $title = NULL;
+
+    // If the provider was able to produce an entity we'll use that since we can
+    // show more information and link to the entity.
+    if (!empty($reservation->ding_entity_id)) {
+      $entity = $reservation->entity;
+
       $uri = entity_uri('ting_object', $entity);
       $title = l($entity->getTitle(), $uri['path']);
+      $creators = $entity->getCreators();
+      $mat_type = $entity->getType();
     }
-
-    // Add creator(s).
-    $creators = $entity->creators;
-
-    // Add type.
-    $mat_type = $entity->type;
+    // Else the provider has the option to supply a display name and author.
+    elseif (!empty($reservation->display_name)) {
+      $title = $reservation->display_name;
+      $creators = $reservation->author;
+    }
+    else {
+      $title = t('Title not available');
+    }
 
     $pickup_branch = ding_provider_invoke('reservation', 'branch_name', $reservation->pickup_branch_id);
     switch ($reservation->reservation_type) {

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -287,7 +287,9 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
       // therefore we can't get a well ID to display. We'll note that it's an
       // ILL and use the title instead.
       else {
-        $material_ids[$loan->id] = 'Interlibrary Loan: ' . $loan->display_name;
+        $material_ids[$loan->id] = t('Interlibrary Loan: %title', [
+          '%title' => $loan->display_name,
+        ]);
       }
     }
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -280,7 +280,15 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
   $material_ids = [];
   foreach ($loans as $loan) {
     if ($loan->renewable) {
-      $material_ids[$loan->id] = $loan->getEntity()->getId();
+      if (is_object($loan->entity)) {
+        $material_ids[$loan->id] = $loan->entity->getId();
+      }
+      // For interlibrary loans the material may not reachable in the well and
+      // therefore we can't get a well ID to display. We'll note that it's an
+      // ILL and use the title instead.
+      else {
+        $material_ids[$loan->id] = 'Interlibrary Loan: ' . $loan->display_name;
+      }
     }
   }
 

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -287,9 +287,9 @@ function ding_webtrekk_form_ding_loan_loans_form_alter(&$form, &$form_state) {
       // therefore we can't get a well ID to display. We'll note that it's an
       // ILL and use the title instead.
       else {
-        $material_ids[$loan->id] = t('Interlibrary Loan: %title', [
+        $material_ids[$loan->id] = t('Interlibrary Loan: %title', array(
           '%title' => $loan->display_name,
-        ]);
+        ));
       }
     }
   }

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -48,12 +48,21 @@ function fbs_loan_list($account, $reset = FALSE) {
         $id = $loan->loanDetails->loanId;
 
         $loan_data = array(
-          'ding_entity_id' => $ids[$loan->loanDetails->recordId],
           'loan_date' => $loan->loanDetails->loanDate,
           'expiry' => $loan->loanDetails->dueDate,
           'renewable' => $loan->isRenewable,
           'materials_number' => $loan->loanDetails->materialItemNumber,
         );
+
+        // With the FBS provider we have to use FBS data for ILL, since we can't
+        // rely on the record ID being unique in these cases.
+        if (!empty($loan->loanDetails->ilBibliographicRecord)) {
+          $loan_data['display_name'] = $loan->loanDetails->ilBibliographicRecord->title;
+          $loan_data['author'] = $loan->loanDetails->ilBibliographicRecord->author;
+        }
+        elseif (isset($ids[$loan->loanDetails->recordId])) {
+          $loan_data['ding_entity_id'] = $ids[$loan->loanDetails->recordId];
+        }
 
         // Ding loan maintains a list of renewed loans in this session, and if
         // this loan is here we will use it for renewal feedback.
@@ -92,11 +101,6 @@ function fbs_loan_list($account, $reset = FALSE) {
           else {
             $loan_data['notes'] = t('Issue @vol', array('@vol' => $vol));
           }
-        }
-
-        // Handle inter library loans.
-        if (!empty($loan->loanDetails->ilBibliographicRecord)) {
-          $loan_data['display_name'] = $loan->loanDetails->ilBibliographicRecord->title;
         }
 
         $results[$id] = new DingProviderLoan($id, $loan_data);

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -121,13 +121,13 @@ function fbs_loan_list($account, $reset = FALSE) {
  *
  * @param object $account
  *   User to renew loan for.
- * @param array $loan
+ * @param array $loans
  *   Loan ids to renew.
  *
  * @return array
  *   Result of revewals.
  */
-function fbs_loan_renew($account, $loans) {
+function fbs_loan_renew($account, array $loans) {
   $res = array();
   try {
     $res = fbs_service()->MaterialLoans->renewLoans(fbs_service()->agencyId, fbs_patron_id($account), $loans);

--- a/modules/fbs/includes/fbs.loan.inc
+++ b/modules/fbs/includes/fbs.loan.inc
@@ -141,8 +141,8 @@ function fbs_loan_renew($account, array $loans) {
     // Using an array for renewalStatus is an odd choice, but we'll only
     // consider the loan renewed if 'renewed' is the only status.
     if ($loan->renewalStatus == array('renewed')) {
-      $result[$loan->loanDetails->loanId] =
-        $loan->loanDetails->loanType == 'interLibraryLoan' ?
+      $result[$loan->loanDetails->loanId]
+        = $loan->loanDetails->loanType == 'interLibraryLoan' ?
         DingProviderLoan::STATUS_RENEWAL_REQUESTED :
         DingProviderLoan::STATUS_RENEWED;
     }

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -54,7 +54,6 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
         $type = $reservation->state == 'interLibraryReservation' ? DING_RESERVATION_INTERLIBRARY_LOANS : $type;
 
         $ding_reservation = array(
-          'ding_entity_id' => $ids[$reservation->recordId],
           'id' => $reservation->reservationId,
           'pickup_branch_id' => $reservation->pickupBranch,
           'created' => $reservation->dateOfReservation,
@@ -62,6 +61,16 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
           // Required by ding_reservation.
           'reservation_type' => $type,
         );
+
+        // With the FBS provider we have to use FBS data for ILL, since we can't
+        // rely on the record ID being unique in these cases.
+        if (isset($reservation->ilBibliographicRecord)) {
+          $ding_reservation['display_name'] = $reservation->ilBibliographicRecord->title;
+          $ding_reservation['author'] = $reservation->ilBibliographicRecord->author;
+        }
+        else {
+          $ding_reservation['ding_entity_id'] = $ids[$reservation->recordId];
+        }
 
         if ($type === DING_RESERVATION_READY) {
           $ding_reservation['pickup_date'] = $reservation->pickupDeadline;
@@ -94,11 +103,6 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
           else {
             $ding_reservation['notes'] = t('Issue @vol', array('@vol' => $vol));
           }
-        }
-
-        // Handle inter library loans.
-        if (!empty($reservation->ilBibliographicRecord)) {
-          $ding_reservation['display_name'] = $reservation->ilBibliographicRecord->title;
         }
 
         $results[$type][$ding_reservation['id']] = new DingProviderReservation($ding_reservation['id'], $ding_reservation);

--- a/modules/fbs/includes/fbs.reservation.inc
+++ b/modules/fbs/includes/fbs.reservation.inc
@@ -68,7 +68,7 @@ function fbs_reservation_list($account, $requested_type = NULL, $reset = FALSE) 
           $ding_reservation['display_name'] = $reservation->ilBibliographicRecord->title;
           $ding_reservation['author'] = $reservation->ilBibliographicRecord->author;
         }
-        else {
+        elseif (isset($ids[$reservation->recordId])) {
           $ding_reservation['ding_entity_id'] = $ids[$reservation->recordId];
         }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3936

#### Description

In the latest versions a lot of libraries has experienced the "Error: unknown/missing/inaccessible record:" problem with materials on statuslists.

I have posted a pretty hacky attempt to fix this here: https://github.com/ding2/ding2/pull/1293, but it relies on a weird way of handling not-found object in opensearch getObject. We are in contact with DBC and they will update opensearch to handle it in a better way.

This should only be a problem with ILL loans/reservations since we should be able to always get an entity for materials in the libraries own catalog.

During analysis in https://platform.dandigbib.org/issues/3936 we have found out that we actually shouldn't try to make a request against opensearch at all for ILL, since the ID we recieve from FBS API isn't guaranteed to be a faust and hence there's a risk for collisions with wrong materials from other sources than the library catalog.

So I believe a better fix for this right now is to **not** make an opensearch request for ILL. This should fix all the cases with  "Error: unknown/missing/inaccessible record:" on loan/reservation.

The main approach is that we don't send a ding_entity_id from the providers when we have an ILL-bibliographic record on the response from FBS API. Ding_loan/reservation will check for the entity and if provider didn't set ding_entity_id, NULL will be returned. Before we were actually sending a wrong ding_entity_id in some cases.

We will still have problem with debts, since we have no idea whether it's ILL there. But we will handle that in another case, since we will have to wait for Systematic to (hopefully) update the API with more ILL-information.

Off course we should also try to fix the "Errors as real object"-problem that my previous PR tried to address, but we will also handle that in another case, since we will have to wait for DBC to update opensearch.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

I found a weird quirk in the DingProviderReservation and DingProviderLoan objects, where it would try to make a very problematic opensearch request, when the object has been serialized in ding_session_cache(). More about that in the related commit message.

Tbh I'm not really a fan of these classes, and have a very hard time seeing the usefulness of all the complexity in these, but I have tried to fix this without changing too much.

I did experience much better performance on the status lists after fixing it, because it doesn't make the very problematic request agaisnt opensearch. 
