### PR TITLE
4266 by Inlead: Complete Nodelist element should be clickable.

### DIFF
--- a/modules/ding_nodelist/templates/ding_nodelist_widget_promoted_nodes.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist_widget_promoted_nodes.tpl.php
@@ -11,7 +11,6 @@
  *  - title - list title
  * $links - list of links (array)
  */
-
 ?>
 <?php if ($items): ?>
   <div class="<?php print $conf['classes'] ?>">
@@ -25,7 +24,7 @@
             <?php foreach ($chunck as $key => $item): ?>
               <?php $block_classes = ($key % 2 == 0 ? 'left' : 'right'); ?>
               <div
-                class="<?php print $row_classes . '-' . $block_classes; ?>-block">
+                class="<?php print $row_classes . '-' . $block_classes; ?>-block" data-href="<?php print url('node/' . $item->nid, ['absolute' => TRUE]); ?>">
                 <?php print theme($item->item_template, array(
                   'item' => $item,
                   'conf' => $conf,

--- a/themes/ddbasic/scripts/ddbasic.common.js
+++ b/themes/ddbasic/scripts/ddbasic.common.js
@@ -102,4 +102,26 @@
     }
   };
 
+  // Nodelist "Promoted Nodes".
+  Drupal.behaviors.ding_nodelist_promoted_nodes = {
+    attach: function (context, settings) {
+      // "Promoted nodes" items classes list.
+      var classes = ['first-left-block', 'first-right-block', 'last-left-block', 'last-right-block'];
+      classes.forEach(function (value) {
+        // Getting item wrapper.
+        var itemWrapper = $('.' + value);
+        // Extracting item's url from wrapper.
+        var href = itemWrapper.data('href');
+        itemWrapper.on('mouseover click', function (event) {
+          // Always display pointer cursor.
+          itemWrapper.css('cursor', 'pointer');
+          // Act as a click on link when "click" event is executed.
+          if (event.type === 'click') {
+            window.location.href = href;
+          }
+        });
+      });
+    }
+  };
+
 })(jQuery);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4266

#### Description

Makes all "Promoted Nodes" Nodelist widget items clickable.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
