### PR TITLE
4270: Add new webtrekk tracking parameters

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -218,6 +218,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       'p_mat_source' => $entity->getAc_source(),
       'p_mat_ficnonfic' => $fic_nonfic,
       'p_mat_category' => $entity->getGenre(),
+      'p_mat_audience' => $entity->getAudience(),
     ];
     ding_webtrekk_add_page_parameters($params);
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -194,21 +194,12 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
   // The page parametes for the ting object view should only be added on the
   // full page view for the material.
   if ($view_mode == 'full' && current_path() == $entity_path) {
-    // Get classification now as we also need it to determine category.
-    $classification = $entity->getClassification();
-
-    // The only reliable way to determine whether the material is fiction or
-    // non-fiction, is by using the 'sk' marker from the DK5 classification.
-    $fic_nonfic = FALSE;
-    // If classification is 'sk' OpenSearchTingObject returns empty string.
-    // See: OpenSearchTingObject::getClassification().
-    if ($classification === '') {
-      $fic_nonfic = 'fiktion';
-    }
-    // Else, if not FALSE, the material has a DK5 classification and is
-    // nonfiction.
-    elseif ($classification !== FALSE) {
-      $fic_nonfic = 'nonfiktion';
+    // TingObjectInterface doesn't allow us determine fiction/nonfiction in a
+    // clean way, but if the search provider is opensearch we can use a provider
+    // specific mehtod to get value.
+    $p_mat_ficnonfic = FALSE;
+    if (module_exists('opensearch')) {
+      $p_mat_ficnonfic = $entity->getTingObject()->isFiction() ? 'fiktion' : 'nonfiktion';
     }
 
     // Process array values so they are ready to be inserted in parameter.
@@ -228,7 +219,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
 
     $params = [
       'p_mat_type' => $entity->getType(),
-      'p_mat_indexno' => $classification,
+      'p_mat_indexno' =>  $entity->getClassification(),
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
       'p_mat_ficnonfic' => $fic_nonfic,

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -217,6 +217,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
       'p_mat_ficnonfic' => $fic_nonfic,
+      'p_mat_category' => $entity->getGenre(),
     ];
     ding_webtrekk_add_page_parameters($params);
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -211,14 +211,29 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       $fic_nonfic = 'nonfiktion';
     }
 
+    // Process array values so they are ready to be inserted in parameter.
+    $p_mat_audience = FALSE;
+    if (!empty($entity->getTingObject()->getAudience())) {
+      $p_mat_audience = $entity->getTingObject()->getAudience();
+      // Here we can only have one value so we need to pick the first element
+      // out of the array.
+      $p_mat_audience = reset($p_mat_audience);
+    }
+    $p_mat_category = FALSE;
+    if (!empty($entity->getTingObject()->getGenre())) {
+      // Here we can have multiple values so we implode the values to a comma
+      // separated list.
+      $p_mat_category = implode(', ', $entity->getTingObject()->getGenre());
+    }
+
     $params = [
       'p_mat_type' => $entity->getType(),
       'p_mat_indexno' => $classification,
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
       'p_mat_ficnonfic' => $fic_nonfic,
-      'p_mat_category' => $entity->getGenre(),
-      'p_mat_audience' => $entity->getAudience(),
+      'p_mat_category' => $p_mat_category,
+      'p_mat_audience' => $p_mat_audience,
     ];
     ding_webtrekk_add_page_parameters($params);
   }

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -219,10 +219,10 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
 
     $params = [
       'p_mat_type' => $entity->getType(),
-      'p_mat_indexno' =>  $entity->getClassification(),
+      'p_mat_indexno' => $entity->getClassification(),
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
-      'p_mat_ficnonfic' => $fic_nonfic,
+      'p_mat_ficnonfic' => $p_mat_ficnonfic,
       'p_mat_category' => $p_mat_category,
       'p_mat_audience' => $p_mat_audience,
     ];

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -197,19 +197,18 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
     // Get classification now as we also need it to determine category.
     $classification = $entity->getClassification();
 
