### PR TITLE
4428: Enable i18n variable module

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -737,6 +737,9 @@ function ding2_update_7063() {
  * Update EU Cookie Compliance settings.
  */
 function ding2_update_7064() {
+  if (!module_exists('i18n_variable')) {
+    module_enable(array('i18n_variable'));
+  }
   $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da');
   $ecc_settings['method'] = 'default';
   $ecc_settings['show_disagree_button'] = 0;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4428

#### Description

Enabled i18n variable module if it is not. Fixed error in update hook that uses that module.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.
