### PR TITLE
4090: Add help text to rating buttons.

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -799,3 +799,11 @@ function ding2_update_7070() {
   ding2_translation_update();
 }
 
+
+/**
+ * Update translations.
+ */
+function ding2_update_7071() {
+  ding2_translation_update();
+}
+

--- a/modules/p2/ding_entity_rating/ding_entity_rating.module
+++ b/modules/p2/ding_entity_rating/ding_entity_rating.module
@@ -432,7 +432,14 @@ function ding_entity_rating_build_theme_list($rating) {
     if ($i <= $rating) {
       $classes[] = 'submitted';
     }
-    $output .= '<a class="' . implode(' ', $classes) . '" href="#"></a>';
+
+    $title = t(
+      'Rate this !number / 5 stars',
+      array('!number' => $i),
+      array('context' => 'Rating')
+    );
+
+    $output .= '<a class="' . implode(' ', $classes) . '" href="#" title="' . $title . '"></a>';
   }
 
   return $output;

--- a/translations/da.po
+++ b/translations/da.po
@@ -67541,3 +67541,8 @@ msgstr "Redigér artiklens status i BPI"
 msgctxt "Price"
 msgid "Free"
 msgstr "Gratis"
+
+#: /search/ting
+msgctxt "Rating"
+msgid "Rate this !number / 5 stars"
+msgstr "Bedøm dette !number / 5 stjerner"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4090

#### Description

Adding a `title` tag to the rating option `<a>`'s. See screenshot for best explanation :)

#### Screenshot of the result

Code + Hover text:

<img width="723" alt="Screenshot 2019-06-26 at 11 10 39" src="https://user-images.githubusercontent.com/12376583/60167471-75314d80-9803-11e9-8a10-7dd3d41a98d2.png">


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
