### PR TITLE
4394 by Inlead: Place2book: Clone of events does not create new ticket.

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -99,7 +99,8 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         '#value' => TRUE,
       );
 
-      if (!empty($event)) {
+      // Hide prepopulated form if this is clone of the event.
+      if (!empty($event) && arg(2) != 'clone') {
         $begin_at = date('d/m/Y H:i:s', strtotime($event->begin_at));
         $end_at = date('d/m/Y H:i:s', strtotime($event->end_at));
         $element['place2book']['event_data'] = array(
@@ -461,7 +462,7 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
           $synchronized_items = _ding_place2book_sync_p2b_entities($entity, $settings);
         }
 
-        // Only update field data if synchronizationn was successful.
+        // Only update field data if synchronization was successful.
         if (!empty($synchronized_items)) {
           $items = $synchronized_items;
         }
@@ -567,8 +568,8 @@ function _ding_place2book_sync_p2b_entities($entity, array $settings) {
 
   $event_id = !empty($settings['event_id']) ? $settings['event_id'] : FALSE;
   $event_maker_id = FALSE;
-  // For clarity.
-  $is_new = !$event_id;
+  // For clarity and make if clone the event.
+  $is_new = !$event_id || arg(2) == 'clone';
 
   if ($is_new) {
     $event_maker_id = _ding_place2book_get_event_maker($entity);

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -567,9 +567,19 @@ function _ding_place2book_sync_p2b_entities($entity, array $settings) {
   $items = [];
 
   $event_id = !empty($settings['event_id']) ? $settings['event_id'] : FALSE;
+  $prices = $settings['prices_wrapper']['prices'];
   $event_maker_id = FALSE;
-  // For clarity and make if clone the event.
-  $is_new = !$event_id || arg(2) == 'clone';
+
+  // For clarity.
+  $is_new = !$event_id;
+  if (arg(2) == 'clone') {
+    $is_new = TRUE;
+    $prices = array_map(function ($price) {
+      unset($price['id']);
+
+      return $price;
+    }, $prices);
+  }
 
   if ($is_new) {
     $event_maker_id = _ding_place2book_get_event_maker($entity);
@@ -581,7 +591,6 @@ function _ding_place2book_sync_p2b_entities($entity, array $settings) {
   if ($event_maker_id) {
     $p2b = ding_place2book_instance();
     // Collect data for synchronizing event.
-    $prices = $settings['prices_wrapper']['prices'];
     unset($settings['prices_wrapper']);
     unset($settings['synchronize']);
     unset($settings['event_id']);

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -99,8 +99,7 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         '#value' => TRUE,
       );
 
-      // Hide prepopulated form if this is clone of the event.
-      if (!empty($event) && arg(2) != 'clone') {
+      if (!empty($event)) {
         $begin_at = date('d/m/Y H:i:s', strtotime($event->begin_at));
         $end_at = date('d/m/Y H:i:s', strtotime($event->end_at));
         $element['place2book']['event_data'] = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4394

#### Description

_Solution_

On the clone stage(node/{node id}/clone/confirm page) form submit it is copied the old event from the p2b and are removed all relations(id of event and prices ids).

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.