### PR TITLE
4378: Improve behat setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,7 +238,7 @@ jobs:
         command: |
           mkdir -p ~/tests/behat/screenshots
           export SCREENSHOT_DIR="/home/circleci/tests/behat/screenshots/"
-          export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://localhost/" }}}'
+          export BEHAT_PARAMS='{"extensions" : {"Behat\\MinkExtension" : {"base_url" : "http://localhost/", "sessions" : { "default": { "chrome": { "api_url": "http://localhost:9222" }}}}}}'
           ./bin/behat -p chrome --tags '~no_ci' --tags '~wip'  --list-scenarios \
             | circleci tests split --split-by=timings --timings-type=testname \
             | xargs -n 1 -I % ./bin/behat --format=junit --out=$HOME/tests/behat/% --format=pretty --out=std -p chrome %

--- a/tests/behat/behat.yml
+++ b/tests/behat/behat.yml
@@ -49,5 +49,4 @@ chrome:
       sessions:
         default:
           chrome:
-            api_url: "http://localhost:9222"
             socket_timeout: 600

--- a/tests/behat/composer.json
+++ b/tests/behat/composer.json
@@ -22,7 +22,8 @@
         "liuggio/fastest": "^1.6",
         "dmore/behat-chrome-extension": "^1.2",
         "cweagans/composer-patches": "^1.6",
-        "bossa/phpspec2-expect": "^3.0"
+        "bossa/phpspec2-expect": "^3.0",
+        "dmore/chrome-mink-driver": "^2.7"
     },
     "extra": {
         "patches": {

--- a/tests/behat/composer.lock
+++ b/tests/behat/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71420f6b082125941684156887389839",
+    "content-hash": "2f6a2f5245dbc9902023b2606285ef73",
     "packages": [
         {
             "name": "behat/behat",
@@ -708,21 +708,22 @@
         },
         {
             "name": "dmore/chrome-mink-driver",
-            "version": "2.6.4",
+            "version": "2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://gitlab.com/DMore/chrome-mink-driver.git",
-                "reference": "e02596cdb45b79f530739572c9d51f10963200ef"
+                "reference": "d66765fb7f448e8b2bca2b899308a4a6d8a69264"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://gitlab.com/api/v4/projects/DMore%2Fchrome-mink-driver/repository/archive.zip?sha=e02596cdb45b79f530739572c9d51f10963200ef",
-                "reference": "e02596cdb45b79f530739572c9d51f10963200ef",
+                "url": "https://gitlab.com/api/v4/projects/DMore%2Fchrome-mink-driver/repository/archive.zip?sha=d66765fb7f448e8b2bca2b899308a4a6d8a69264",
+                "reference": "d66765fb7f448e8b2bca2b899308a4a6d8a69264",
                 "shasum": ""
             },
             "require": {
                 "behat/mink": "^1.7",
                 "ext-curl": "*",
+                "ext-json": "*",
                 "textalk/websocket": "^1.2.0"
             },
             "require-dev": {
@@ -751,7 +752,7 @@
                 }
             ],
             "description": "Mink driver for controlling chrome without selenium",
-            "time": "2018-08-08T12:10:47+00:00"
+            "time": "2019-03-30T09:22:58+00:00"
         },
         {
             "name": "doctrine/collections",


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4378

#### Description

This PR addresses a few annoyances when working with Behat tests locally:

1. Allow developers to define Chrome remote debugging url using params. It might not always be running on localhost.
2. Require newest version of Chrome Mink Driver for compatibility.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.