### PR TITLE
4001 by Inlead: Use validation as in ting_reference field.

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -317,8 +317,7 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
 
       // Loop over materials from BPI inserting new default field for each.
       foreach ($bpi_content['material'] as $key => $material_number) {
-        preg_match('/[^\:]+\:\s?(.*)/', $material_number, $matches);
-        $id = bpi_validate_material($matches[1]);
+        $id = bpi_validate_material($material_number);
         $form[$materials_field][$current_language][$key] = $default_field;
         if (!$id) {
           $id = $material_number;
@@ -945,29 +944,23 @@ function bpi_workflow_by_machine_names($machine_names) {
 /**
  * Makes request to ting and checks exist material with such id.
  *
- * @param $id
+ * @param string $ting_object_id
+ *   Faust number.
  *
  * @return mixed
  *   FALSE in case when id not exist
  *   int in case when material with same id was found.
  */
-function bpi_validate_material($id) {
-  $result = ting_start_query()
-    ->withFullTextQuery($id)
-    ->withCount(1)
-    ->withPopulateCollections(FALSE)
-    ->execute();
+function bpi_validate_material($ting_object_id) {
+  // If the colon was URL-encoded, decode it - and trim whitespace from
+  // both ends of the input string.
+  $ting_object_id = trim(str_replace('%3A', ':', $ting_object_id));
 
-  $primary_objects = array_map(function (TingCollection $collection) {
-    return $collection->getPrimary_object();
-  }, $result->getTingEntityCollections());
-  // Collections may not have a primary object. Remove such entries.
-  $primary_objects = array_filter($primary_objects);
-  $ids = array_map(function (TingEntity $object) {
-    return $object->getId();
-  }, $primary_objects);
+  // Load the object to validate it exists.
+  // Loading it should make it available for use with ting_get_object().
+  $ting_entity = ting_object_load($ting_object_id);
 
-  return array_shift($ids);
+  return $ting_entity ? $ting_object_id : FALSE;
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4001

#### Description

Change the validation mechanism of imported bpi materials to use same logic as in the ting_reference field. This makes sure that there's no different logic when validating materials, therefore producing unexpected results. For example, when after syndicating content the form reports validation errors regarding bpi materials, when, in fact, these materials do exist.

#### Screenshot of the result

None.

#### Checklist

- [x] My complies with [coding guidelines](../docs/code_guidelines.md).
- [x] My code passes static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

None.
