### PR TITLE
4322: Do not display async empty campaign plus pane wrapper

### DIFF
--- a/modules/ding_campaign_plus/js/ding_campaign_plus.js
+++ b/modules/ding_campaign_plus/js/ding_campaign_plus.js
@@ -13,10 +13,18 @@
     attach: function (context) {
       $('[data-ding-campaign-plus-cid]', context).once(function () {
         var campaign = $(this);
+        // Hide the wrapper by default. We do not know if we have any actual
+        // content to insert yet.
+        var wrapper = campaign.parents('.pane-ding-campaign-plus').hide();
         var cid = campaign.data('ding-campaign-plus-cid');
         var url = Drupal.settings.basePath + Drupal.settings.pathPrefix + 'ding_campaigns_plus/' + cid;
         $.get(url, {}, function (response) {
-          campaign.replaceWith(response);
+          // Only show the campaign wrapper if there are any campaigns to be
+          // displayed.
+          if (response) {
+            campaign.replaceWith(response);
+            wrapper.slideDown('fast');
+          }
         });
 
       });


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4322

#### Description

The default panel pane markup surrounding campaign plus panel panes
has styling. It will be rendered when using asynchronous loading
but only the content of the pane is replaced with actual content. If 
there are no campaigns to be shown in the panel pane this means that 
the surrounding markup remains. As it is styled with a padding and 
background color this leaves an empty grey box.

To avoid this we hide the entire wrapper by default and only show
it if any actual campaign markup has been loaded.

#### Screenshot of the result

![screencast 2019-05-29 14-58-32](https://user-images.githubusercontent.com/73966/58558952-58b0ee00-8222-11e9-8f9f-4b99991698f6.gif)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.