### PR TITLE
4291: Delete left over fields and instances from DB

### DIFF
--- a/modules/p2/ding_entity_rating/ding_entity_rating.install
+++ b/modules/p2/ding_entity_rating/ding_entity_rating.install
@@ -11,3 +11,13 @@
 function ding_entity_rating_update_7001() {
   variable_del('ding_entity_rating_popular_on_frontpage');
 }
+
+/**
+ * Delete left over ding_entity_rating_result field and its intances.
+ */
+function ding_entity_rating_update_7002() {
+  field_delete_field('ding_entity_rating_result');
+  // It's now marked for deletion, but since this was a virtual field with no
+  // data in db we can easily purge it right away.
+  field_purge_batch(1);
+}

--- a/modules/ting_infomedia/ting_infomedia.install
+++ b/modules/ting_infomedia/ting_infomedia.install
@@ -47,3 +47,13 @@ function ting_infomedia_update_7000() {
 function ting_infomedia_update_7001() {
   ding_entity_unlock_fields('ting_infomedia', array('ting_infomedia'));
 }
+
+/**
+ * Delete left over ting_infomedia field and instances from DB.
+ */
+function ting_infomedia_update_7002() {
+  field_delete_field('ting_infomedia');
+  // It's now marked for deletion, but since this was a virtual field with no
+  // data in db we can easily purge it right away.
+  field_purge_batch(1);
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4291

#### Description

I have observed on two of my local test sites that one of the causes for the FacesExtendable exception can be a field instance in the DB, that is missing its field type definition.

There're a couple of cases where a field type definition has been removed, but any associated fields/instances has not been correctly removed from the DB. This PR ensures that this is done.

Se these notes for more info:
https://platform.dandigbib.org/issues/4291#note-8
https://platform.dandigbib.org/issues/4291#note-19

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.