### PR TITLE
4168 by Inlead: Add Eresource CT as supported Nodelist CT.

### DIFF
--- a/modules/ding_nodelist/css/ding_nodelist.css
+++ b/modules/ding_nodelist/css/ding_nodelist.css
@@ -74,14 +74,18 @@
   }
 }
 .ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-prev:after, .ding_nodelist-carousel .icon-next::after, .ding_nodelist-carousel .icon-next:after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i::after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i:after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i:after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i:after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i:after {
   font-family: 'icomoon';
@@ -98,28 +102,38 @@
   content: "\e907";
 }
 
+.ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
+  content: "\e907";
+}
+
 .ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-next::after {
   content: "\e903";
 }
 
 .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i::after {
   content: "\ea15";
 }
 
 .ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-prev:after, .ding_nodelist-carousel .icon-next::after, .ding_nodelist-carousel .icon-next:after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i::after, .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i:after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i:after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i:after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after, .ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i:after {
   font-family: 'icomoon';
@@ -136,14 +150,20 @@
   content: "\e907";
 }
 
+.ding_nodelist-promoted_nodes .has-video .media-container .pn-close-media i::after {
+  content: "\e907";
+}
+
 .ding_nodelist-carousel .icon-prev::after, .ding_nodelist-carousel .icon-next::after {
   content: "\e903";
 }
 
 .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i::after {
   content: "\ea15";
@@ -616,9 +636,11 @@
   font-size: 100%;
 }
 .ding_nodelist-promoted_nodes .last-right-block:hover .news-info,
+.ding_nodelist-promoted_nodes .last-right-block:hover .eresource-info,
 .ding_nodelist-promoted_nodes .last-right-block:hover .event-info,
 .ding_nodelist-promoted_nodes .last-right-block:hover .page-info,
 .ding_nodelist-promoted_nodes .first-left-block:hover .news-info,
+.ding_nodelist-promoted_nodes .first-left-block:hover .eresource-info,
 .ding_nodelist-promoted_nodes .first-left-block:hover .event-info,
 .ding_nodelist-promoted_nodes .first-left-block:hover .page-info {
   padding-top: 30px;
@@ -629,9 +651,11 @@
 }
 @media screen and (max-width: 950px) {
   .ding_nodelist-promoted_nodes .last-right-block:hover .news-info,
+  .ding_nodelist-promoted_nodes .last-right-block:hover .eresource-info,
   .ding_nodelist-promoted_nodes .last-right-block:hover .event-info,
   .ding_nodelist-promoted_nodes .last-right-block:hover .page-info,
   .ding_nodelist-promoted_nodes .first-left-block:hover .news-info,
+  .ding_nodelist-promoted_nodes .first-left-block:hover .eresource-info,
   .ding_nodelist-promoted_nodes .first-left-block:hover .event-info,
   .ding_nodelist-promoted_nodes .first-left-block:hover .page-info {
     background-color: transparent;
@@ -672,9 +696,11 @@
   height: auto;
 }
 .ding_nodelist-promoted_nodes .last-right-block .news-info,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info,
 .ding_nodelist-promoted_nodes .last-right-block .event-info,
 .ding_nodelist-promoted_nodes .last-right-block .page-info,
 .ding_nodelist-promoted_nodes .first-left-block .news-info,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info,
 .ding_nodelist-promoted_nodes .first-left-block .event-info,
 .ding_nodelist-promoted_nodes .first-left-block .page-info {
   -webkit-transition: height 300ms cubic-bezier(0.165, 0.84, 0.44, 1);
@@ -693,9 +719,11 @@
   padding-left: 10px;
 }
 .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play {
   font-size: 180%;
@@ -711,18 +739,22 @@
   z-index: 50;
 }
 .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i {
   font-style: normal;
   position: relative;
 }
 .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i::after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i::after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i::after {
   font-size: 54px;
@@ -733,9 +765,11 @@
   top: 0;
 }
 .ding_nodelist-promoted_nodes .last-right-block .news-info .pn-media-play i:after,
+.ding_nodelist-promoted_nodes .last-right-block .eresource-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .last-right-block .event-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .last-right-block .page-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .news-info .pn-media-play i:after,
+.ding_nodelist-promoted_nodes .first-left-block .eresource-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .event-info .pn-media-play i:after,
 .ding_nodelist-promoted_nodes .first-left-block .page-info .pn-media-play i:after {
   font-size: 37px;
@@ -781,9 +815,11 @@
     height: 100%;
   }
   .ding_nodelist-promoted_nodes .last-left-block .news-info,
+  .ding_nodelist-promoted_nodes .last-left-block .eresource-info,
   .ding_nodelist-promoted_nodes .last-left-block .event-info,
   .ding_nodelist-promoted_nodes .last-left-block .page-info,
   .ding_nodelist-promoted_nodes .first-right-block .news-info,
+  .ding_nodelist-promoted_nodes .first-right-block .eresource-info,
   .ding_nodelist-promoted_nodes .first-right-block .event-info,
   .ding_nodelist-promoted_nodes .first-right-block .page-info {
     -webkit-transition: height 300ms cubic-bezier(0.165, 0.84, 0.44, 1);
@@ -903,7 +939,9 @@
   }
 }
 .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item .news-info,