-    // Here category refers to whether the material is fiction/non-fiction. The
-    // only reliable way to determine this, is by using the 'sk' marker from
-    // the DK5 classification.
-    $category = FALSE;
+    // The only reliable way to determine whether the material is fiction or
+    // non-fiction, is by using the 'sk' marker from the DK5 classification.
+    $fic_nonfic = FALSE;
     // If classification is 'sk' OpenSearchTingObject returns empty string.
     // See: OpenSearchTingObject::getClassification().
     if ($classification === '') {
-      $category = 'fiktion';
+      $fic_nonfic = 'fiktion';
     }
     // Else, if not FALSE, the material has a DK5 classification and is
     // nonfiction.
     elseif ($classification !== FALSE) {
-      $category = 'nonfiktion';
+      $fic_nonfic = 'nonfiktion';
     }
 
     $params = [
@@ -217,7 +216,7 @@ function ding_webtrekk_ding_entity_view($entity, $view_mode) {
       'p_mat_indexno' => $classification,
       'p_mat_lang' => $entity->getLanguage(),
       'p_mat_source' => $entity->getAc_source(),
-      'p_mat_category' => $category,
+      'p_mat_ficnonfic' => $fic_nonfic,
     ];
     ding_webtrekk_add_page_parameters($params);
   }

