### PR TITLE
4237: Clean up in infomedia error handling

### DIFF
--- a/modules/ting_infomedia/includes/ting_infomedia.wrapper.inc
+++ b/modules/ting_infomedia/includes/ting_infomedia.wrapper.inc
@@ -25,12 +25,7 @@ function ting_infomedia_get_article($id) {
 
     ting_infomedia_add_user_creds($request);
     $ret = opensearch_execute($request->getRequest());
-    if (is_string($ret)) {
-      $ret = FALSE;
-    }
-    else {
-      $ret = $request->parse($ret);
-    }
+    $ret = $request->parse($ret);
   }
   catch (TingClientException $exception) {
     watchdog_exception('infomedia', $exception);
@@ -145,9 +140,5 @@ function ting_infomedia_add_user_creds(TingClientInfomediaRequest $request) {
     // Do nothing.
   }
 
-  $name = isset($creds['name']) ? $creds['name'] : '';
-
-  // Check if user is authenticated.
-  ding_provider_invoke_page('user', 'authenticate', $name, $pass);
   return $request;
 }

--- a/modules/ting_infomedia/ting_infomedia.module
+++ b/modules/ting_infomedia/ting_infomedia.module
@@ -193,7 +193,7 @@ function ting_infomedia_form_opensearch_admin_settings_alter(&$form, &$form_stat
   $form['opensearch']['ting_infomedia_url'] = array(
     '#type' => 'textfield',
     '#title' => t('Infomedia web service URL'),
-    '#description' => t('URL to the infomedia webservice (access to infomedia article base) , e.g. http://useraccessinfomedia.addi.dk/1.4/'),
+    '#description' => t('URL to the infomedia webservice (access to infomedia article base) , e.g. https://useraccessinfomedia.addi.dk/1.4/'),
     '#default_value' => variable_get('ting_infomedia_url', ''),
   );
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4237

#### Description

Infomedia throws exception as it tries to login to FBS without pin-code which is not available (and not at all available when using singe-sign-on services). Code removed was from 2011.

Also fixed error handling that was wrong (sorry for that one) which now is handled by exceptions. 

#### Screenshot of the result

![Screenshot 2019-04-30 at 10 58 41](https://user-images.githubusercontent.com/111397/56950992-f5ef0880-6b36-11e9-8049-be30e72c14c0.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.
