### PR TITLE
4382: Make dibs payments unique.

### DIFF
--- a/modules/ding_dibs/ding_dibs.module
+++ b/modules/ding_dibs/ding_dibs.module
@@ -211,6 +211,10 @@ function ding_dibs_capture($delta = NULL, array &$transaction = NULL) {
   $param['orderid'] = $transaction['payment_order_id'];
   $param['transact'] = $transaction['payment_transaction_id'];
   $param['textreply'] = TRUE;
+  // If this parameter is present, the parameter orderid has to be unique
+  // compared to all other orderid's used by the merchant.
+  // If the orderid isn't unique, the call will be declined by a reason=7.
+  $param['uniqueoid'] = 'yes';
 
   $md5 = isset($settings['general']['md5']) ? $settings['general']['md5'] : FALSE;
   if ($md5) {
@@ -222,7 +226,8 @@ function ding_dibs_capture($delta = NULL, array &$transaction = NULL) {
         "merchant=" . $param['merchant'] .
         "&orderid=" . $param['orderid'] .
         "&transact=" . $param['transact'] .
-        "&amount=" . $param['amount']
+        "&amount=" . $param['amount'] .
+        "&uniqueoid=" . $param['uniqueoid']
       )
     );
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4382

#### Description

By adding the uniqueoid=yes parameter to the payment URL, we make sure that if is a payment with an identical ID already has been submitted, it will be rejected.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

As I mention in the redmine Issue, I havent found any way of testing this locally, meaning we need to **be extra careful in our payments tests.**