### PR TITLE
4279 by Inlead: Do not make menu default when creating Section.

### DIFF
--- a/modules/ding_sections/modules/ding_sections_term_menu/ding_sections_term_menu.module
+++ b/modules/ding_sections/modules/ding_sections_term_menu/ding_sections_term_menu.module
@@ -66,7 +66,7 @@ function ding_sections_term_menu_form_taxonomy_form_term_alter(&$form, &$form_st
     $form['section']['enabled'] = array(
       '#type' => 'checkbox',
       '#title' => t('Provide a menu link'),
-      '#default_value' => !empty($link['mlid']) ? !empty($link['mlid']) : TRUE,
+      '#default_value' => !empty($link['mlid']) ? !empty($link['mlid']) : FALSE,
     );
     $form['section']['link'] = array(
       '#type' => 'container',


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4279

#### Description

By default on Section creation there is an option to create menu item in main menu. As it was required, this commit disables this action so by default checkbox will be unchecked.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.