### PR TITLE
4286: Fix event price display

### DIFF
--- a/modules/ding_event/ding_event.admin.inc
+++ b/modules/ding_event/ding_event.admin.inc
@@ -14,13 +14,13 @@
  * @return mixed
  */
 function ding_event_admin_setting_form(array $form, array &$form_state) {
-  $currency = variable_get('ding_event_currency_type', 'Kr');
+  $currency = variable_get('ding_event_currency_type', 'kr.');
   $form['#submit'][] = 'ding_event_admin_submit';
 
   $form['ding_event']['ding_event_currency_type'] = array(
     '#type' => 'radios',
     '#title' => t('Currency'),
-    '#options' => drupal_map_assoc(array('Kr', '€')),
+    '#options' => drupal_map_assoc(array('kr.', '€')),
     '#default_value' => $currency,
     '#description' => t("Select which currency to use on events"),
   );

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -332,6 +332,9 @@ function ding_event_date_popup_process_alter(&$element, &$form_state, $context) 
   }
 }
 
+/**
+ * Implements hook_metatag_metatags_view_alter().
+ */
 function ding_event_metatag_metatags_view_alter(&$output, $instance, $options) {
   if ($instance == 'panels:ding_event_node_view') {
     $node = menu_get_object();

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -389,7 +389,12 @@ function ding_event_preprocess_node(&$variables) {
   $price = $node_wrapper->field_ding_event_price->value();
 
   if (!empty($price)) {
-    $variables['event_price'] = $price . ' ' . variable_get('ding_event_currency_type', 'Kr');
+    $variables['event_price'] = $price;
+    // The price field is a text field and we should only show currency if the
+    // price is numeric.
+    if (is_numeric($price)) {
+      $variables['event_price'] .= ' ' . variable_get('ding_event_currency_type', 'Kr');
+    }
   }
   // If the price is empty use "Free" text instead.
   else {

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -375,3 +375,24 @@ function ding_event_metatag_metatags_view_alter(&$output, $instance, $options) {
     $output['description']['#attached']['drupal_add_html_head'][0][0]['#value'] = implode(', ', array_filter($metatag));
   }
 }
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function ding_event_preprocess_node(&$variables) {
+  if ($variables['type'] != 'ding_event') {
+    return;
+  }
+
+  // Handle display of event price.
+  $node_wrapper = entity_metadata_wrapper('node', $variables['node']);
+  $price = $node_wrapper->field_ding_event_price->value();
+
+  if (!empty($price)) {
+    $variables['event_price'] = $price . ' ' . variable_get('ding_event_currency_type', 'Kr');
+  }
+  // If the price is empty use "Free" text instead.
+  else {
+    $variables['event_price'] = t('Free');
+  }
+}

--- a/modules/ding_event/ding_event.module
+++ b/modules/ding_event/ding_event.module
@@ -393,7 +393,7 @@ function ding_event_preprocess_node(&$variables) {
     // The price field is a text field and we should only show currency if the
     // price is numeric.
     if (is_numeric($price)) {
-      $variables['event_price'] .= ' ' . variable_get('ding_event_currency_type', 'Kr');
+      $variables['event_price'] .= ' ' . variable_get('ding_event_currency_type', 'kr.');
     }
   }
   // If the price is empty use "Free" text instead.

--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -280,22 +280,18 @@ function ddbasic_preprocess__node__ding_event(&$variables) {
           '#label' => t('Share this event'),
         );
 
-        // Make book/participate in event button.
-        $price = ding_base_get_value('node', $variables['node'], 'field_ding_event_price');
-        $participate = t('Participate in the event');
-        $book = t('Book a ticket');
-
-        if (empty($price)) {
-          $text = $participate;
-        }
-        else {
-          $text = $book;
+        $book_button_text = t('Participate in the event');
+        // If the event has a numeric price show an alternative text. If the
+        // price is not numeric we can't make any assumption about whether the
+        // event is free or not.
+        if (is_numeric($variables['event_price'])) {
+          $book_button_text = t('Book a ticket');
         }
 
         $link_url = ding_base_get_value('node', $variables['node'], 'field_ding_event_ticket_link', 'url');
 
         if (!empty($link_url)) {
-          $variables['book_button'] = l($text, $link_url, array(
+          $variables['book_button'] = l($book_button_text, $link_url, array(
             'attributes' => array(
               'class' => array('ticket', 'button'),
               'target' => '_blank',

--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -168,16 +168,7 @@ function ddbasic_preprocess__node__ding_news(&$variables) {
  * Ding event.
  */
 function ddbasic_preprocess__node__ding_event(&$variables) {
-
   $date = field_get_items('node', $variables['node'], 'field_ding_event_date');
-
-  $price = field_get_items('node', $variables['node'], 'field_ding_event_price');
-  if (!empty($price)) {
-    $variables['event_price'] = $price[0]['value'] . ' ' . variable_get('ding_event_currency_type', 'Kr');
-  }
-  else {
-    $variables['event_price'] = t('Free');
-  }
 
   $location = field_get_items('node', $variables['node'], 'field_ding_event_location');
   $variables['alt_location_is_set'] = !empty($location[0]['name_line']) || !empty($location[0]['thoroughfare']);

--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -203,15 +203,14 @@ function ddbasic_preprocess__node__ding_event(&$variables) {
         // (e.g. UTC time 2018-01-09 23:00). To print out the date/time properly
         // We first need to create the dateObject with the UTC database time, and
         // afterwards we can convert the dateObject db-time to localtime.
-
-        // Create a dateObject from startdate, set base timezone to UTC
+        // Create a dateObject from startdate, set base timezone to UTC.
         $date_start = new DateObject($date[0]['value'], new DateTimeZone($date[0]['timezone_db']));
-        // Set timezone to local timezone
+        // Set timezone to local timezone.
         $date_start->setTimezone(new DateTimeZone($date[0]['timezone']));
 
-        // Create a dateObject from enddate, set base timezone to UTC
+        // Create a dateObject from enddate, set base timezone to UTC.
         $date_end = new DateObject($date[0]['value2'], new DateTimeZone($date[0]['timezone_db']));
-        // Set timezone to local timezone
+        // Set timezone to local timezone.
         $date_end->setTimezone(new DateTimeZone($date[0]['timezone']));
 
         $variables['event_date'] = date_format_date($date_start, 'ding_date_only_version2');
@@ -364,10 +363,10 @@ function ddbasic_preprocess__node__ding_campaign(&$variables) {
         break;
 
       case 'image':
-        $variables['image'] = theme('image_style',array(
+        $variables['image'] = theme('image_style', array(
             'style_name' => "ding_full_width",
             'path' => $image_uri,
-            'attributes' => array('class' => 'ding-campaign-image')
+            'attributes' => array('class' => 'ding-campaign-image'),
           )
         );
         break;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4286

#### Description

Fix the display of event price to work with the price field after it has been converted to a text field.

- If price is empty show "Free" text
- Only show currency if price is numeric.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
