### PR TITLE
3738: Fix incorrect shelfmarks for non-fiction

### DIFF
--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -131,40 +131,63 @@ function fbs_availability_holdings($provider_ids) {
       elseif ($suffix_type == 'shelf_mark' && isset($entities[$datawell_pids[$item->recordId]])) {
         $entity = $entities[$datawell_pids[$item->recordId]];
 
-        $field652m = fbs_get_marc_field($entity, '652', 'm');
-        $field652o = fbs_get_marc_field($entity, '652', 'o');
-
-        // For music and non-fiction a special prefix is used.
+        // For non-fiction and music a special prefix is used.
         $prefix = '';
 
+        // The DK5 classification that we need to consider can both be present
+        // in subfield 'm' and 'o' of field 652. So we extract them both here
+        // for later use.
+        $field652 = fbs_get_marc_field($entity, '652');
+        $field652m = $field652o = '';
+        // There can be multiple 652 fields each with their own subfields. It's
+        // important that we use data from the same 652 field that we use the
+        // classification from, so remember the index of the field we end up
+        // using.
+        $field652index = NULL;
+        if (!empty($field652['m'])) {
+          $field652m = reset($field652['m']);
+          $field652index = key($field652['m']);
+        }
+
+        if (!empty($field652['o'])) {
+          $field652o = reset($field652['o']);
+          // We need to look in both 'm' and 'o' subfield for the 'sk' marker
+          // but we only need to use data from one of the fields. We prefer the
+          // 'm' subfield, but if for some reason there was no data we will use
+          // the 'o' field. So in these cases use remember the index of 'o'.
+          if (empty($field652['m'])) {
+            $field652index = key($field652['o']);
+          }
+        }
+        // Non-fiction: Look for the 'sk' marker in both 'm' and 'o' subfield.
+        // If it's not present in any of these, we consider the material be to
+        // be non-fiction and we should use the special prefix for non-fiction
+        // materials.
+        if ($field652m !== 'sk' && $field652o !== 'sk') {
+          // DK5 classification.
+          $prefix .= $field652m;
+
+          // Additional descriptors from the DK5 classification. Note that we
+          // ensure to use data from the correct subfield where we also got the
+          // DK5-classification from.
+          if (!empty($field652['b'][$field652index])) {
+            $prefix .= ' ' . $field652['b'][$field652index];
+          }
+          elseif (!empty($field652['a'][$field652index])) {
+            $prefix .= ' ' . $field652['a'][$field652index];
+            if (!empty($field652['h'][$field652index])) {
+              $prefix .= ', ' . $field652['h'][$field652index];
+            }
+          }
+        }
         // Music: Field 039.a is present on music materials, so we can use this
         // is an indicator.
-        if ($field039a = fbs_get_marc_field($entity, '039', 'a')) {
+        elseif ($field039a = fbs_get_marc_field($entity, '039', 'a')) {
           $prefix .= fbs_translate_marc($field039a, '039.a');
 
           // We'll also append additional subfields if present.
           if ($field039b = fbs_get_marc_field($entity, '039', 'b')) {
             $prefix .= ' ' . fbs_translate_marc($field039b, '039.b');
-          }
-        }
-        // Non-fiction: The 'sk' marker is in DK5-classification fields, to mark
-        // fiction materials. Everything else has a classification number and is
-        // non-fiction. Subfield 'm' and 'o' can both contain this special
-        // marker, so we check them both to be more resilient against error and
-        // missing data.
-        elseif ($field652m !== 'sk' && $field652o !== 'sk') {
-          // DK5 classification.
-          $prefix .= $field652m;
-
-          // Additional descriptors from the DK5 classification.
-          if ($field652b = fbs_get_marc_field($entity, '652', 'b')) {
-            $prefix .= ' ' . $field652b;
-          }
-          elseif ($field652a = fbs_get_marc_field($entity, '652', 'a')) {
-            $prefix .= ' ' . $field652a;
-            if ($field652h = fbs_get_marc_field($entity, '652', 'h')) {
-              $prefix .= ', ' . $field652h;
-            }
           }
         }
 

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -164,8 +164,8 @@ function fbs_availability_holdings($provider_ids) {
         // be non-fiction and we should use the special prefix for non-fiction
         // materials.
         if ($field652m !== 'sk' && $field652o !== 'sk') {
-          // DK5 classification.
-          $prefix .= $field652m;
+          // DK5 classification. Prefer subfield 'm'. Fallback to 'o'.
+          $prefix .= $field652m ? $field652m : $field652o;
 
           // Additional descriptors from the DK5 classification. Note that we
           // ensure to use data from the correct subfield where we also got the

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -138,38 +138,34 @@ function fbs_availability_holdings($provider_ids) {
         // in subfield 'm' and 'o' of field 652. So we extract them both here
         // for later use.
         $field652 = fbs_get_marc_field($entity, '652');
-        $field652m = $field652o = '';
-        // There can be multiple 652 fields each with their own subfields. It's
-        // important that we use data from the same 652 field that we use the
-        // classification from, so remember the index of the field we end up
-        // using.
-        $field652index = NULL;
-        if (!empty($field652['m'])) {
-          $field652m = reset($field652['m']);
-          $field652index = key($field652['m']);
-        }
+        $field652m = !empty($field652['m']) ? reset($field652['m']) : '';
+        $field652o = !empty($field652['o']) ? reset($field652['o']) : '';
 
-        if (!empty($field652['o'])) {
-          $field652o = reset($field652['o']);
-          // We need to look in both 'm' and 'o' subfield for the 'sk' marker
-          // but we only need to use data from one of the fields. We prefer the
-          // 'm' subfield, but if for some reason there was no data we will use
-          // the 'o' field. So in these cases use remember the index of 'o'.
-          if (empty($field652['m'])) {
-            $field652index = key($field652['o']);
-          }
-        }
         // Non-fiction: Look for the 'sk' marker in both 'm' and 'o' subfield.
         // If it's not present in any of these, we consider the material be to
         // be non-fiction and we should use the special prefix for non-fiction
         // materials.
         if ($field652m !== 'sk' && $field652o !== 'sk') {
-          // DK5 classification. Prefer subfield 'm'. Fallback to 'o'.
-          $prefix .= $field652m ? $field652m : $field652o;
+          // There can be multiple 652 fields with their own subfields and some
+          // of them will have the same subfields. It's therefore important that
+          // we use data from the subfields of the same field that we got the
+          // DK5 classification from. We can achieve this be remembering the
+          // index of 652 field we end up using.
+          // See: TingMarcResult::process()
+          $field652index = 0;
+          // Get the DK5 classification. Prefer subfield 'm'. Fallback to 'o'.
+          if ($field652m) {
+            $prefix .= $field652m;
+            $field652index = key($field652['m']);
+          }
+          elseif ($field652o) {
+            $prefix .= $field652o;
+            $field652index = key($field652['o']);
+          }
 
           // Additional descriptors from the DK5 classification. Note that we
-          // ensure to use data from the correct subfield where we also got the
-          // DK5-classification from.
+          // ensure to use data from the correct subfields of the field we got
+          // the DK5 classification from.
           if (!empty($field652['b'][$field652index])) {
             $prefix .= ' ' . $field652['b'][$field652index];
           }

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -134,45 +134,52 @@ function fbs_availability_holdings($provider_ids) {
         // For non-fiction and music a special prefix is used.
         $prefix = '';
 
+        // Look for the marc field to get DK5 classification from. We require
+        // that either 'm' or 'o' subfield is present and prefer 652. If this is
+        // not the case we'll try the outdated marc field 654 for DK5.
+        $field_dk5 = fbs_get_marc_field($entity, '652');
+        if (empty($field_dk5['m']) && empty($field_dk5['o'])) {
+          $field_dk5 = fbs_get_marc_field($entity, '654');
+        }
+
         // The DK5 classification that we need to consider can both be present
         // in subfield 'm' and 'o' of field 652. So we extract them both here
         // for later use.
-        $field652 = fbs_get_marc_field($entity, '652');
-        $field652m = !empty($field652['m']) ? reset($field652['m']) : '';
-        $field652o = !empty($field652['o']) ? reset($field652['o']) : '';
+        $field_dk5_m = !empty($field_dk5['m']) ? reset($field_dk5['m']) : '';
+        $field_dk5_o = !empty($field_dk5['o']) ? reset($field_dk5['o']) : '';
 
         // Non-fiction: Look for the 'sk' marker in both 'm' and 'o' subfield.
         // If it's not present in any of these, we consider the material be to
         // be non-fiction and we should use the special prefix for non-fiction
         // materials.
-        if ($field652m !== 'sk' && $field652o !== 'sk') {
+        if ($field_dk5_m !== 'sk' && $field_dk5_o !== 'sk') {
           // There can be multiple 652 fields with their own subfields and some
           // of them will have the same subfields. It's therefore important that
           // we use data from the subfields of the same field that we got the
           // DK5 classification from. We can achieve this be remembering the
           // index of 652 field we end up using.
           // See: TingMarcResult::process()
-          $field652index = 0;
+          $field_dk5_index = 0;
           // Get the DK5 classification. Prefer subfield 'm'. Fallback to 'o'.
-          if ($field652m) {
-            $prefix .= $field652m;
-            $field652index = key($field652['m']);
+          if ($field_dk5_m) {
+            $prefix .= $field_dk5_m;
+            $field_dk5_index = key($field_dk5['m']);
           }
-          elseif ($field652o) {
-            $prefix .= $field652o;
-            $field652index = key($field652['o']);
+          elseif ($field_dk5_o) {
+            $prefix .= $field_dk5_o;
+            $field_dk5_index = key($field_dk5['o']);
           }
 
           // Additional descriptors from the DK5 classification. Note that we
           // ensure to use data from the correct subfields of the field we got
           // the DK5 classification from.
-          if (!empty($field652['b'][$field652index])) {
-            $prefix .= ' ' . $field652['b'][$field652index];
+          if (!empty($field_dk5['b'][$field_dk5_index])) {
+            $prefix .= ' ' . $field_dk5['b'][$field_dk5_index];
           }
-          elseif (!empty($field652['a'][$field652index])) {
-            $prefix .= ' ' . $field652['a'][$field652index];
-            if (!empty($field652['h'][$field652index])) {
-              $prefix .= ', ' . $field652['h'][$field652index];
+          elseif (!empty($field_dk5['a'][$field_dk5_index])) {
+            $prefix .= ' ' . $field_dk5['a'][$field_dk5_index];
+            if (!empty($field_dk5['h'][$field_dk5_index])) {
+              $prefix .= ', ' . $field_dk5['h'][$field_dk5_index];
             }
           }
         }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3738 

The cause for this issue was also the cause for the issues reported in:

https://platform.dandigbib.org/issues/4178
https://platform.dandigbib.org/issues/4219

So this PR also fixes the examples from those cases.

#### Description

There was two separate issues causing the reported cases:

1. There can be multiple 652 fields on a material and we need to use data
from the same 652 field that we got the classification number from.

2. The DK5 classification was missing in some cases where there was no
value in 'm', but 'o' had the correct value. Before we assumed it would
always be present in 'm', but apparently this is not the case for some
materials.

#### Screenshot of the result

![3738-shelfmark-issue-wrong-field-1](https://user-images.githubusercontent.com/5011234/54538297-50bc0e80-4994-11e9-8c30-14e54d53444d.PNG)

![3738-shelfmark-issue-wrong-field-2](https://user-images.githubusercontent.com/5011234/54538306-54e82c00-4994-11e9-9737-e576c8b3cdc4.PNG)

![3738-shelfmark-issue-wrong-field-3](https://user-images.githubusercontent.com/5011234/54538313-57e31c80-4994-11e9-8811-cd4f1e74a0af.PNG)

![3738-shelfmark-issue-wrong-field-4](https://user-images.githubusercontent.com/5011234/54538320-5a457680-4994-11e9-898e-d382fb1cff8a.PNG)

![3738-shelfmark-issue-missing-dk5-1](https://user-images.githubusercontent.com/5011234/54538340-603b5780-4994-11e9-9ec8-10c8b77bf5f5.PNG)

![3738-shelfmark-issue-missing-dk5-2](https://user-images.githubusercontent.com/5011234/54538348-629db180-4994-11e9-993a-051537a5af95.PNG)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
