### PR TITLE
4295: Disable ratings on search results

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -726,3 +726,11 @@ function ding2_update_7063() {
     'ding_nodelist',
   ));
 }
+
+/**
+ * Revert Ding Entity Rating feature to hide ratings on search results.
+ */
+function ding2_update_7065() {
+  require_once drupal_get_path('profile', 'ding2') . '/ding2.install_callbacks.inc';
+  _ding2_features_revert('ding_entity_rating');
+}

--- a/ding2.install_callbacks.inc
+++ b/ding2.install_callbacks.inc
@@ -42,17 +42,17 @@ function _ding2_insert_translation($type, $translation_file, &$context) {
 /**
  * Reverts a given feature module.
  *
- * @param string $feature
+ * @param string $feature_name
  *   Name of the module to revert.
  */
-function _ding2_features_revert($feature) {
+function _ding2_features_revert($feature_name) {
   // Load the feature.
-  if (($feature = features_load_feature($feature, TRUE)) && module_exists($feature)) {
+  if (($feature = features_load_feature($feature_name, TRUE)) && module_exists($feature_name)) {
     // Get all components of the feature.
     foreach (array_keys($feature->info['features']) as $component) {
       if (features_hook($component, 'features_revert')) {
         // Revert each component (force).
-        features_revert(array($feature => array($component)));
+        features_revert(array($feature_name => array($component)));
       }
     }
   }

--- a/modules/ding_ting_frontend/ding_ting_frontend.field_group.inc
+++ b/modules/ding_ting_frontend/ding_ting_frontend.field_group.inc
@@ -272,27 +272,15 @@ function ding_ting_frontend_field_group_info() {
   $field_group->entity_type = 'ting_object';
   $field_group->bundle = 'ting_object';
   $field_group->mode = 'search_result';
-  $field_group->parent_name = 'group_info';
+  $field_group->parent_name = '';
   $field_group->data = array(
     'label' => 'Rating',
     'weight' => '23',
-    'children' => array(
-      0 => 'ding_entity_rating_action',
-      1 => 'ding_entity_rating_result',
-    ),
-    'format_type' => 'div',
+    'children' => array(),
+    'format_type' => 'hidden',
     'format_settings' => array(
-      'label' => 'Rating',
-      'instance_settings' => array(
-        'classes' => 'group-rating field-group-div',
-        'description' => '',
-        'show_label' => '0',
-        'label_element' => 'h3',
-        'effect' => 'none',
-        'speed' => 'fast',
-        'id' => 'ting_object_ting_object_search_result_group_rating',
-      ),
-      'formatter' => 'open',
+      'formatter' => '',
+      'instance_settings' => array(),
     ),
   );
   $field_groups['group_rating|ting_object|ting_object|search_result'] = $field_group;

--- a/modules/p2/ding_entity_rating/ding_entity_rating.features.field_base.inc
+++ b/modules/p2/ding_entity_rating/ding_entity_rating.features.field_base.inc
@@ -10,14 +10,13 @@
 function ding_entity_rating_field_default_field_bases() {
   $field_bases = array();
 
-  // Exported field_base: 'ding_entity_rating_action'
+  // Exported field_base: 'ding_entity_rating_action'.
   $field_bases['ding_entity_rating_action'] = array(
     'active' => 1,
     'cardinality' => 1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'ding_entity_rating_action',
-    'foreign keys' => array(),
     'indexes' => array(),
     'locked' => 1,
     'module' => 'ding_entity_rating',
@@ -32,14 +31,13 @@ function ding_entity_rating_field_default_field_bases() {
     'type' => 'ding_entity_rating_action',
   );
 
-  // Exported field_base: 'ding_entity_rating_result'
+  // Exported field_base: 'ding_entity_rating_result'.
   $field_bases['ding_entity_rating_result'] = array(
     'active' => 1,
     'cardinality' => 1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'ding_entity_rating_result',
-    'foreign keys' => array(),
     'indexes' => array(),
     'locked' => 1,
     'module' => 'ding_entity_rating',

--- a/modules/p2/ding_entity_rating/ding_entity_rating.features.field_instance.inc
+++ b/modules/p2/ding_entity_rating/ding_entity_rating.features.field_instance.inc
@@ -10,7 +10,8 @@
 function ding_entity_rating_field_default_field_instances() {
   $field_instances = array();
 
-  // Exported field_instance: 'ting_object-ting_object-ding_entity_rating_action'
+  // Exported field_instance:
+  // 'ting_object-ting_object-ding_entity_rating_action'.
   $field_instances['ting_object-ting_object-ding_entity_rating_action'] = array(
     'bundle' => 'ting_object',
     'default_value' => NULL,
@@ -52,9 +53,8 @@ function ding_entity_rating_field_default_field_instances() {
       ),
       'search_result' => array(
         'label' => 'hidden',
-        'module' => 'ding_entity_rating',
         'settings' => array(),
-        'type' => 'ding_entity_rating_action_default',
+        'type' => 'hidden',
         'weight' => 2,
       ),
       'teaser' => array(
@@ -63,6 +63,12 @@ function ding_entity_rating_field_default_field_instances() {
         'settings' => array(),
         'type' => 'ding_entity_rating_action_default',
         'weight' => 46,
+      ),
+      'teaser_no_overlay' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -92,7 +98,8 @@ function ding_entity_rating_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'ting_object-ting_object-ding_entity_rating_result'
+  // Exported field_instance:
+  // 'ting_object-ting_object-ding_entity_rating_result'.
   $field_instances['ting_object-ting_object-ding_entity_rating_result'] = array(
     'bundle' => 'ting_object',
     'default_value' => NULL,
@@ -133,9 +140,8 @@ function ding_entity_rating_field_default_field_instances() {
       ),
       'search_result' => array(
         'label' => 'hidden',
-        'module' => 'ding_entity_rating',
         'settings' => array(),
-        'type' => 'ding_entity_rating_result_default',
+        'type' => 'hidden',
         'weight' => 3,
       ),
       'teaser' => array(
@@ -144,6 +150,12 @@ function ding_entity_rating_field_default_field_instances() {
         'settings' => array(),
         'type' => 'ding_entity_rating_result_default',
         'weight' => 47,
+      ),
+      'teaser_no_overlay' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4214

#### Description

Disable ratings on search results

The current implementation loads ratings synchronously for each
result. This increases response times considerably.

To address this we hide the ratings field on search results. This is
also in line with UX recommendations.

If we want to reintroduce ratings they should be loaded
asynchronously instead.

This change is the result of hiding the ratings field group and 
fields on the search result view mode for ting objects and doing a 
features export.

Field instances and definitions are stored in the database.
Consequently we need to do an explicit feature revert for our changes
to take effect.

In the process we also have to fix programmatic feature reverting.
In the current form the feature object would be passed to
module_exists() which expects a string. If not it will return false
and features will not be reverted.

To address this we separate the feature name and the feature object
into separate variables.

#### Screenshot of the result

<img width="896" alt="Search Ting | danmark | Ding2 2019-05-06 14-50-28" src="https://user-images.githubusercontent.com/73966/57226467-6605fe80-700f-11e9-920e-1c7192880b07.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.