### PR TITLE
4379: Prevent carousel timeouts

### DIFF
--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -246,7 +246,7 @@ function _ting_search_carousel_find_entities_with_covers(TingSearchCarouselQuery
   // Search offset must be divisible by chunk size.
   // We cannot map a situation where offset is not divisible by chunk size to
   // the search abstraction layer paging model.
-  if (!$start % $size === 0) {
+  if ($start % $size !== 0) {
     throw new InvalidArgumentException('Offset to start from % search chunk size should not have remainders left.');
   }
 

--- a/modules/ting_search_carousel/ting_search_carousel.module
+++ b/modules/ting_search_carousel/ting_search_carousel.module
@@ -291,7 +291,7 @@ function _ting_search_carousel_find_entities_with_covers(TingSearchCarouselQuery
     $entities_found_with_covers[$id] = $entities[$id];
   }
 
-  return array($entities_found_with_covers, $start, $finished);
+  return array($entities_found_with_covers, $start + $size, $finished);
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4379

#### Description

This PR fixes two issues with the current implementation of search carousels to prevent timeouts when retrieving carousel items:

1. Fix progressing through search result for carousel covers
2. Correct identification of search carousel offset/size mismatch 

Please check commit comments for additional details.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
