### PR TITLE
4331: Campaign plus basic search term fixes

### DIFF
--- a/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
+++ b/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
@@ -172,23 +172,31 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
         // We re-assign it here for clarity.
         $search_term = $context;
 
-        // If the search term is empty we just return an empty array, since
-        // executing the query with an empty array in the IN-condition throws
-        // a PDO syntax error exception.
+        // If the search term is empty we just return an empty array.
         if (!empty($search_term)) {
-          $search_term = drupal_strtolower($search_term);
-          $terms = preg_split('/,|\s/', $search_term);
-          $terms = array_filter($terms);
+          _ding_campaign_plus_basic_normalize_search_term($search_term);
 
-          // Check if any active campaigns matches the search terms.
+          // Fetch all basic campaigns of type search term.
           $query = db_select('ding_campaign_plus_basic', 'dcpb')
-            ->fields('dcpb', array('nid'))
+            ->fields('dcpb', array('nid', 'value'))
             ->condition('dcpb.type', $key)
-            ->condition('value', $terms, 'IN');
+            ->condition('status', 1);
           $query->join('node', 'n', 'dcpb.nid = n.nid');
-          $nids = $query->condition('status', 1)
-            ->execute()
-            ->fetchCol();
+          $campaigns = $query->execute()->fetchAllKeyed(0, 1);
+
+          // See if any of them matches the users search term.
+          foreach ($campaigns as $nid => $value) {
+            _ding_campaign_plus_basic_normalize_search_term($value);
+
+            // The match value for this campaign type can contain several comma
+            // separated values.
+            $values = array_map('trim', explode(',', $value));
+            $values = array_filter($values);
+
+            if (in_array($search_term, $values)) {
+              $nids[] = $nid;
+            }
+          }
         }
 
         $matches['search_term'] = is_array($nids) ? $nids : array();
@@ -197,6 +205,15 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
   }
 
   return $matches;
+}
+
+/**
+ * Helper function to normalize input and stored search terms before matching.
+ */
+function _ding_campaign_plus_basic_normalize_search_term(&$term) {
+  // Normalize whitespaces (replace 2 or more space with 1).
+  $term = preg_replace('/ {2,}/', ' ', trim($term));
+  $term = drupal_strtolower($term);
 }
 
 /**

--- a/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
+++ b/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
@@ -164,18 +164,20 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
         $matches['path'] = _ding_campaign_plus_basic_match('path', $context->path);
         break;
 
-      case 'search_request':
+      case 'search_term':
         $nids = [];
 
-        // Get current search query and split it into array of terms.
-        $value = $context->getFullTextQuery();
+        // For the search term basic campaign the ctools string context is used,
+        // which means that $context will just be a string with the search term.
+        // We re-assign it here for clarity.
+        $search_term = $context;
 
-        // If the search string is empty we just return an empty array, since
+        // If the search term is empty we just return an empty array, since
         // executing the query with an empty array in the IN-condition throws
         // a PDO syntax error exception.
-        if (!empty($value)) {
-          $value = drupal_strtolower($value);
-          $terms = preg_split('/,|\s/', $value);
+        if (!empty($search_term)) {
+          $search_term = drupal_strtolower($search_term);
+          $terms = preg_split('/,|\s/', $search_term);
           $terms = array_filter($terms);
 
           // Check if any active campaigns matches the search terms.
@@ -189,7 +191,7 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
             ->fetchCol();
         }
 
-        $matches['search_request'] = is_array($nids) ? $nids : array();
+        $matches['search_term'] = is_array($nids) ? $nids : array();
         break;
     }
   }

--- a/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
+++ b/modules/ding_campaign_plus/modules/ding_campaign_plus_basic/ding_campaign_plus_basic.module
@@ -162,6 +162,12 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
 
       case 'path':
         $matches['path'] = _ding_campaign_plus_basic_match('path', $context->path);
+        // Allow administrators to use the special '<front>' value to target the
+        // frontpage. Note that we still check the "normal" path in these cases,
+        // to maintain support of direct insertion of frontpage path.
+        if ($context->path == variable_get('site_frontpage', 'ding_frontpage')) {
+          $matches['path'] += _ding_campaign_plus_basic_match('path', '<front>');
+        }
         break;
 
       case 'search_term':
@@ -179,12 +185,12 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
           // Fetch all basic campaigns of type search term.
           $query = db_select('ding_campaign_plus_basic', 'dcpb')
             ->fields('dcpb', array('nid', 'value'))
-            ->condition('dcpb.type', $key)
+            ->condition('dcpb.type', 'search_term')
             ->condition('status', 1);
           $query->join('node', 'n', 'dcpb.nid = n.nid');
           $campaigns = $query->execute()->fetchAllKeyed(0, 1);
 
-          // See if any of them matches the users search term.
+          // See if any of them have value that matches the users search term.
           foreach ($campaigns as $nid => $value) {
             _ding_campaign_plus_basic_normalize_search_term($value);
 
@@ -199,7 +205,7 @@ function ding_campaign_plus_basic_ding_campaign_plus_matches($contexts, $style) 
           }
         }
 
-        $matches['search_term'] = is_array($nids) ? $nids : array();
+        $matches['search_term'] = $nids;
         break;
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4331

#### Description

This PR contains two fixes to the matching in campaign plus basic search term trigger, which both prevent it from working it all.

1. There was a typo on the sub-type of basic campaign. For search term the key is `search_term` not `search_request`. This typo prevented the code from fetching the correct campaigns in the DB. Fixed in: 80f88146ca9536eb59091adb4c063d17c0cecd36

2. The mathing of the user entered search term and the matching value in the DB for the campaign was incorrect/the other way around. Instead of taking the comma-separated value from the DB and splitting into terms it took the user entered search. As a consequence, campaigns with several comma-separated terms was not working and also a single search term with several words was not working. Fixed in 141c81a3e6c243fca45bedad43a1f5c141ccf8eb

Also allow administrative users to use the special "\<front\>"-value for basic path trigger, to target frontpage.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
