### PR TITLE
4150: Fixed ting-object accordion wrapper

### DIFF
--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -517,6 +517,7 @@ a.opening-hours-toggle {
     }
   }
   .field-group-format-wrapper {
+    @include clearfix;
     width: 100% !important; // field_group module uses toggle to show and hide content. We use !important here to avoid the width to animate
     margin-top: 40px;
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4150

#### Description

In some cases the field-group-format-wrapper has a zero height in the 'group-on-this-site' accordion section of a ting-object. This causes the accordion to fail. A simple clearfix on the element solves the issue.

#### Screenshot of the result

![Screenshot 2019-03-26 at 14 19 31](https://user-images.githubusercontent.com/30495061/55000166-360c1a00-4fd2-11e9-9ac5-d4d2d320fbb7.png)
