### PR TITLE
4282 by Inlead: Remove stall relationships.

### DIFF
--- a/modules/ding_news/ding_news.views_default.inc
+++ b/modules/ding_news/ding_news.views_default.inc
@@ -684,16 +684,6 @@ function ding_news_views_default_views() {
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['exposed_block'] = TRUE;
   $handler->display->display_options['defaults']['relationships'] = FALSE;
-  /* Relationship: OG membership: OG membership from Node */
-  $handler->display->display_options['relationships']['og_membership_rel']['id'] = 'og_membership_rel';
-  $handler->display->display_options['relationships']['og_membership_rel']['table'] = 'node';
-  $handler->display->display_options['relationships']['og_membership_rel']['field'] = 'og_membership_rel';
-  /* Relationship: OG membership: Group Node from OG membership */
-  $handler->display->display_options['relationships']['og_membership_related_node_group']['id'] = 'og_membership_related_node_group';
-  $handler->display->display_options['relationships']['og_membership_related_node_group']['table'] = 'og_membership';
-  $handler->display->display_options['relationships']['og_membership_related_node_group']['field'] = 'og_membership_related_node_group';
-  $handler->display->display_options['relationships']['og_membership_related_node_group']['relationship'] = 'og_membership_rel';
-  $handler->display->display_options['relationships']['og_membership_related_node_group']['label'] = 'OG node group';
   /* Relationship: Content: Category (field_ding_news_category) */
   $handler->display->display_options['relationships']['field_ding_news_category_tid']['id'] = 'field_ding_news_category_tid';
   $handler->display->display_options['relationships']['field_ding_news_category_tid']['table'] = 'field_data_field_ding_news_category';


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4282

#### Description

This is an addition for https://github.com/ding2/ding2/pull/1276/files#diff-8ae6c63897cf337c6827a7082586be05L913

The issue outlines that news nodes that lack group/library are missing in the view for anonymous users. Since only the exposed filters that relied on relationships were removed in the PR above, abandoned relationships interfered with the view output.

#### Screenshot of the result

The **4 super sjove billedbøger** news lacks both library and group, and shows fine both for admin and anon users. It was missing for anons previously.
![image](https://user-images.githubusercontent.com/574498/56737699-a776ee00-6773-11e9-97b6-40763f43c09f.png)

#### Checklist

- [x] My code complies with [coding guidelines](../docs/code_guidelines.md).
- [x] My code passes static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

None.
