### PR TITLE
4332: Align search results

### DIFF
--- a/themes/ddbasic/sass/components/form/form-search-sort.scss
+++ b/themes/ddbasic/sass/components/form/form-search-sort.scss
@@ -2,13 +2,15 @@
 
 .form-search-sort {
   .form-type-select {
+    float: left;
     max-width: none;
+    width: 100%;
 
     > label {
       display: block;
       float: left;
 
-      font-weight: bold;
+      font-family: $font-family-bold;
       color: $color-text;
     }
   }
@@ -29,7 +31,6 @@
   .select-wrapper {
     float: left;
     margin-left: 10px;
-    margin-bottom: 20px;
     line-height: 22px;
 
     overflow: visible;

--- a/themes/ddbasic/sass/components/panel/class-panel.scss
+++ b/themes/ddbasic/sass/components/panel/class-panel.scss
@@ -470,7 +470,7 @@
 .pane-search-result {
   width: 100%;
   float: left;
-  padding: 20px 0;
+  padding-bottom: 20px;
   background-image: none;
   .pane-content {
     padding: 0;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4332

#### Description

Adjusted the sort select element on search-results to align with top of ting-search-backend-engines-form.

Also changed the font weight to use the correct typography.

#### Screenshot of the result

![Screenshot 2019-05-15 at 11 42 05](https://user-images.githubusercontent.com/30495061/57765844-89fbcb00-7706-11e9-84d1-a558fae48a5b.png)

#### Comments
The commit fail on ci/circleci: behat_tests, but since the PR only includes small changes to 2 scss files - i dont see why this PR should fail?