### PR TITLE
4094: Langcode on node content.

### DIFF
--- a/modules/ding_campaign_plus/ding_campaign_plus.strongarm.inc
+++ b/modules/ding_campaign_plus/ding_campaign_plus.strongarm.inc
@@ -124,7 +124,7 @@ function ding_campaign_plus_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_campaign_plus';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_campaign_plus'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/ding_eresource/ding_eresource.info
+++ b/modules/ding_eresource/ding_eresource.info
@@ -14,6 +14,7 @@ dependencies[] = file
 dependencies[] = image
 dependencies[] = link
 dependencies[] = media
+dependencies[] = node
 dependencies[] = options
 dependencies[] = page_manager
 dependencies[] = strongarm

--- a/modules/ding_eresource/ding_eresource.strongarm.inc
+++ b/modules/ding_eresource/ding_eresource.strongarm.inc
@@ -128,7 +128,7 @@ function ding_eresource_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_eresource';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_eresource'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/ding_event/ding_event.strongarm.inc
+++ b/modules/ding_event/ding_event.strongarm.inc
@@ -169,7 +169,7 @@ function ding_event_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_event';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_event'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/ding_groups/ding_groups.info
+++ b/modules/ding_groups/ding_groups.info
@@ -13,6 +13,7 @@ dependencies[] = list
 dependencies[] = manualcrop
 dependencies[] = media
 dependencies[] = menu_position
+dependencies[] = node
 dependencies[] = nodequeue
 dependencies[] = og_context
 dependencies[] = og_menu

--- a/modules/ding_groups/ding_groups.strongarm.inc
+++ b/modules/ding_groups/ding_groups.strongarm.inc
@@ -129,7 +129,7 @@ function ding_groups_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_group';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_group'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/ding_library/ding_library.info
+++ b/modules/ding_library/ding_library.info
@@ -25,6 +25,7 @@ dependencies[] = menu
 dependencies[] = menu_block
 dependencies[] = menu_position
 dependencies[] = metatag_panels
+dependencies[] = node
 dependencies[] = nodequeue
 dependencies[] = og
 dependencies[] = og_menu

--- a/modules/ding_library/ding_library.strongarm.inc
+++ b/modules/ding_library/ding_library.strongarm.inc
@@ -170,7 +170,7 @@ function ding_library_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_library';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_library'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/ding_news/ding_news.strongarm.inc
+++ b/modules/ding_news/ding_news.strongarm.inc
@@ -187,7 +187,7 @@ function ding_news_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_news';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_news'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/ding_page/ding_page.info
+++ b/modules/ding_page/ding_page.info
@@ -18,6 +18,7 @@ dependencies[] = manualcrop
 dependencies[] = media
 dependencies[] = menu
 dependencies[] = menu_block
+dependencies[] = node
 dependencies[] = og
 dependencies[] = og_menu
 dependencies[] = og_ui

--- a/modules/ding_page/ding_page.strongarm.inc
+++ b/modules/ding_page/ding_page.strongarm.inc
@@ -150,7 +150,7 @@ function ding_page_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_page';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_page'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/modules/ding_tabroll/ding_tabroll.info
+++ b/modules/ding_tabroll/ding_tabroll.info
@@ -12,6 +12,7 @@ dependencies[] = image
 dependencies[] = link
 dependencies[] = manualcrop
 dependencies[] = media
+dependencies[] = node
 dependencies[] = nodequeue
 dependencies[] = og_ui
 dependencies[] = options