--- a/modules/opensearch/src/OpenSearchTingObject.php
+++ b/modules/opensearch/src/OpenSearchTingObject.php
@@ -19,19 +19,21 @@ use TingRelation;
  */
 class OpenSearchTingObject implements TingObjectInterface {
   /**
-   * @var string[] list of property-names that can be found directly on $this
-   *   and should not be delegated to $this->clientObject.
+   * @var string[]
+   *   List of property-names that can be found directly on $this and should not
+   *   be delegated to $this->clientObject.
    */
   protected $localProperties = ['openSearchObject'];
 
   /**
-   * @var TingClientObject an object from the Ting Client that represents a
-   *   material search object.
+   * @var TingClientObject
+   *   An object from the Ting Client that represents a material search object.
    */
   protected $openSearchObject;
 
   /**
-   * @var string Id of the owner of the object, eg. the Agency.
+   * @var string
+   *   Id of the owner of the object, eg. the Agency.
    */
   protected $ownerId;
 
@@ -41,7 +43,8 @@ class OpenSearchTingObject implements TingObjectInterface {
    * The property needs to be local as the __get() magic functions won't be
    * able to properly handle arrays as they need to be passed by reference.
    *
-   * @var TingRelation[] list of materials related to this material.
+   * @var TingRelation[]
+   *   List of materials related to this material.
    */
   protected $relations = [];
 
@@ -511,20 +514,16 @@ class OpenSearchTingObject implements TingObjectInterface {
    * Returns whether the material is fiction/nonfiction.
    */
   public function isFiction() {
-    /**
-     * @var array $fiction_classifications
-     *
-     * An array with DK5 values/prefixes for fiction classifications.
-     *
-     * sk : Danish fiction (translated and danish authors).
-     * 82*: French fiction.
-     * 83*: English fiction.
-     * 84*: German fiction.
-     * 85*: Norwegian fiction.
-     * 86*: Danish fiction (danish authors).
-     * 87*: Swedish fiction.
-     * 88*: Misc. language fiction.
-     */
+    // An array with DK5 values/prefixes for fiction classifications.
+    //
+    // sk : Danish fiction (translated and danish authors).
+    // 82*: French fiction.
+    // 83*: English fiction.
+    // 84*: German fiction.
+    // 85*: Norwegian fiction.
+    // 86*: Danish fiction (danish authors).
+    // 87*: Swedish fiction.
+    // 88*: Misc. language fiction.
     $fiction_classifications = [
       'sk',
       '82',
@@ -556,7 +555,7 @@ class OpenSearchTingObject implements TingObjectInterface {
    *   Key for the first level of value to fetch.
    * @param string $l2_key
    *   Key for the second level of value to fetch. If not specified it is
-   *   assumed that the value can be fetched via $array[$l1_key]['']
+   *   assumed that the value can be fetched via $array[$l1_key][''].
    *
    * @return string|array|false
    *   The value from the open search object or FALSE if not found
@@ -585,14 +584,13 @@ class OpenSearchTingObject implements TingObjectInterface {
    *
    * @param array $records
    *   Associative list of records.
-   *
    * @param array $blacklist
    *   List of keys that should be removed from the list of records.
    *
    * @return array
    *   The filtered list of records.
    */
-  protected function filterRecordsExclude($records, $blacklist = []) {
+  protected function filterRecordsExclude(array $records, array $blacklist = []) {
     return array_filter($records, function ($key) use ($blacklist) {
       return !in_array($key, $blacklist);
     }, ARRAY_FILTER_USE_KEY);
@@ -609,7 +607,7 @@ class OpenSearchTingObject implements TingObjectInterface {
    * @return array
    *   List of all unique values of the nested arrays.
    */
-  protected function recordsFlatten($records) {
+  protected function recordsFlatten(array $records) {
     if (!is_array($records)) {
       return $records;
     }

--- a/modules/opensearch/src/OpenSearchTingObject.php
+++ b/modules/opensearch/src/OpenSearchTingObject.php
@@ -18,7 +18,6 @@ use TingRelation;
  * @package OpenSearch
  */
 class OpenSearchTingObject implements TingObjectInterface {
-
   /**
    * @var string[] list of property-names that can be found directly on $this
    *   and should not be delegated to $this->clientObject.
@@ -506,6 +505,48 @@ class OpenSearchTingObject implements TingObjectInterface {
    */
   public function getFormatsAvailable() {
     return $this->openSearchObject->formatsAvailable;
+  }
+
+  /**
+   * Returns whether the material is fiction/nonfiction.
+   */
+  public function isFiction() {
+    /**
+     * @var array $fiction_classifications
+     *
+     * An array with DK5 values/prefixes for fiction classifications.
+     *
+     * sk : Danish fiction (translated and danish authors).
+     * 82*: French fiction.
+     * 83*: English fiction.
+     * 84*: German fiction.
+     * 85*: Norwegian fiction.
+     * 86*: Danish fiction (danish authors).
+     * 87*: Swedish fiction.
+     * 88*: Misc. language fiction.
+     */
+    $fiction_classifications = [
+      'sk',
+      '82',
+      '83',
+      '84',
+      '85',
+      '86',
+      '87',
+      '88',
+    ];
+
+    // Note that we get classification directly from the reply as
+    // getClassification() removes the 'sk' marker which we need.
+    $classification = $this->firstEntry(
+      $this->getRecordEntry('dc:subject', 'dkdcplus:DK5')
+    );
+    foreach ($fiction_classifications as $fiction_classification) {
+      if (strpos($classification, $fiction_classification) === 0) {
+        return TRUE;
+      }
+    }
+    return FALSE;
   }
 
   /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4270

#### Description

Material audience is now tracked in the parameter `p_mat_audience` with the value from [dc:subject with scheme dkdcplus:genre](http://metadata.dk/DKABM_2011#dcterms:audience)

Material fiction/nonfiction is now moved to `p_mat_ficnonfic` from `p_mat_category`. Also tried to find a more clean a correct way to get the value.

Material genre is now tracked in the parameter `p_mat_category` with the value from [dcterms:audience](http://metadata.dk/DKABM_2011#dc:subject_med_scheme_dkdcplus:genre)

#### Screenshot of the result

![4270-nonfiction](https://user-images.githubusercontent.com/5011234/56047918-b6f34180-5d46-11e9-9068-839dd9d4ddff.PNG)

![4270-fiction](https://user-images.githubusercontent.com/5011234/56047926-ba86c880-5d46-11e9-8a33-6094e7e83063.PNG)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
