### PR TITLE
4196: Ensure fixed header elements doesn't overlap in-page anchors

### DIFF
--- a/themes/ddbasic/sass/base/standard.scss
+++ b/themes/ddbasic/sass/base/standard.scss
@@ -53,7 +53,6 @@ body {
     }
   }
 
-
   $_selectors-padding-top-values--body: (
     '.search-form-extended': $header-height + $search-form-extended-height,
     '.search-form-extended.extended-search-is-not-open': $header-height
@@ -80,6 +79,67 @@ body {
       &#{$_selector}.has-second-level-menu.has-multiline-main-menu,
       &#{$_selector}.secondary-menu-below-main {
         padding-top: $_value + $second-level-menu-height + $search-form-extended-height;
+      }
+    }
+  }
+}
+
+// Ensure that our fixed header elements doesn't overlap in-page anchors. We use
+// the ':target' selector, which represents a unique element (the target
+// element) with an id matching the URL's fragment.
+// See: https://stackoverflow.com/a/28824157
+:target::before {
+  display: block;
+  content: " ";
+
+  // Note that we use the spacing between paragraphs in the base offset, to give
+  // some air above the anchor.
+  $_base-offset: $distance-paragraph + $header-height;
+
+  margin-top: -($_base-offset);
+  height: $_base-offset;
+
+  // Use the same selector mapping as body padding above, but here we also need
+  // every possible combination with admin menu. Admin menu module adds a top
+  // margin to the body itself, but here we can use that, since we need to
+  // include the admin menu height in the margin-top/height offset on :target.
+  $_selectors-offset-values--target: (
+    '.search-form-extended': $search-form-extended-height,
+    '.search-form-extended.extended-search-is-not-open': 0,
+    '.admin-menu.search-form-extended': $search-form-extended-height + $admin-menu-height,
+    '.admin-menu.search-form-extended.extended-search-is-not-open': $admin-menu-height,
+    '.admin-menu-with-shortcuts.search-form-extended': $search-form-extended-height + $toolbar-height,
+    '.admin-menu-with-shortcuts.search-form-extended.extended-search-is-not-open': $toolbar-height
+  );
+
+  @each $_selector, $_value in $_selectors-offset-values--target {
+    @include media($tablet-min-width) {
+      $_offset: $_value + $_base-offset;
+
+      #{$_selector} & {
+        margin-top: -$_offset;
+        height: $_offset;
+      }
+
+      // If there are too many links in secondary or main menu, we need to add
+      // even more padding.
+      #{$_selector}.secondary-menu-below-main &,
+      #{$_selector}.has-multiline-main-menu & {
+        margin-top: -($_offset + $search-form-extended-height);
+        height: $_offset + $search-form-extended-height;
+      }
+
+      // If the main menu has a second level submenu visible.
+      #{$_selector}.has-second-level-menu & {
+        margin-top: -($_offset + $second-level-menu-height);
+        height: $_offset + $second-level-menu-height;
+      }
+
+      // Combination of the two cases above.
+      #{$_selector}.has-second-level-menu.secondary-menu-below-main &,
+      #{$_selector}.has-second-level-menu.has-multiline-main-menu & {
+        margin-top: -($_offset + $second-level-menu-height + $search-form-extended-height);
+        height: $_offset + $second-level-menu-height + $search-form-extended-height;
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4196

#### Description

Ensure that our fixed header elements doesn't overlap in-page anchors.

#### Screenshot of the result - before
![4196-before-fix](https://user-images.githubusercontent.com/5011234/54938719-3ef3e180-4f27-11e9-94f9-feea072fd989.png)

#### Screenshot of the result - after
![4196-aftere-fix](https://user-images.githubusercontent.com/5011234/54938735-44e9c280-4f27-11e9-8791-76ffda27f8b8.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
