### PR TITLE
1404: Dont delete field data on p2b API error

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -414,13 +414,19 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
     case 'ding_p2b':
       if (!empty($items)) {
         $settings = reset($items);
+        $synchronized_items = [];
         // Ensure that both 'synchronize' and 'do_sync' is set and TRUE, before
         // making any requests to p2b API. This is to ensure we don't make lots
         // of unneeded requests when nodes are saved programmatically or updated
         // in bulk via the UI.
         // See ding_place2book_field_widget_form() for more info.
         if ($settings['synchronize'] && !empty($settings['do_sync'])) {
-          $items = _ding_place2book_sync_p2b_entities($entity, $settings);
+          $synchronized_items = _ding_place2book_sync_p2b_entities($entity, $settings);
+        }
+
+        // Only update field data if synchronizationn was successful.
+        if (!empty($synchronized_items)) {
+          $items = $synchronized_items;
         }
         else {
           $items = array(
@@ -551,6 +557,14 @@ function _ding_place2book_sync_p2b_entities($entity, array $settings) {
       else {
         $event = $p2b->updateEvent($event_maker_id, $event_id, $options);
       }
+
+      $items = array(
+        array(
+          'event_id' => $event->id,
+          'event_maker_id' => $event_maker_id,
+          'synchronize' => 1,
+        ),
+      );
     }
     catch (Exception $ex) {
       watchdog_exception('ding_place2book', $ex);
@@ -598,15 +612,9 @@ function _ding_place2book_sync_p2b_entities($entity, array $settings) {
       catch (Exception $ex) {
         watchdog_exception('ding_place2book', $ex);
         drupal_set_message($ex->getMessage(), 'error');
+        return $items;
       }
     }
-    $items = array(
-      array(
-        'event_id' => $event->id,
-        'event_maker_id' => $event_maker_id,
-        'synchronize' => 1,
-      ),
-    );
 
     if ($is_new) {
       drupal_set_message(t('Event was successfully created.'));


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1404

#### Description

I discovered this while testing the new integration module on our production database:

If something goes wrong communicating with p2b API when updating existing event that is sync'ed with p2b, the code will override the field data with empty array, destroying the the link between p2b and CMS.

This PR introduces some better handling of these situations.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
