### PR TITLE
4088: Replace jQuery UI selector with native JS.

### DIFF
--- a/themes/ddbasic/scripts/menu.js
+++ b/themes/ddbasic/scripts/menu.js
@@ -51,8 +51,9 @@
           second_level_expanded = $('.main-menu-wrapper > .main-menu > .expanded > .main-menu > .expanded > a .main-menu-expanded-icon', context),
           body = $('body'),
           userPaneForm = $('.js-topbar-user.pane-user-login #user-login-form'),
-          userPaneFocusElements = userPaneForm.find(':focusable'),
-          userPaneFirstInput = userPaneForm.find('input:focusable').first();
+          // Selectors below basically means to get any items that are focusable.
+          userPaneFocusElements = userPaneForm.find('a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, *[tabindex], *[contenteditable]'),
+          userPaneFirstInput = userPaneForm.find('input').first();
 
       // By default, the user login pane is hidden, so focusable elements should
       // not be allowed to have tab-focus.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4088#change-43789

#### Description

Previously we used :focusable, which turns out to be a jQuery UI selector.
This replaces it to work with standard, vanilla jQuery.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.