### PR TITLE
3974 by Inlead: Sorting of Events is changed

### DIFF
--- a/themes/ddbasic/scripts/view.js
+++ b/themes/ddbasic/scripts/view.js
@@ -207,14 +207,6 @@
                 has_image = false;
               }
 
-              // If odd and has image.
-              if (row_total % 2 === 1 && has_image === true) {
-                row_order = row_order - 1;
-              }
-              else {
-                row_order = row_order + 1;
-              }
-
               // Set css order on rows.
               $(this).attr('style',  'order:' + row_order);
 

--- a/themes/ddbasic/scripts/view.js
+++ b/themes/ddbasic/scripts/view.js
@@ -187,7 +187,6 @@
         $('.view-ding-event.max-two-rows .view-elements .view-elements-inner .group-row').each(function () {
           var rows = $(this).children('.views-row'),
               row_total = 0,
-              row_order = 0,
               has_image,
               doc_style = document.documentElement.style;
 
@@ -206,9 +205,6 @@
                 row_total = row_total + 1;
                 has_image = false;
               }
-
-              // Set css order on rows.
-              $(this).attr('style',  'order:' + row_order);
 
             });
           }


### PR DESCRIPTION
#### Link to issue

http://platform.dandigbib.org/issues/3974

#### Description

At some point between the latest releases, the sorting/display of Events have changed.
**Release 29 (7.x-4.5.x):**
![image](https://user-images.githubusercontent.com/3027336/54364054-d2e6c300-4674-11e9-80b9-e0f09eb06974.png)

**Release 30 (7.x-4.6.x):**
![image](https://user-images.githubusercontent.com/3027336/54364095-e2fea280-4674-11e9-8ee6-e24d77f51627.png)

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/3027336/54363942-a3d05180-4674-11e9-8b4f-e870596262c8.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The problem is not in the releases. This behavior occurs when 2 or more nodes in the view doesn't have images. It tries to stack them in a single column. 
