### PR TITLE
4391 by Inlead: Place2book: Default values are overriding given values.

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -46,9 +46,9 @@ function ding_place2book_field_widget_info() {
  * Implements hook_field_widget_form().
  */
 function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instance, $langcode, $items, $delta, $element) {
-  $event = $event_id = $event_maker_id = $synchronize = NULL;
+  $event = $event_id = $event_maker_id = $synchronize = $passive = NULL;
   if (!empty($items)) {
-    list($event_id, $event_maker_id, $synchronize) = array_values(reset($items));
+    list($event_id, $event_maker_id, $synchronize, $passive) = array_values(reset($items));
     try {
       $p2b = ding_place2book_instance();
       $event = $p2b->getEvent($event_maker_id, $event_id);
@@ -177,8 +177,7 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         ),
       );
 
-      $passive = 0;
-      if (!isset($meta_data->event_state)) {
+      if ($passive === NULL) {
         $passive = variable_get('ding_p2b_default_passive', FALSE);
       }
       elseif ($meta_data->event_state == 'passive') {
@@ -474,6 +473,7 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
             ),
           );
         }
+        $items[0]['passive'] = $settings['passive'];
       }
       break;
   }

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -276,14 +276,12 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         $element['place2book']['prices_wrapper']['prices'][$key]['sale_begin_at'] = array(
           '#type' => 'date_popup',
           '#default_value' => $sale_begin_at,
-          '#states' => $required_state,
         );
 
         $sale_end_at = !empty($price->sale_end_at) ? date('Y-m-d H:i:s', strtotime($price->sale_end_at)) : '';
         $element['place2book']['prices_wrapper']['prices'][$key]['sale_end_at'] = array(
           '#type' => 'date_popup',
           '#default_value' => $sale_end_at,
-          '#states' => $required_state,
         );
 
         $element['place2book']['prices_wrapper']['prices'][$key]['id'] = array(

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -46,9 +46,9 @@ function ding_place2book_field_widget_info() {
  * Implements hook_field_widget_form().
  */
 function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instance, $langcode, $items, $delta, $element) {
-  $event = $event_id = $event_maker_id = $synchronize = $passive = NULL;
+  $event = $event_id = $event_maker_id = $synchronize = NULL;
   if (!empty($items)) {
-    list($event_id, $event_maker_id, $synchronize, $passive) = array_values(reset($items));
+    list($event_id, $event_maker_id, $synchronize) = array_values(reset($items));
     try {
       $p2b = ding_place2book_instance();
       $event = $p2b->getEvent($event_maker_id, $event_id);
@@ -177,7 +177,8 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         ),
       );
 
-      if ($passive === NULL) {
+      $passive = 0;
+      if (!isset($meta_data->event_state)) {
         $passive = variable_get('ding_p2b_default_passive', FALSE);
       }
       elseif ($meta_data->event_state == 'passive') {
@@ -473,7 +474,6 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
             ),
           );
         }
-        $items[0]['passive'] = $settings['passive'];
       }
       break;
   }

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -177,7 +177,7 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         ),
       );
 
-      $passive = 0;
+      $passive = $event->passive ?? 0;
       if (!isset($meta_data->event_state)) {
         $passive = variable_get('ding_p2b_default_passive', FALSE);
       }
@@ -276,12 +276,14 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         $element['place2book']['prices_wrapper']['prices'][$key]['sale_begin_at'] = array(
           '#type' => 'date_popup',
           '#default_value' => $sale_begin_at,
+          '#states' => $required_state,
         );
 
         $sale_end_at = !empty($price->sale_end_at) ? date('Y-m-d H:i:s', strtotime($price->sale_end_at)) : '';
         $element['place2book']['prices_wrapper']['prices'][$key]['sale_end_at'] = array(
           '#type' => 'date_popup',
           '#default_value' => $sale_end_at,
+          '#states' => $required_state,
         );
 
         $element['place2book']['prices_wrapper']['prices'][$key]['id'] = array(

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -177,7 +177,7 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         ),
       );
 
-      $passive = $event->passive ?? 0;
+      $passive = 0;
       if (!isset($meta_data->event_state)) {
         $passive = variable_get('ding_p2b_default_passive', FALSE);
       }

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -30,13 +30,7 @@ function ding_place2book_field_schema($field) {
           'size' => 'tiny',
           'not null' => TRUE,
           'default' => 0,
-        ),
-        'passive' => array(
-          'type' => 'int',
-          'size' => 'tiny',
-          'not null' => TRUE,
-          'default' => 0,
-        ),
+        )
       );
       break;
   }
