### PR TITLE
4272: Nodequeue on event list exposed library filter

### DIFF
--- a/modules/ding_event/ding_event.info
+++ b/modules/ding_event/ding_event.info
@@ -28,6 +28,7 @@ dependencies[] = menu
 dependencies[] = menu_position
 dependencies[] = metatag_panels
 dependencies[] = node
+dependencies[] = nodequeue
 dependencies[] = number
 dependencies[] = og_ui
 dependencies[] = options

--- a/modules/ding_event/ding_event.views_default.inc
+++ b/modules/ding_event/ding_event.views_default.inc
@@ -1661,6 +1661,18 @@ function ding_event_views_default_views() {
   $handler->display->display_options['row_plugin'] = 'entityreference_fields';
   $handler->display->display_options['defaults']['row_options'] = FALSE;
   $handler->display->display_options['defaults']['relationships'] = FALSE;
+  /* Relationship: Nodequeue: Queue */
+  $handler->display->display_options['relationships']['nodequeue_rel']['id'] = 'nodequeue_rel';
+  $handler->display->display_options['relationships']['nodequeue_rel']['table'] = 'node';
+  $handler->display->display_options['relationships']['nodequeue_rel']['field'] = 'nodequeue_rel';
+  $handler->display->display_options['relationships']['nodequeue_rel']['label'] = 'kø';
+  $handler->display->display_options['relationships']['nodequeue_rel']['limit'] = 1;
+  $handler->display->display_options['relationships']['nodequeue_rel']['names'] = array(
+    'ding_library_listing' => 'ding_library_listing',
+    'ding_groups_listning' => 0,
+    'ding_groups_frontpage_listing' => 0,
+    'ding_tabroll_frontpage' => 0,
+  );
   $handler->display->display_options['defaults']['fields'] = FALSE;
   /* Field: Title */
   $handler->display->display_options['fields']['title']['id'] = 'title';
@@ -1678,6 +1690,11 @@ function ding_event_views_default_views() {
   $handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['title']['hide_alter_empty'] = FALSE;
   $handler->display->display_options['defaults']['sorts'] = FALSE;
+  /* Sort criterion: Nodequeue: Position */
+  $handler->display->display_options['sorts']['position']['id'] = 'position';
+  $handler->display->display_options['sorts']['position']['table'] = 'nodequeue_nodes';
+  $handler->display->display_options['sorts']['position']['field'] = 'position';
+  $handler->display->display_options['sorts']['position']['relationship'] = 'nodequeue_rel';
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
@@ -1777,6 +1794,7 @@ function ding_event_views_default_views() {
     t('Original Image'),
     t('Cropped Image'),
     t('Event: Libraries list'),
+    t('kø'),
   );
   $export['ding_event'] = $view;
 

--- a/modules/ding_event/ding_event.views_default.inc
+++ b/modules/ding_event/ding_event.views_default.inc
@@ -1665,7 +1665,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['relationships']['nodequeue_rel']['id'] = 'nodequeue_rel';
   $handler->display->display_options['relationships']['nodequeue_rel']['table'] = 'node';
   $handler->display->display_options['relationships']['nodequeue_rel']['field'] = 'nodequeue_rel';
-  $handler->display->display_options['relationships']['nodequeue_rel']['label'] = 'kø';
+  $handler->display->display_options['relationships']['nodequeue_rel']['label'] = 'library listing';
   $handler->display->display_options['relationships']['nodequeue_rel']['limit'] = 1;
   $handler->display->display_options['relationships']['nodequeue_rel']['names'] = array(
     'ding_library_listing' => 'ding_library_listing',
@@ -1794,7 +1794,7 @@ function ding_event_views_default_views() {
     t('Original Image'),
     t('Cropped Image'),
     t('Event: Libraries list'),
-    t('kø'),
+    t('library listing'),
   );
   $export['ding_event'] = $view;
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4272

#### Description

Reuses the "Library list" nodequeue on the the main event list' exposed library filter.

This enables administrators to control the order of libraries in the filter list shown to users.

The order of the "Library list" nodequeue is used to sort the library list and it makes good sense to use this order also on the filter list.

#### Screenshot of the result

![4272-exposed-libary-filter](https://user-images.githubusercontent.com/5011234/57513725-399ffa00-730f-11e9-94cc-54947f0b649f.PNG)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.