### PR TITLE
4197: Remove subtitle from ting_search_carousel

### DIFF
--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -28,7 +28,6 @@ function ting_search_carousel_carousel_content_type_render($subtype, $conf, $pan
     foreach ($searches as $search) {
       $search += array(
         'title' => '',
-        'subtitle' => '',
         'query' => '',
         'sort' => '',
         'available' => '',
@@ -208,14 +207,6 @@ function ting_search_carousel_query_form(array $item = array(), $index = 0) {
     '#default_value' => isset($item['title']) ? $item['title'] : '',
   );
 
-  // @todo kill this
-  $form['subtitle'] = array(
-    '#type' => 'textfield',
-    '#title' => t('Description'),
-    '#description' => t('The subtitle displayed next to the search results.'),
-    '#default_value' => isset($item['subtitle']) ? $item['subtitle'] : '',
-  );
-
   $form['query'] = array(
     '#type' => 'textfield',
     '#title' => t('Query'),
@@ -280,7 +271,6 @@ function ting_search_carousel_admin_form_callback(array $form, array &$form_stat
 function ting_search_carousel_admin_form_add_one($form, &$form_state) {
   $form_state['conf']['searches'][] = array(
     'title' => '',
-    'subtitle' => '',
     'query' => '',
     'sort' => '',
     'available' => 0,


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4197

#### Description

Removes the "description" field from carousels. It haven't been used for a long time.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
