### PR TITLE
4207: Update EU Cookie Compliance module to 1.28

### DIFF
--- a/ding2.info
+++ b/ding2.info
@@ -21,6 +21,7 @@ dependencies[] = field_ui
 ; Helper modules.
 dependencies[] = module_filter
 dependencies[] = menu_position
+dependencies[] = i18n_variable
 dependencies[] = eu_cookie_compliance
 dependencies[] = view_unpublished
 dependencies[] = redirect

--- a/ding2.install
+++ b/ding2.install
@@ -199,6 +199,12 @@ function ding2_update_dependencies() {
     // provider is present.
     'ting' => 7014,
   );
+  // Update hook which sets custom configuration for EU Cookie Compliance.
+  $dependencies['ding2'][7064] = array(
+    // Update hook that updates the configuration format for EU Cookie
+    // Compliance module.
+    'eu_cookie_compliance' => 7010,
+  );
 
   return $dependencies;
 }
@@ -725,4 +731,14 @@ function ding2_update_7063() {
     'ding_sections',
     'ding_nodelist',
   ));
+}
+
+/**
+ * Update EU Cookie Compliance settings.
+ */
+function ding2_update_7064() {
+  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da');
+  $ecc_settings['method'] = 'default';
+  $ecc_settings['show_disagree_button'] = 0;
+  i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
 }

--- a/ding2.make
+++ b/ding2.make
@@ -96,7 +96,7 @@ projects[entityreference_filter][subdir] = "contrib"
 projects[entityreference_filter][version] = "1.7"
 
 projects[eu_cookie_compliance][subdir] = "contrib"
-projects[eu_cookie_compliance][version] = "1.14"
+projects[eu_cookie_compliance][version] = "1.28"
 
 projects[environment_indicator][subdir] = "contrib"
 projects[environment_indicator][version] = "2.8"