-.ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item .news-info {
+.ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item .eresource-info,
+.ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item .news-info,
+.ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item .eresource-info {
   margin-top: 10px;
 }
 .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item .item-body,
@@ -917,9 +955,11 @@
   position: absolute;
 }
 .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .news-info::after,
+.ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .eresource-info::after,
 .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .event-info::after,
 .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .page-info::after,
 .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .news-info::after,
+.ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .eresource-info::after,
 .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .event-info::after,
 .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .page-info::after {
   background-color: rgba(0, 0, 0, 0.8);
@@ -932,9 +972,11 @@
 }
 @media screen and (max-width: 1100px) {
   .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .news-info::after,
+  .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .eresource-info::after,
   .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .event-info::after,
   .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .page-info::after,
   .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .news-info::after,
+  .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .eresource-info::after,
   .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .event-info::after,
   .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .page-info::after {
     height: 216px;
@@ -942,9 +984,11 @@
 }
 @media screen and (max-width: 950px) {
   .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .news-info::after,
+  .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .eresource-info::after,
   .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .event-info::after,
   .ding_nodelist-promoted_nodes .last-left-block .ding_nodelist-pn-item:hover .page-info::after,
   .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .news-info::after,
+  .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .eresource-info::after,
   .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .event-info::after,
   .ding_nodelist-promoted_nodes .first-right-block .ding_nodelist-pn-item:hover .page-info::after {
     background-color: transparent;
@@ -1068,7 +1112,7 @@
 .ding_nodelist-node_blocks .nb-item .nb-image:after {
   display: none;
 }
-.ding_nodelist-node_blocks .nb-item .nb-image.page-list-image, .ding_nodelist-node_blocks .nb-item .nb-image.ding-news-list-image {
+.ding_nodelist-node_blocks .nb-item .nb-image.page-list-image, .ding_nodelist-node_blocks .nb-item .nb-image.ding-eresource-list-image, .ding_nodelist-node_blocks .nb-item .nb-image.ding-news-list-image {
   width: 100%;
   height: 200px;
   overflow: hidden;
@@ -1252,6 +1296,7 @@
   transition: opacity 300ms 400ms cubic-bezier(0.165, 0.84, 0.44, 1);
 }
 .ding_nodelist-node_blocks .nb-item:hover .field-name-field-ding-page-lead,
+.ding_nodelist-node_blocks .nb-item:hover .field-name-field-ding-eresource-lead,
 .ding_nodelist-node_blocks .nb-item:hover .field-name-field-ding-news-lead {
   position: relative;
   padding-bottom: 10px;

--- a/modules/ding_nodelist/ding_nodelist.install
+++ b/modules/ding_nodelist/ding_nodelist.install
@@ -67,6 +67,10 @@ function ding_nodelist_install() {
       'widget' => 'carousel',
       'content_type' => 'ding_news',
     ),
+    'ding_nodelist.ding_eresource.carousel' => array(
+      'widget' => 'carousel',
+      'content_type' => 'ding_eresource',
+    ),
     'ding_nodelist.ding_event.rolltab' => array(
       'widget' => 'rolltab',
       'content_type' => 'ding_event',
@@ -78,6 +82,10 @@ function ding_nodelist_install() {
     'ding_nodelist.ding_page.rolltab' => array(
       'widget' => 'rolltab',
       'content_type' => 'ding_page',
+    ),
+    'ding_nodelist.ding_eresource.rolltab' => array(
+      'widget' => 'rolltab',
+      'content_type' => 'ding_eresource',
     ),
     'ding_nodelist.ding_event.promoted_nodes' => array(
       'widget' => 'promoted_nodes',
@@ -91,6 +99,10 @@ function ding_nodelist_install() {
       'widget' => 'promoted_nodes',
       'content_type' => 'ding_page',
     ),
+    'ding_nodelist.ding_eresource.promoted_nodes' => array(
+      'widget' => 'promoted_nodes',
+      'content_type' => 'ding_eresource',
+    ),
     'ding_nodelist.ding_event.node_blocks' => array(
       'widget' => 'node_blocks',
       'content_type' => 'ding_event',
@@ -102,6 +114,10 @@ function ding_nodelist_install() {
     'ding_nodelist.ding_page.node_blocks' => array(
       'widget' => 'node_blocks',
       'content_type' => 'ding_page',
+    ),
+    'ding_nodelist.ding_eresource.node_blocks' => array(
+      'widget' => 'node_blocks',
+      'content_type' => 'ding_eresource',
     ),
   );
 
@@ -258,6 +274,42 @@ function ding_nodelist_update_7005() {
  */
 function ding_nodelist_update_7006() {
   _ding_nodelist_process_css_colors();
+}
+
+/**
+ * Implements new display for "Eresource" CT.
+ */
+function ding_nodelist_update_7007() {
+  // Adding new records to db table.
+  $mappings = array(
+    'ding_nodelist.ding_eresource.carousel' => array(
+      'widget' => 'carousel',
+      'content_type' => 'ding_eresource',
+    ),
+    'ding_nodelist.ding_eresource.rolltab' => array(
+      'widget' => 'rolltab',
+      'content_type' => 'ding_eresource',
+    ),
+    'ding_nodelist.ding_eresource.promoted_nodes' => array(
+      'widget' => 'promoted_nodes',
+      'content_type' => 'ding_eresource',
+    ),
+    'ding_nodelist.ding_eresource.node_blocks' => array(
+      'widget' => 'node_blocks',
+      'content_type' => 'ding_eresource',
+    ),
+  );
+
+  foreach ($mappings as $filename => $mapping) {
+    $fields = array(
+      'filename' => $filename,
+      'title' => $filename,
+      'content_type' => $mapping['content_type'],
+      'widget' => $mapping['widget'],
+      'status' => 0,
+    );
+    db_insert('ding_nodelist_templates')->fields($fields)->execute();
+  }
 }
 
 /**

--- a/modules/ding_nodelist/ding_nodelist.strongarm.inc
+++ b/modules/ding_nodelist/ding_nodelist.strongarm.inc
@@ -26,6 +26,7 @@ function ding_nodelist_strongarm() {
     'ding_event' => 'ding_event',
     'ding_news' => 'ding_news',
     'ding_page' => 'ding_page',
+    'ding_eresource' => 'ding_eresource',
     'ding_campaign' => 0,
     'ding_library' => 0,
   );

--- a/modules/ding_nodelist/js/video.js
+++ b/modules/ding_nodelist/js/video.js
@@ -151,6 +151,7 @@
           top.children('.news-info').fadeOut();
           top.children('.event-info').fadeOut();
           top.children('.page-info').fadeOut();
+          top.children('.eresource-info').fadeOut();
           //append the video
           top.children('.media-container')
             .children('.media-content')
@@ -172,6 +173,7 @@
             top.children('.news-info').fadeOut();
             top.children('.event-info').fadeOut();
             top.children('.page-info').fadeOut();
+            top.children('.eresource-info').fadeOut();
             top.children('.media-container')
               .children('.media-content')
               .append(iframe);
@@ -188,6 +190,7 @@
               top.children('.news-info').fadeOut();
               top.children('.event-info').fadeOut();
               top.children('.page-info').fadeOut();
+              top.children('.eresource-info').fadeOut();
               top.children('.media-container')
                 .children('.media-content')
                 .append(iframe);
@@ -206,6 +209,7 @@
         $this.parent().parent().children('.news-info').fadeIn();
         $this.parent().parent().children('.event-info').fadeIn();
         $this.parent().parent().children('.page-info').fadeIn();
+        $this.parent().parent().children('.eresource-info').fadeIn();
       });
     }
   };

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -540,6 +540,7 @@ $label-bg: url('../images/p.png');
 
     &:hover {
       .news-info,
+      .eresource-info,
       .event-info,
       .page-info {
         padding-top: 30px;
@@ -584,6 +585,7 @@ $label-bg: url('../images/p.png');
     }
 
     .news-info,
+    .eresource-info,
     .event-info,
     .page-info {
       @include transition(height $speed $ease);
@@ -660,6 +662,7 @@ $label-bg: url('../images/p.png');
       }
 
       .news-info,
+      .eresource-info,
       .event-info,
       .page-info {
         @include transition(height $speed $ease);
@@ -760,7 +763,8 @@ $label-bg: url('../images/p.png');
         }
       }
 
-      .news-info {
+      .news-info,
+      .eresource-info {
         margin-top: 10px;
       }
 
@@ -775,6 +779,7 @@ $label-bg: url('../images/p.png');
 
       &:hover {
         .news-info,
+        .eresource-info,
         .event-info,
         .page-info {
           &::after {
@@ -914,6 +919,7 @@ $label-bg: url('../images/p.png');
       }
 
       &.page-list-image,
+      &.ding-eresource-list-image,
       &.ding-news-list-image {
         width: 100%;
         height: 200px;
@@ -1095,6 +1101,7 @@ $label-bg: url('../images/p.png');
       }
 
       .field-name-field-ding-page-lead,
+      .field-name-field-ding-eresource-lead,
       .field-name-field-ding-news-lead {
         position: relative;
         padding-bottom: 10px;

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
@@ -6,11 +6,14 @@
  *
  * @var array $item
  */
+
+$image = '';
+if (!empty($item->image)) {
+  $image = '<div class="article_image" style="background-image:url(' . $item->image . ');"></div>';
+}
 ?>
 <div class="item">
-  <?php if (!empty($item->image)): ?>
-    <div class="article_image" style="background-image:url(<?php print $item->image; ?>);"></div>
-  <?php endif; ?>
+  <?php print $image ;?>
   <div class="article-info">
     <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>
     <div class="node">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
@@ -6,12 +6,11 @@
  *
  * @var array $item
  */
-
 ?>
 <div class="item">
-  <div class="article_image">
-    <?php print $item->image_link; ?>
-  </div>
+  <?php if (!empty($item->image)): ?>
+    <div class="article_image" style="background-image:url(<?php print $item->image; ?>);"></div>
+  <?php endif; ?>
   <div class="article-info">
     <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>
     <div class="node">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
@@ -13,7 +13,7 @@ if (!empty($item->image)) {
 }
 ?>
 <div class="item">
-  <?php print $image ;?>
+  <?php print $image; ?>
   <div class="article-info">
     <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>
     <div class="node">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
@@ -6,6 +6,7 @@
  *
  * @var array $item
  */
+
 ?>
 <div class="item">
   <div class="article_image">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @file
+ * Ding news image and text template.
+ *
+ * @var array $item
+ */
+?>
+<div class="item">
+  <div class="article_image">
+    <?php print $item->image_link; ?>
+  </div>
+  <div class="article-info">
+    <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>
+    <div class="node">
+      <h3 class="node-title">
+        <?php print l($item->title, 'node/' . $item->nid); ?>
+      </h3>
+      <p>
+        <?php print $item->teaser_lead; ?>
+      </p>
+      <div class="more">
+        <?php print l(t('More'), 'node/' . $item->nid); ?>
+      </div>
+    </div>
+  </div>
+</div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * Ding eresource node blocks template.
+ *
+ * @var array $item
+ * @var string $column
+ */
+?>
+<article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>"
+         class="node node-ding-eresource node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>">
+  <a href="<?php print '/node/' . $item->nid; ?>">
+    <div class="inner">
+      <div class="background">
+        <div class="button"><?php print t('Read more'); ?></div>
+      </div>
+      <div class="text news-text">
+        <div class="info-top">
+          <?php print drupal_render($item->category); ?>
+        </div>
+        <div class="title-and-lead">
+          <h3 class="title"><?php print $item->title; ?></h3>
+          <div
+            class="field field-name-field-ding-eresource-lead field-type-text-long field-label-hidden">
+            <div class="field-items">
+              <div class="field-item">
+                <?php print $item->teaser_lead; ?>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <?php if (!empty($item->image)): ?>
+      <div class="ding-eresource-list-image nb-image" style="background-image:url(<?php print $item->image; ?>);"></div>
+    <?php endif; ?>
+  </a>
+</article>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
@@ -7,6 +7,7 @@
  * @var array $item
  * @var string $column
  */
+
 ?>
 <article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>"
          class="node node-ding-eresource node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.promoted_nodes.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.promoted_nodes.tpl.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @file
+ * Ding news promoted nodes template.
+ *
+ * @var array $class
+ * @var array $item
+ */
+
+$position = ($class[0] == 'first' && $class[1] == 'left' || $class[0] == 'last' && $class[1] == 'right');
+$classes = array("ding_nodelist-pn-item");
+$classes[] = (empty($item->image) ? 'no-bgimage' : NULL);
+$classes[] = (isset($item->video) ? 'has-video' : NULL);
+$classes = implode(" ", $classes);
+?>
+<div
+  class="<?php print $classes; ?>"
+  <?php if (!empty($item->image) && $position): ?>
+    style="background-image: url(<?php print $item->image; ?>);"
+  <?php
+  endif;
+  ?>
+>
+  <?php if (isset($item->video)): ?>
+    <div class="media-container">
+      <div class="media-content" data-url="<?php print $item->video; ?>"></div>
+      <div class="pn-close-media"><i class="icon-cross"></i></div>
+    </div>
+  <?php
+  endif;
+  ?>
+  <?php if (!empty($item->image) && !$position): ?>
+    <div class="nb-image" style="background-image:url(<?php print $item->image; ?>);"></div>
+  <?php
+  endif;
+  ?>
+  <div class="eresource-info">
+    <h3><?php print l($item->title, 'node/' . $item->nid); ?></h3>
+    <?php print drupal_render($item->category_link); ?>
+    <div class="item-body"><?php print $item->teaser_lead; ?></div>
+    <div class="read-more">
+      <?php print l(t('Read more'), 'node/' . $item->nid); ?>
+    </div>
+    <?php if (isset($item->video)): ?>
+      <div class='pn-media-play'>
+        <div class='pn-play pn-round'><i class='icon-play'></i></div>
+      </div>
+    <?php
+    endif;
+    ?>
+  </div>
+</div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.rolltab.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.rolltab.tpl.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Template file for ding_news rolltab layout.
+ *
+ * @var array $item
+ */
+?>
+<div class="ding-tabroll">
+  <div class="ui-tabs-panel">
+    <div class="image">
+      <?php if (!$item->image): ?>
+        <span class="no-image"></span>
+      <?php
+      else:
+        ?>
+        <?php print $item->image_link; ?>
+      <?php
+      endif;
+      ?>
+    </div>
+
+    <div class="info">
+      <h3><?php print l($item->title, 'node/' . $item->nid); ?></h3>
+      <p> <?php print $item->teaser_lead; ?>
+      </p>
+    </div>
+  </div>
+</div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.rolltab.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.rolltab.tpl.php
@@ -6,6 +6,7 @@
  *
  * @var array $item
  */
+
 ?>
 <div class="ding-tabroll">
   <div class="ui-tabs-panel">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_news.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_news.carousel.tpl.php
@@ -3,13 +3,14 @@
 /**
  * @file
  * Ding news image and text template.
+ *
+ * @var array $item
  */
-
 ?>
 <div class="item">
-  <div class="article_image">
-    <?php print $item->image_link; ?>
-  </div>
+  <?php if (!empty($item->image)): ?>
+    <div class="article_image" style="background-image:url(<?php print $item->image; ?>);"></div>
+  <?php endif; ?>
   <div class="article-info">
     <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>
     <div class="node">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_news.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_news.carousel.tpl.php
@@ -6,11 +6,14 @@
  *
  * @var array $item
  */
+
+$image = '';
+if (!empty($item->image)) {
+  $image = '<div class="article_image" style="background-image:url(' . $item->image . ');"></div>';
+}
 ?>
 <div class="item">
-  <?php if (!empty($item->image)): ?>
-    <div class="article_image" style="background-image:url(<?php print $item->image; ?>);"></div>
-  <?php endif; ?>
+  <?php print $image; ?>
   <div class="article-info">
     <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>
     <div class="node">


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4168

#### Description

Added support of Eresources CT content into nodelist module. This commit contains changes for clean installs/update for enabling Eresources support and templates for each type of widgets present in current distribution.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.