### PR TITLE
4379: Catch exception when checking reservability

### DIFF
--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -99,10 +99,17 @@ function fbs_ding_entity_is($object, $class) {
       // display and has a chance of calling opensearch to get marc record. We
       // need none of this and only want to know if the material is reservable
       // and if it has any periodical information.
-      $result = fbs_service()->Catalog->getHoldings(
-        fbs_service()->agencyId,
-        $object->localId
-      );
+      try {
+        $result = fbs_service()->Catalog->getHoldings(
+          fbs_service()->agencyId,
+          $object->localId
+        );
+      }
+      catch(Exception $e) {
+	watchdog_exception('fbs', $e);
+        return FALSE;
+      }
+
       $result = reset($result);
       $holdings = reset($result->holdings);
 


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

An exception can be thrown if provider is down or if its not
configureed correctly. Since we call fbs_service directly, we
need to handle exception ourselves.

The reservability check should always be done asynchronously with AJAX and therefore should not be able to take the whole frontpage down. I havn't had time to investigate why this happens, but I can confirm this fixes the WSOD on frontpage, when issues with FBS-provider.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