--- a/ding2.profile
+++ b/ding2.profile
@@ -727,30 +727,29 @@ function ding2_add_administrators_role($uid) {
  * Add page with std. cookie information.
  */
 function ding2_set_cookie_page() {
-
-  $eu_cookie_compliance_da['popup_enabled'] = TRUE;
-  $eu_cookie_compliance_da['popup_clicking_confirmation'] = FALSE;
-  $eu_cookie_compliance_da['popup_info']['value'] = '<p>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse.</p><p>Læs mere her: <a href="' . url('cookies') . '">Hvad er cookies?</a></p>';
-  $eu_cookie_compliance_da['popup_info']['format'] = 'ding_wysiwyg';
-  $eu_cookie_compliance_da['popup_agree_button_message'] = 'Jeg accepterer brugen af cookies';
-  $eu_cookie_compliance_da['popup_disagree_button_message'] = 'Læs mere';
-  $eu_cookie_compliance_da['popup_find_more_button_message'] = 'Mere info';
-  $eu_cookie_compliance_da['popup_hide_button_message'] = 'Luk';
-  $eu_cookie_compliance_da['popup_agreed'][value] = '<p>Tak fordi du accepterer cookies</p><p>Du kan nu lukke denne besked, eller læse mere om cookies.</p>';
-  $eu_cookie_compliance_da['popup_agreed']['format'] = 'ding_wysiwyg';
-  $eu_cookie_compliance_da['popup_link'] = 'cookies';
-  $eu_cookie_compliance_da['popup_link_new_window'] = FALSE;
-  $eu_cookie_compliance_da['popup_bg_hex'] = '0D0D26';
-  $eu_cookie_compliance_da['popup_text_hex'] = 'FFFFFF';
-  $eu_cookie_compliance_da['popup_position'] = FALSE;
-  $eu_cookie_compliance_da['popup_agreed_enabled'] = FALSE;
-  $eu_cookie_compliance_da['popup_height'] = '';
-  $eu_cookie_compliance_da['popup_width'] = '100%';
-  $eu_cookie_compliance_da['popup_delay'] = 1;
+  // Enable translation variables for EU Cookie Compliance.
+  $controller = variable_realm_controller('language');
+  $old_variables = $controller->getEnabledVariables();
+  $old_list = variable_children($old_variables);
+  $variables = array_merge($old_list, array('eu_cookie_compliance'));
+  $controller->setRealmVariable('list', $variables);
 
   // Set cookie compliance variables
-  variable_set('eu_cookie_compliance_da', $eu_cookie_compliance_da);
-  variable_set('eu_cookie_compliance_cookie_lifetime', 365);
+  $eu_cookie_compliance = i18n_variable_get('eu_cookie_compliance', 'da', variable_get('eu_cookie_compliance', array()));
+  $eu_cookie_compliance = array_merge($eu_cookie_compliance, array(
+    'method' => 'default',
+    'popup_info' => array(
+      'value' => '<p>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse.</p><p>Læs mere her: <a href="' . url('cookies') . '">Hvad er cookies?</a></p>',
+      'format' => 'ding_wysiwyg',
+    ),
+    'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',
+    'show_disagree_button' => 0,
+    'popup_link' => 'cookies',
+    'popup_bg_hex' => '0D0D26',
+    'popup_text_hex' => 'FFFFFF',
+    'popup_delay' => 1000,
+  ));
+  i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
 
   $body = '<p><strong>Hvad er cookies?</strong></p>
           <p>En cookie er en lille tekstfil, som lægges på din computer, smartphone, ipad eller lignende med det formål at indhente data. Den gør det muligt for os at måle trafikken på vores site og opsamle viden om f.eks. antal besøg på vores hjemmeside, hvilken browser der bliver brugt, hvilke sider der bliver klikket på, og hvor lang tid der bruges på siden. Alt sammen for at vi kan forbedre brugeroplevelsen og udvikle nye services.</p>

--- a/themes/ddbasic/sass/components/cookie.scss
+++ b/themes/ddbasic/sass/components/cookie.scss
@@ -18,6 +18,7 @@
       padding-top: 20px;
       padding-bottom: 10px;
       p {
+        display: block;
         margin: 0;
         &:nth-child(1) {
           @include font('display-small');

--- a/themes/ddbasic/scripts/site.js
+++ b/themes/ddbasic/scripts/site.js
@@ -51,10 +51,17 @@
    */
   Drupal.behaviors.close_cookie_notification = {
     attach: function(context, settings) {
-      $('#sliding-popup .close', context).bind('click', function () {
-        $(this).closest('#sliding-popup').slideUp();
+      $(context).on('eu_cookie_compliance_popup_open', function() {
+        $('#sliding-popup .close', context).bind('click', function () {
+          var popup = $('#sliding-popup');
+          if (popup.hasClass('sliding-popup-top')) {
+            popup.animate({ top: popup.outerHeight() * -1 }, Drupal.settings.eu_cookie_compliance.popup_delay).trigger('eu_cookie_compliance_popup_close');
+          }
+          else {
+            popup.animate({ bottom: popup.outerHeight() * -1 }, Drupal.settings.eu_cookie_compliance.popup_delay).trigger('eu_cookie_compliance_popup_close');
+          }
+        });
       });
     }
   };
-
 }(jQuery));

--- a/themes/ddbasic/templates/eu-cookie-compliance-popup-info.tpl.php
+++ b/themes/ddbasic/templates/eu-cookie-compliance-popup-info.tpl.php
@@ -1,8 +1,8 @@
 <?php
+
 /**
  * @file
- * This is a template file for a pop-up prompting user to give their consent for
- * the website to set cookies.
+ * Template file for consent banner customized with close button.
  *
  * When overriding this template it is important to note that jQuery will use
  * the following classes to assign actions to buttons:
@@ -11,18 +11,35 @@
  * find-more-button  - link to an information page
  *
  * Variables available:
- * - $message:  Contains the text that will be display whithin the pop-up
- * - $agree_button: Contains agree button title
+ * - $message:  Contains the text that will be display within the pop-up
+ * - $agree_button: Label for the primary/agree button. Note that this is the
+ *   primary button. For backwards compatibility, the name remains agree_button.
+ * - $disagree_button: Contains Cookie policy button title. (Note: for
+ *   historical reasons, this label is called "disagree" even though it just
+ *   displays the privacy policy.)
+ * - $secondary_button_label: Contains the action button label. The current
+ *   action depends on whether you're running the module in Opt-out or Opt-in
+ *   mode.
+ * - $primary_button_class: Contains class names for the primary button.
+ * - $secondary_button_class: Contains class names for the secondary button
+ *   (if visible).
  */
+
 ?>
 <div>
-  <div class ="popup-content info">
+  <div class="popup-content info">
     <div class="close"></div>
     <div id="popup-text">
       <?php print $message ?>
+      <?php if ($disagree_button) : ?>
+        <button type="button" class="find-more-button eu-cookie-compliance-more-button"><?php print $disagree_button; ?></button>
+      <?php endif; ?>
     </div>
     <div id="popup-buttons">
-      <button type="button" class="agree-button"><?php print $agree_button; ?></button>
+      <button type="button" class="<?php print $primary_button_class; ?>"><?php print $agree_button; ?></button>
+      <?php if ($secondary_button_label) : ?>
+        <button type="button" class="<?php print $secondary_button_class; ?>" ><?php print $secondary_button_label; ?></button>
+      <?php endif; ?>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4207

#### Description

This addresses a cross site scripting security issue:
https://www.drupal.org/sa-contrib-2019-033

The update is a major leap in versions where the functionality of the
module has been extended to take GDPR and other issues into account.

We do not have to do anything special regarding consent here so we
just need to configure the module to behave as it did previously.
With the new configuration options this boils down to:

1. Using the default consent method
2. Not showing any disagreement button

The updated module uses `I18n_variable` to store internationalized
settings. To provide a consistent configuration we also use this
module for new installs. Instead of defining all configuration
options we modify the defaults to work as we want to. This allows us
to highlight what is important in our case.

Our custom template has been updated to both include the close button
and be in line with the latest changes to the module.

Finally we have to explicitly specify paragraphs in our cookie text
to be in block format. For some reason the updated module thinks
they should be inline.

In the current form the button does nothing - probably because of a
race condition. The behavior was called before the popup was created.

To fix this we instead listen for an event emitted by the module and
register our click handler then.

Click logic is replicated from 
`Drupal.eu_cookie_compliance.declineAction` to ensure that the close
animation is similar to the open animation. Before it was too fast.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The update only required an update to version 1.26 but since this is a major leap in versions anyhow and [1.26 had a bug which affected us](https://www.drupal.org/project/eu_cookie_compliance/issues/3038087) I chose to upgrade to the latest version.

Regarding Scrutinizer failures:

- [Comments in `ding2.install`](https://scrutinizer-ci.com/g/ding2/ding2/inspections/c34c7f5d-5591-4d35-a5ac-4a12d913d331/issues/files/ding2.install?status=new&orderField=path&order=asc&honorSelectedPaths=0) should be disregarded as it is related to code which has not been changed as a part of this PR
- I think [comments in `eu-cookie-compliance-popup-info.tpl.php`](https://scrutinizer-ci.com/g/ding2/ding2/inspections/c34c7f5d-5591-4d35-a5ac-4a12d913d331/issues/files/themes/ddbasic/templates/eu-cookie-compliance-popup-info.tpl.php?status=new&orderField=path&order=asc&honorSelectedPaths=0) should be disregarded. The code follows standard procedures for template files.