### PR TITLE
Core: Allow lowercase letters when searching for ÆØÅ in tests

### DIFF
--- a/tests/behat/features/01-Searching.feature
+++ b/tests/behat/features/01-Searching.feature
@@ -23,8 +23,8 @@ Feature: SEEK redroute 01
 
     Examples:
       | title                                                      | letter |
-      | term.language=dansk AND term.type=bog  AND term.title=Æ*   | Æ      |
-      | term.language=dansk AND term.type=bog  AND term.title=Ø*   | Ø      |
+      | term.language=dansk AND term.type=bog  AND term.title=Æ*   | [Ææ]  |
+      | term.language=dansk AND term.type=bog  AND term.title=Ø*   | [Øø]  |
       | term.language=dansk AND term.type=bog  AND term.title=?æ*  | æ      |
       | term.language=dansk AND term.type=bog  AND term.title=?ø*  | ø      |
       | term.language=dansk AND term.type=bog  AND term.title=?å*  | å      |


### PR DESCRIPTION
#### Description

Allow lowercase letters when searching for ÆØÅ in tests

These cases may return search results with æøå (lowercase) which will 
currently not be accepted by the test case. However this is
acceptable behavior.

Update test case to allow lowercase versions of these letters.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.