### PR TITLE
4055 by Inlead: DAMS should be enabled by default.

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -726,3 +726,10 @@ function ding2_update_7063() {
     'ding_nodelist',
   ));
 }
+
+/**
+ * Enable Ding DAMS module.
+ */
+function ding2_update_7064() {
+  module_enable(array('ding_dams'));
+}


### PR DESCRIPTION
#### Link to issue

http://platform.dandigbib.org/issues/4055

#### Description

Adds hook_update() into profile which will enable Ding DAMS module.
**NOTE:** This PR must be merged **only after** https://github.com/ding2/ding2/pull/1332 is merged.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.