### PR TITLE
4136 by Inlead: Use core function and not variable-contrib function.

### DIFF
--- a/modules/ting_search/ting_search.install
+++ b/modules/ting_search/ting_search.install
@@ -9,5 +9,5 @@
  * Removing unused 'ting_search_result_message_limit' variable.
  */
 function ting_search_update_7001() {
-  variable_delete('ting_search_result_message_limit');
+  variable_del('ting_search_result_message_limit');
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4136

#### Description

This change-set prevents DBCs environment to fail upon deployment of **ddb_cp**-active clients.
Apparently `variable_delete()` is a function from within the `variable`-contrib modul and not Drupal core. Since the `variable` module is only used by the **ddb_cp** module, it was only reproducible on "Webmaster"-libraries.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This only solves the problem and does not prevent any future errors of similar kind in regards to deployment.