### PR TITLE
4261: Fix renew all loans button

### DIFF
--- a/modules/ding_loan/js/ding_loan.js
+++ b/modules/ding_loan/js/ding_loan.js
@@ -16,7 +16,7 @@
     $('.action-buttons input[type=submit]').prop('disabled', 'disabled');
 
     // Handle select all checkboxes.
-    var sub_select_all = $('.select-all input[type=checkbox]').click(function() {
+    var sub_select_all = $('.select-all input[type=checkbox]').change(function() {
       var checkboxes = $('input[type=checkbox]', $(this).closest('.select-all').nextUntil('.select-all'));
       if ($(this).prop('checked')) {
         // Only checkboxes that are enabled.
@@ -39,7 +39,7 @@
     var select_all = $('.form-item-select-all input[type=checkbox]').change(function () {
       sub_select_all
         .prop('checked', $(this).prop('checked'))
-        .click()
+        .change()
         // Make sure the select all is checked or unchecked even after events.
         .prop('checked', $(this).prop('checked'));
     });


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4261

#### Description

Something has changed so that using a click handler for these checkboxes
breaks the functionality of the select all renew checkbox and therefore
also the global select all renew button (which just reuses the select
all checkbox).

The problem was the triggering of click handler on the local select all
checkboxes, from the change event handler on the global select all. This
would simuluate a real click changing state of the checkbox and mess up
the logic in the click handler. For example, if we have just set the box status 
to checked with the prop method, it would immediately change it back in 
browser click handler, before invoking our change handler.

I don't know why this hasn't been a problem before, but I suspect the jquery
update have caused our logic to behave a bit different.

The easiest fix seem to be to use a change handler instead on the local
select all checkboxes. This will not break any functionality since a
real click from a user will also fire the change handler. And now we can
trigger the change handler instead, which doesn't change the state of
the checkbox. It also seems more consistent since a change handler is
alos used on the other checkboxes.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
