### PR TITLE
4256: Fix missing tabrolls

### DIFF
--- a/modules/ding_tabroll/ding_tabroll.views_default.inc
+++ b/modules/ding_tabroll/ding_tabroll.views_default.inc
@@ -28,7 +28,7 @@ function ding_tabroll_views_default_views() {
   $handler->display->display_options['access']['type'] = 'none';
   $handler->display->display_options['cache']['type'] = 'none';
   $handler->display->display_options['query']['type'] = 'views_query';
-  $handler->display->display_options['query']['options']['query_comment'] = FALSE;
+  $handler->display->display_options['query']['options']['disable_sql_rewrite'] = TRUE;
   $handler->display->display_options['exposed_form']['type'] = 'basic';
   $handler->display->display_options['exposed_form']['options']['reset_button_label'] = 'Revert';
   $handler->display->display_options['pager']['type'] = 'some';


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4256

#### Description

The tabrolls are missing because of a bug that appears in a very specific setup with a non-required entity reference field used as a non-required relationship on a view:

https://www.drupal.org/project/drupal/issues/1349080

The reason why this error hasn't surfaced before is that the node_access table hasn't been rebuild after enabling view_unpublished and therefore still contains the global view all access record that the node module adds on install. On those sites where it's suddenly appearing something must have triggered a rebuild.

There's a patch provided for Drupal 7 in the issue, but it's a bit extensive and has some test fails. When reading through the comments in above issue, it doesn't seem like the Drupal 7 patches are tested and "approved" by the other participants.

I therefore think our best cause of action right now, is to just disable the SQL-rewriting for this specific problematic view. I list some reasons for this approach in this comment: https://platform.dandigbib.org/issues/4256#note-25 

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

We could consider triggering a node_access_rebuild during next release in an update function, to ensure node_access table is consistent on all tables.

I'm really not sure what, if any, problems would surface/occure if doing this/not doing this. 