### PR TITLE
4319: Show red asterisk for required p2b fields

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -235,7 +235,9 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
 
         $element['place2book']['prices_wrapper']['prices'][$key]['name'] = array(
           '#type' => 'textfield',
+          '#title' => t('Name'),
           '#default_value' => !empty($price) ? $price->name : $price_name,
+          '#required' => TRUE,
         );
 
         if (empty($price->meta_data->deletable)) {
@@ -244,7 +246,9 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
 
         $element['place2book']['prices_wrapper']['prices'][$key]['value'] = array(
           '#type' => 'textfield',
+          '#title' => t('Price'),
           '#default_value' => !empty($price) ? $price->value : '',
+          '#required' => TRUE,
         );
         $sale_begin_at = !empty($price->sale_begin_at) ? date('Y-m-d H:i:s', strtotime($price->sale_begin_at)) : '';
         $element['place2book']['prices_wrapper']['prices'][$key]['sale_begin_at'] = array(
@@ -337,15 +341,6 @@ function ding_place2book_widget_validate($form, &$form_state) {
 
       if (empty($address[0]['locality'])) {
         form_set_error('field_ding_event_location][und][0][locality', t('City is required for creating event on P2b.'));
-      }
-    }
-    if (!$place2book['passive'] && isset($place2book['prices_wrapper']['prices'])) {
-      $prices = $place2book['prices_wrapper']['prices'];
-      $prices = array_filter($prices, function ($i) {
-        return !empty($i['name']) && (!empty($i['value']) || $i['value'] === '0');
-      });
-      if (empty($prices)) {
-        form_set_error('field_place2book][und][place2book][prices_wrapper][prices', t('At least one price should exist.'));
       }
     }
 

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -382,7 +382,7 @@ function ding_place2book_widget_validate($form, &$form_state) {
       }, ARRAY_FILTER_USE_BOTH);
 
       if (empty($prices)) {
-        form_set_error('field_place2book][und][place2book][prices_wrapper][prices', t('At least one price should exist and botn name and price value is required.'));
+        form_set_error('field_place2book][und][place2book][prices_wrapper][prices', t('At least one price should exist and both name and price value is required.'));
       }
     }
 

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -289,7 +289,7 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#event_maker_id' => $event_maker_id,
           '#submit' => array('ding_place2book_prices_remove_submit'),
           '#limit_validation_errors' => array(),
-          '#disabled' => empty($price->meta_data->deletable),
+          '#disabled' => isset($price->id) && empty($price->meta_data->deletable),
           '#ajax' => array(
             'wrapper' => 'ding-place2book-prices-wrapper',
             'callback' => 'ding_p2b_prices_remove_ajax_handler',

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -237,7 +237,13 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#type' => 'textfield',
           '#title' => t('Name'),
           '#default_value' => !empty($price) ? $price->name : $price_name,
-          '#required' => TRUE,
+          '#states' => array(
+            'required' => array(
+              ':input[name="field_place2book[und][place2book][passive]"]' => array(
+                'checked' => FALSE
+              ),
+            ),
+          ),
         );
 
         if (isset($price->id) && empty($price->meta_data->deletable)) {
@@ -248,7 +254,13 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#type' => 'textfield',
           '#title' => t('Price'),
           '#default_value' => !empty($price) ? $price->value : '',
-          '#required' => TRUE,
+          '#states' => array(
+            'required' => array(
+              ':input[name="field_place2book[und][place2book][passive]"]' => array(
+                'checked' => FALSE
+              ),
+            ),
+          ),
         );
         $sale_begin_at = !empty($price->sale_begin_at) ? date('Y-m-d H:i:s', strtotime($price->sale_begin_at)) : '';
         $element['place2book']['prices_wrapper']['prices'][$key]['sale_begin_at'] = array(

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -240,7 +240,7 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#required' => TRUE,
         );
 
-        if (empty($price->meta_data->deletable)) {
+        if (isset($price->id) && empty($price->meta_data->deletable)) {
           $element['place2book']['prices_wrapper']['prices'][$key]['name']['#description'] = t('NB: This ticket type can not be deleted (most likely because of sold tickets).');
         }
 

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -230,6 +230,20 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         $form_state['prices_count'] = empty($prices) ? range(0, 0) : range(0, count($prices));
       }
       $price_name = variable_get('ding_p2b_default_price_name', '');
+
+      // We have elements that are required depending on other fields. This
+      // doesn't goes well with the states API, so we theme our own required
+      // marker, use states API and do the validation ourselves.
+      // See: https://www.drupal.org/project/drupal/issues/2855139#comment-12472554
+      $required_marker = array('#theme' => 'form_required_marker');
+      $required_marker = drupal_render($required_marker);
+      $required_state = array(
+        'required' => array(
+          ':input[name="field_place2book[und][place2book][passive]"]' => array(
+            'checked' => FALSE,
+          ),
+        ),
+      );
       foreach ($form_state['prices_count'] as $key) {
         $price = isset($prices[$key]) ? $prices[$key] : NULL;
 
@@ -237,13 +251,6 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#type' => 'textfield',
           '#title' => t('Name'),
           '#default_value' => !empty($price) ? $price->name : $price_name,
-          '#states' => array(
-            'required' => array(
-              ':input[name="field_place2book[und][place2book][passive]"]' => array(
-                'checked' => FALSE
-              ),
-            ),
-          ),
         );
 
         if (isset($price->id) && empty($price->meta_data->deletable)) {
@@ -254,14 +261,17 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#type' => 'textfield',
           '#title' => t('Price'),
           '#default_value' => !empty($price) ? $price->value : '',
-          '#states' => array(
-            'required' => array(
-              ':input[name="field_place2book[und][place2book][passive]"]' => array(
-                'checked' => FALSE
-              ),
-            ),
-          ),
         );
+
+        // Only show required marker and add required state for existing prices
+        // unless no prices exists in p2b, since we need at least one price.
+        if (isset($price->id) || empty($prices)) {
+          foreach (array('name', 'value') as $field) {
+            $element['place2book']['prices_wrapper']['prices'][$key][$field]['#title'] .= ' ' . $required_marker;
+            $element['place2book']['prices_wrapper']['prices'][$key][$field]['#states'] = $required_state;
+          }
+        }
+
         $sale_begin_at = !empty($price->sale_begin_at) ? date('Y-m-d H:i:s', strtotime($price->sale_begin_at)) : '';
         $element['place2book']['prices_wrapper']['prices'][$key]['sale_begin_at'] = array(
           '#type' => 'date_popup',
@@ -353,6 +363,26 @@ function ding_place2book_widget_validate($form, &$form_state) {
 
       if (empty($address[0]['locality'])) {
         form_set_error('field_ding_event_location][und][0][locality', t('City is required for creating event on P2b.'));
+      }
+    }
+
+    if (!$place2book['passive'] && isset($place2book['prices_wrapper']['prices'])) {
+      $prices = $place2book['prices_wrapper']['prices'];
+      $prices = array_filter($prices, function ($price, $key) {
+        $has_values = !empty($price['name']) && (!empty($price['value']) || $price['value'] === '0');
+        // For existing prices we need both name and value, so flag an error if
+        // this is not the case. If price ID is not set it's not an existing
+        // price and just "the add one" more price, which admin can fill out if
+        // they want to add another price. We require at least one price to
+        // exist though (see below).
+        if (isset($price['id']) && !$has_values) {
+          form_set_error("field_place2book][und][place2book][prices_wrapper][prices][$key", t('Both Name and price value is required for prices'));
+        }
+        return $has_values;
+      }, ARRAY_FILTER_USE_BOTH);
+
+      if (empty($prices)) {
+        form_set_error('field_place2book][und][place2book][prices_wrapper][prices', t('At least one price should exist and botn name and price value is required.'));
       }
     }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4319

#### Description

Adds red asterisk to required p2b price fields. See screenshot.

The price field is only required if the event is **not** passive. Therefore we can't use the FAPI #required validation, since [it only cares about the initial field setting in backend](https://www.drupal.org/project/drupal/issues/2855139#comment-12472554).

To still take advangtage of the states API, we can manually theme the required marker in backend and keep our custom validate handler. Some additional logic is required though, since the fields should only be required for existing prices or if no prices currently exist for the event in p2b (we need at least one price for non-passive event for it to work correctly in p2b).

#### Screenshot of the result

![4319-p2b-required-fields](https://user-images.githubusercontent.com/5011234/57384860-94bbda80-71b1-11e9-937d-0d95ad7834a9.PNG)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Also removed the notice about price is not deletable and disabling of the remove button for prices, for new prices that is not created yet:

![4319-p2b-unwanted-price-deletable](https://user-images.githubusercontent.com/5011234/57384957-cb91f080-71b1-11e9-8065-3b1a45f252df.PNG)