### PR TITLE
4170 by Inlead: Show search suggestions on 0-hits.

### DIFF
--- a/modules/ting_search/plugins/content_types/search_result.inc
+++ b/modules/ting_search/plugins/content_types/search_result.inc
@@ -89,7 +89,7 @@ function ting_search_search_result_content_type_render($subtype, $conf, $panel_a
   else {
     if (empty($conf['override_empty'])) {
       $block->title = t('Your search yielded no results');
-      $block->content = search_help('search#noresults', drupal_help_arg());
+      $block->content = $prefix . search_help('search#noresults', drupal_help_arg()) . $suffix;
     }
     else {
       $block->title = $conf['empty_title'];


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4170#note-13

#### Description

Adds the prefix and suffix to "0-hits" block on search results pane.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/800338/54832555-0d7bdb80-4cc5-11e9-88ce-c379d676d0fc.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.