### PR TITLE
4267: Fix offset for user menu in header

### DIFF
--- a/themes/ddbasic/sass/components/menu.scss
+++ b/themes/ddbasic/sass/components/menu.scss
@@ -569,11 +569,15 @@ ul.topbar-menu {
     border-radius: $round-corner;
     background-color: $white;
     box-shadow: $box-shadow;
-    top: 7px;
+    top: 71px;
     margin-top: 8px;
     padding: 10px 20px;
     .toolbar & {
       top: 7px + $toolbar-height;
+    }
+    .admin-menu-with-shortcuts &,
+    .admin-menu & {
+      top: 7px;
     }
     &::before {
       @include transform(rotate(-45deg));


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4267

#### Description

Fixes wrong offset for user menu in header. Screenshot of the problem in the issue above.

Also fixes wrong offset of the menu when admin menu with or without shortcuts are used. In these cases we don't need the extra height, since admin_menu itself adds an offset.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
