### PR TITLE
4243: Fixed overflow on object view

### DIFF
--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -503,6 +503,7 @@ a.opening-hours-toggle {
   width: 100%;
   padding: 28px 0 26px;
   border-top: 1px solid $charcoal-opacity-light;
+  overflow: hidden;
   > h2 {
     @include font('base');
     margin-bottom: 0;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4243

#### Description

Wrapper on object view page overlap.

#### Screenshot of the result

Before:
![Picture1](https://user-images.githubusercontent.com/111397/55224739-71e0f280-5211-11e9-8cb8-73a49377509a.png)

After:
![Screenshot 2019-03-29 at 10 55 06](https://user-images.githubusercontent.com/111397/55224757-77d6d380-5211-11e9-8fa1-45936a9166e0.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments