### PR TITLE
4197: Make carousel title configurable again

### DIFF
--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -77,12 +77,6 @@ function ting_search_carousel_carousel_content_type_admin_title($subtype, $conf,
 function ting_search_carousel_carousel_content_type_edit_form($form, &$form_state) {
   ctools_form_include($form_state, 'carousel', 'ting_search_carousel', 'plugins/content_types');
 
-  // Hide the title override settings.
-  $form['override_title']['#access'] = FALSE;
-  $form['override_title_text']['#access'] = FALSE;
-  $form['override_title_heading']['#access'] = FALSE;
-  $form['override_title_markup']['#access'] = FALSE;
-
   // Add defoults.
   $form_state['conf'] += array(
     'searches' => array(),


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4197

#### Description

Make carousel pane title configurable.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/57395660-fa679100-71c8-11e9-8838-46a174bf28d5.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