@@ -190,40 +184,4 @@ function ding_place2book_update_7005(&$sandbox) {
  */
 function ding_place2book_update_7006() {
   module_enable(array('ding_place2book_migrate'));
-}
-
-/**
- * Extend field table with markers.
- */
-function ding_place2book_update_7007() {
-  $fields = ding_place2book_get_p2b_fields();
-
-  foreach ($fields as $field) {
-    $tables = array(
-      _field_sql_storage_tablename($field),
-      _field_sql_storage_revision_tablename($field),
-    );
-    $field_name = $field['field_name'];
-
-    foreach ($tables as $table) {
-      db_add_field($table, $field_name . '_passive', array(
-        'type' => 'int',
-        'size' => 'tiny',
-      ));
-    }
-  }
-}
-
-/**
- * Returns all fields created on the system of the type defined in mymodule.
- */
-function ding_place2book_get_p2b_fields() {
-  $types = ['ding_p2b'];
-  $fields = array();
-  foreach (field_info_fields() as $field) {
-    if (in_array($field['type'], $types)) {
-      $fields[] = $field;
-    }
-  }
-  return $fields;
 }

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -201,7 +201,7 @@ function ding_place2book_update_7007() {
   foreach ($fields as $field) {
     $tables = array(
       _field_sql_storage_tablename($field),
-      _field_sql_storage_revision_tablename($field)
+      _field_sql_storage_revision_tablename($field),
     );
     $field_name = $field['field_name'];
 

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -30,7 +30,13 @@ function ding_place2book_field_schema($field) {
           'size' => 'tiny',
           'not null' => TRUE,
           'default' => 0,
-        )
+        ),
+        'passive' => array(
+          'type' => 'int',
+          'size' => 'tiny',
+          'not null' => TRUE,
+          'default' => 0,
+        ),
       );
       break;
   }
@@ -186,3 +192,38 @@ function ding_place2book_update_7006() {
   module_enable(array('ding_place2book_migrate'));
 }
 
+/**
+ * Extend field table with markers.
+ */
+function ding_place2book_update_7007() {
+  $fields = ding_place2book_get_p2b_fields();
+
+  foreach ($fields as $field) {
+    $tables = array(
+      _field_sql_storage_tablename($field),
+      _field_sql_storage_revision_tablename($field)
+    );
+    $field_name = $field['field_name'];
+
+    foreach ($tables as $table) {
+      db_add_field($table, $field_name . '_passive', array(
+        'type' => 'int',
+        'size' => 'tiny',
+      ));
+    }
+  }
+}
+
+/**
+ * Returns all fields created on the system of the type defined in mymodule.
+ */
+function ding_place2book_get_p2b_fields() {
+  $types = ['ding_p2b'];
+  $fields = array();
+  foreach (field_info_fields() as $field) {
+    if (in_array($field['type'], $types)) {
+      $fields[] = $field;
+    }
+  }
+  return $fields;
+}

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -292,7 +292,7 @@ function ding_place2book_node_presave($node) {
       ->url
       ->set($event->links->sales_location);
   }
-  catch (Exception $e) {
+  catch (Exception $ex) {
     watchdog_exception('ding_place2book', $ex, t('Error appeared on getting data from p2b.'));
   }
 }

--- a/modules/ding_place2book/lib/p2b/P2b.php
+++ b/modules/ding_place2book/lib/p2b/P2b.php
@@ -559,7 +559,7 @@ class P2b {
     );
 
     if (!empty($params)) {
-      if ($type == 'POST') {
+      if ($type == 'POST' || $type == 'PUT') {
         $options['json'] = $params;
       }
       else {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4391

#### Description

Once you have created an event and defined values in Maintain copy, Kultunaut export and Passive event as you wish, then it stores the event fine and correct. But if you edit the event, it sets the default values again even if you do not want it to change

**Example 1:**

I have in the standards for p2b under /admin/config/ding/place2book/defaults checked Maintain copy, Kultunaut export and Passive arrangement.

I create an event that I want there to be ticket to. So I remove the checkmark in "Passive".

I save the event.

I would like to edit the body-field of the event, so I edit the event.

I now notice that "Passive" is again marked in the standards.

If I accidentally save, the ticket link is gone, and I cannot undo to a non-passive event, and if tickets have been sold, I cannot delete and start over.

**Example 2:**

I have in the standards for p2b under /admin/config/ding/place2book/defaults checked Maintain copy, and Kultunaut export

I want to make an event where there should not be tickets nor sent to Kultunaut. So I remove the checkmark in Maintain copy and Kultunaut export.

I save the event.

I would like to edit the body-field of the event, so I edit the event.

I now notice that Maintenance copy and Kultunaut export are checked again by the standards.

This means that a ticket will be created for an event, which should not be ticketed and also sent incorrectly to Kultunaut.

**Solution:** 

As mentioned in the API documentation in the PUT request the header input Content-Type should be application/json. Plus, get passive value direct from the event entity.

Could not reproduce example 2.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/3027336/60171205-ceed4400-9812-11e9-86b9-25b31b3ab3a0.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
