### PR TITLE
4091: Skip to content link.

### DIFF
--- a/modules/ding_frontend/plugins/layouts/site_template/ding2-site-template.tpl.php
+++ b/modules/ding_frontend/plugins/layouts/site_template/ding2-site-template.tpl.php
@@ -1,3 +1,6 @@
+<a href="#main-content" class="skip-link">
+  <?php print t('Skip to main content'); ?>
+</a>
 <div id="page<?php print $css_id ? " $css_id" : ''; ?>" class="<?php print $classes; ?>">
   <?php if (!empty($content['branding']) || !empty($content['header']) || !empty($content['navigation'])): ?>
     <header class="site-header">
@@ -28,7 +31,7 @@
     </header>
   <?php endif; ?>
 
-  <div class="content-wrapper">
+  <div class="content-wrapper" id="main-content">
     <div class="content-inner">
       <?php print render($content['content']); ?>
     </div>

--- a/themes/ddbasic/ddbasic.info
+++ b/themes/ddbasic/ddbasic.info
@@ -61,6 +61,8 @@
 
   stylesheets[all][] = sass_css/components/view/view.css
 
+  stylesheets[all][] = sass_css/components/skip-link.css
+
   stylesheets[all][] = sass_css/layout/panel.css
 
   stylesheets[all][] = sass_css/p2/p2-ding-interaction.css

--- a/themes/ddbasic/sass/components/skip-link.scss
+++ b/themes/ddbasic/sass/components/skip-link.scss
@@ -1,0 +1,21 @@
+// This is a visually hidden link which skips to the main content of the page.
+// It's placed at the top of the page, and it's useful for screenreader-users
+// as a way of skipping past any base layout, such as the header.
+// The styling which hides it visually is based on the same way that core themes
+// usually do it.
+.skip-link {
+  position: absolute;
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  word-wrap: normal;
+
+  &:focus {
+    position: static;
+    clip: auto;
+    overflow: visible;
+    height: auto;
+    width: auto;
+  }
+}

--- a/themes/ddbasic/templates/panel-layout/ding2-site-template.tpl.php
+++ b/themes/ddbasic/templates/panel-layout/ding2-site-template.tpl.php
@@ -5,6 +5,9 @@
  * Ddbasic implementation to present a Panels layout.
  */
 ?>
+<a href="#main-content" class="skip-link">
+  <?php print t('Skip to main content'); ?>
+</a>
 <div id="page<?php print $css_id ? " $css_id" : ''; ?>" class="<?php print $classes; ?>">
   <?php if (!empty($content['branding']) || !empty($content['header']) || !empty($content['navigation'])): ?>
     <header class="site-header">
@@ -36,7 +39,7 @@
     </header>
   <?php endif; ?>
 
-  <div class="content-wrapper js-content-wrapper">
+  <div class="content-wrapper js-content-wrapper" id="main-content">
     <div class="content-inner">
       <?php print render($content['content']); ?>
     </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4091

#### Description

This is a visually hidden link which skips to the main content of the page.
It's placed at the top of the page, and it's useful for screenreader-users as a way of skipping past any base layout, such as the header.
The styling which hides it visually is based on the same way that core themes usually do it.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