--- a/modules/ding_tabroll/ding_tabroll.strongarm.inc
+++ b/modules/ding_tabroll/ding_tabroll.strongarm.inc
@@ -111,7 +111,7 @@ function ding_tabroll_strongarm() {
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
   $strongarm->name = 'language_content_type_ding_rolltab';
-  $strongarm->value = '0';
+  $strongarm->value = '1';
   $export['language_content_type_ding_rolltab'] = $strongarm;
 
   $strongarm = new stdClass();

--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -11,7 +11,22 @@
  * Override or insert variables into the node templates.
  */
 function ddbasic_preprocess_node(&$variables, $hook) {
-  //
+  $installed_languages = language_list();
+
+  // If the node has a language associated, and its part of our installed
+  // languages (The value can also be LANGUAGE_NONE), then we will add the
+  // lang="LANGCODE" attribute to the attributes/content_attributes.
+  // This way, if the screenreader reads it, it will read the content in the
+  // correct prounication.
+  if (!empty($variables['language']) &&
+      !empty($installed_languages[$variables['language']])) {
+    // We're doing it to both attributes and content_attributes as it seems
+    // fairly random whether or not a template uses both or not.
+    // Even if a template does use both, it does no damage.
+    $variables['attributes_array']['lang'] = 'en';
+    $variables['content_attributes_array']['lang'] = 'en';
+  }
+
   // Add tpl suggestions for node view modes.
   if (isset($variables['view_mode'])) {
     $variables['theme_hook_suggestions'][] = 'node__view_mode__' . $variables['view_mode'];

--- a/themes/ddbasic/templates/node--ding-library.tpl.php
+++ b/themes/ddbasic/templates/node--ding-library.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the

--- a/themes/ddbasic/templates/node--ding-page.tpl.php
+++ b/themes/ddbasic/templates/node--ding-page.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $date
  *  (NOTE: modified for ddbasic during ddbasic_preprocess_node in templates.php)
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -83,6 +85,7 @@
  * @see template_preprocess_node()
  * @see template_process()
  */
+
 ?>
 <article class="<?php print $classes; ?>"<?php print $attributes; ?>>
 

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--image.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -79,7 +81,7 @@
  */
 
 ?>
-<div class="<?php print $classes; ?>">
+<div class="<?php print $classes; ?>" <?php print $attributes; ?>>
   <div class="ding-campaign ding-campaign--content campaign-image  <?php print $campaign_type; ?>">
     <a href="<?php print $field_ding_campaign_plus_link[LANGUAGE_NONE][0]['url']; ?>?wt_mc=<?php print $wt_mc_id; ?>" target="__blank">
       <?php print render($content['field_ding_campaign_plus_image'])?>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text-and-image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text-and-image.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -79,7 +81,7 @@
  */
 
 ?>
-<div class="<?php print $classes; ?>">
+<div class="<?php print $classes; ?>" <?php print $attributes; ?>>
   <div class="ding-campaign ding-campaign--content image-and-text <?php print $campaign_type; ?>">
     <a href="<?php print $field_ding_campaign_plus_link[LANGUAGE_NONE][0]['url']; ?>?wt_mc=<?php print $wt_mc_id; ?>" target="__blank">
       <div class="ding-campaign-image" style="<?php print $image_as_background; ?>"></div>

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text-with-image.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text-with-image.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -79,7 +81,7 @@
  */
 
 ?>
-<div class="<?php print $classes; ?>">
+<div class="<?php print $classes; ?>" <?php print $attributes; ?>>
   <div class="ding-campaign ding-campaign--content text-on-image <?php print $campaign_type; ?>" style="<?php print $image_as_background; ?>">
     <a href="<?php print $field_ding_campaign_plus_link[LANGUAGE_NONE][0]['url']; ?>?wt_mc=<?php print $wt_mc_id; ?>" target="__blank">
       <div class="ding-campaign-text">

--- a/themes/ddbasic/templates/node/node--ding-campaign-plus--text.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign-plus--text.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -79,7 +81,7 @@
  */
 
 ?>
-<div class="<?php print $classes; ?>">
+<div class="<?php print $classes; ?>" <?php print $attributes; ?>>
   <div class="ding-campaign ding-campaign--content text  <?php print $campaign_type; ?>">
     <a href="<?php print $field_ding_campaign_plus_link[LANGUAGE_NONE][0]['url']; ?>?wt_mc=<?php print $wt_mc_id; ?>" target="__blank">
       <div class="ding-campaign-text">

--- a/themes/ddbasic/templates/node/node--ding-campaign.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-campaign.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -77,21 +79,22 @@
  * @see template_preprocess_node()
  * @see template_process()
  */
+
 ?>
 <?php
   // Hide elements so we can render them later.
   hide($content['comments']);
   hide($content['links']);
 ?>
-<div class="<?php print $classes; ?>">
+<div class="<?php print $classes; ?>" <?php print $attributes; ?>>
   <div class="ding-campaign ding-campaign--content <?php print $type . " " . $panel_style; ?>" <?php print $background; ?>>
     <a href="<?php print $link; ?>" target="<?php print $target; ?>">
-      <?php // if campaign type is "text" or "text on image" hide image here ?>
+      <?php // If campaign type is "text" or "text on image" hide image here. ?>
       <?php if ($type != "text" && $type != "text-on-image"): ?>
         <?php print $image; ?>
       <?php endif; ?>
 
-      <?php // if campaign type is "image only" hide text here ?>
+      <?php // If campaign type is "image only" hide text here. ?>
       <?php if ($type != "image"): ?>
         <div class="ding-campaign-text">
           <h2 class="ding-campaign-headline">

--- a/themes/ddbasic/templates/node/node--view-mode--search-result.tpl.php
+++ b/themes/ddbasic/templates/node/node--view-mode--search-result.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -77,6 +79,7 @@
  * @see template_preprocess_node()
  * @see template_process()
  */
+
 ?>
 <div class="<?php print $classes; ?> view-mode-search-result">
   <div class="content"<?php print $content_attributes; ?>>

--- a/themes/ddbasic/templates/node/node--webform.tpl.php
+++ b/themes/ddbasic/templates/node/node--webform.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -77,6 +79,7 @@
  * @see template_preprocess_node()
  * @see template_process()
  */
+
 ?>
 <?php
   // Hide elements so we can render them later.

--- a/themes/ddbasic/templates/node/node.tpl.php
+++ b/themes/ddbasic/templates/node/node.tpl.php
@@ -18,6 +18,8 @@
  * - $display_submitted: Whether submission information should be displayed.
  * - $submitted: Submission information created from $name and $date during
  *   template_preprocess_node().
+ * - $attributes: String of attributes to be added to a HTML element.
+ * - $content_attributes: String of attributes to be added to a HTML element.
  * - $classes: String of classes that can be used to style contextually through
  *   CSS. It can be manipulated through the variable $classes_array from
  *   preprocess functions. The default values can be one or more of the
@@ -77,6 +79,7 @@
  * @see template_preprocess_node()
  * @see template_process()
  */
+
 ?>
 <?php
   // Hide elements so we can render them later.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4094


#### Description

Currently, some libraries have english pages.
The issue is that these pages, if read by a screen readers, or index by a search engine, will be treated as danish content, as the only `lang` property on the page is on `<html lang="da"`

Looking at the page, this is actually not the problem -  the content around the nodes are actually in danish, such as the menu and footer, so really we only want a `lang="da"` on the actual content.

This PR:
- Adds a selector to the node form, where the editor can choose a language:
<img width="161" alt="Screenshot 2019-05-29 at 14 22 09" src="https://user-images.githubusercontent.com/12376583/58556826-34064780-821d-11e9-818a-c8cbf053a115.png">

- Based on the chosen language, it sets a `lang="[LANGCODE]"` on the relevant node content wrapper.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
