### PR TITLE
3350: Remove duplicate update hook

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -756,10 +756,3 @@ function ding2_update_7065() {
 function ding2_update_7066() {
   ding2_translation_update();
 }
-
-/**
- * Update our own translations.
- */
-function ding2_update_7053() {
-  ding2_translation_update();
-}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3350

#### Description

For some reason this got to sneak in. Remove it as it is a syntax 
error. We are already covered regarding translation updates.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.