### PR TITLE
4199 by Inlead: Nodelist styling changes.

### DIFF
--- a/modules/ding_ipe_filter/css/ding_ipe_filter.modal.css
+++ b/modules/ding_ipe_filter/css/ding_ipe_filter.modal.css
@@ -1,0 +1,26 @@
+#modalContent .modal-content input[type=text] {
+  border: 1px solid #c6c6c6;
+  background-color: #fff;
+}
+#modalContent .select-wrapper {
+  width: 300px;
+}
+#modalContent input[type=submit] {
+  margin: 10px 0;
+}
+#modalContent table td {
+  vertical-align: top;
+}
+#modalContent table td.choice-flag {
+  vertical-align: middle !important;
+}
+#modalContent table td input[type=submit] {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+#modalContent table td .select-wrapper {
+  border: 1px solid #c6c6c6;
+}
+#modalContent table td .select-wrapper select {
+  padding: 0 10px;
+}

--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -248,3 +248,12 @@ function ding_ipe_filter_preprocess_panels_ipe_pane_wrapper(&$variables) {
   unset($variables['links']['style']);
   unset($variables['links']['css']);
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function ding_ipe_filter_form_alter(&$form, &$form_state, $form_id) {
+  if (strpos($form['#action'], '/panels/ajax/ipe/') !== FALSE && $form_state['modal'] == TRUE) {
+    $form['#attached']['css'][] = drupal_get_path('module', 'ding_ipe_filter') . '/css/ding_ipe_filter.modal.css';
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4199

#### Description

Configuration forms rendered in Ding IPE popup takes default site's theme, which is not adapted yet.
In this commit are added styles which are loaded when popup is opened, so those styles are not breaking anything else.

#### Screenshot of the result

![ads](https://user-images.githubusercontent.com/800338/55222750-50820580-5215-11e9-910b-6734c479f616.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.