### PR TITLE
3667: Fix typo resulting in wrong offset for admin bar with shortcuts

### DIFF
--- a/themes/ddbasic/sass/components/header.scss
+++ b/themes/ddbasic/sass/components/header.scss
@@ -698,7 +698,7 @@
         top: $header-height + $admin-menu-height;
       }
       // Admin menu with shortcuts or toolbar
-      .admin-menu-with-shortcut &,
+      .admin-menu-with-shortcuts &,
       .toolbar & {
         top: $header-height + $toolbar-height;
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3667

#### Description

Discovered a typo in this otherwise very fine work :)

#### Screenshot of the result - before

![3667-typo-before](https://user-images.githubusercontent.com/5011234/54919969-5b315780-4f02-11e9-8765-7f99572ef052.PNG)

#### Screenshot of the result - after

![3667-typo-after](https://user-images.githubusercontent.com/5011234/54919979-61bfcf00-4f02-11e9-84d1-4496853c2590.PNG)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
