### PR TITLE
4290: Make sure contact email body shows user email.

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -829,3 +829,10 @@ function ding2_update_7072() {
   // Clear cache before continuing update.
   drupal_flush_all_caches();
 }
+
+/**
+ * Update translations.
+ */
+function ding2_update_7073() {
+  ding2_translation_update();
+}

--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -84,6 +84,21 @@ function ding_contact_mail_alter(&$message) {
       $message['headers']['From'] = $from_value;
       $message['headers']['Reply-To'] = $message['params']['mail'];
       $message['headers']['Sender'] = $sitename;
+
+      // If it is not an anonymous user that has filled out the form,
+      // we want ot make sure their email is included in the message.
+      if (!empty($message['params']['sender']->uid)) {
+        $message['body'][0] .= ' ' . t(
+          "The user's email is !sender-mail.",
+          array(
+            '!sender-mail' => $message['params']['sender']->mail,
+          ),
+          array(
+            'langcode' => $message['language']->language,
+          )
+        );
+      }
+
       break;
   }
 }

--- a/translations/da.po
+++ b/translations/da.po
@@ -61388,6 +61388,9 @@ msgstr "\"Hvis du ønsker at der skal vises yderligere tekst på den globale \"e
 msgid "\"!sender-name (!sender-url) sent a message using the contact form at \"!form-url."
 msgstr "\"!sender-name (!sender-url) sendte en besked via kontaktformularen på \"!form-url."
 
+msgid "The user's email is !sender-mail."
+msgstr "Brugerens email er !sender-mail."
+
 msgid "\"!sender-name (!sender-url) has sent you a message via your contact \"form (!form-url) at !site-name."
 msgstr "\"!sender-name (!sender-url) har sendt dig en besked via din \"kontaktformular (!form-url) på !site-name."
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4290

#### Description

If a user is logged in and fills out the contact form, the username is not displayed in the body, only the user link.
This is not great for the workflow of the librarians, so this adds the email regardless.

See examples here of how it is right now:

![](https://platform.dandigbib.org/attachments/download/4676/Sk%C3%A6rmbillede%202019-04-30%20kl.%2009.42.53.png)
![](https://platform.dandigbib.org/attachments/download/4677/Sk%C3%A6rmbillede%202019-04-30%20kl.%2010.46.17.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
