### PR TITLE
4399 by Inlead: P2b - Do not set ticket link if node is passive.

### DIFF
--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -310,11 +310,12 @@ function ding_place2book_node_presave($node) {
   try {
     $p2b = ding_place2book_instance();
     $event = $p2b->getEvent($event_maker_id, $event_id);
-
-    $node_wrapper
-      ->field_ding_event_ticket_link
-      ->url
-      ->set($event->links->sales_location);
+    if (!$event->passive) {
+      $node_wrapper
+        ->field_ding_event_ticket_link
+        ->url
+        ->set($event->links->sales_location);
+    }
   }
   catch (Exception $e) {
     watchdog_exception('ding_place2book', $ex, t('Error appeared on getting data from p2b.'));


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4399

#### Description

In the hook_node_presave() implementation (ding_place2book_node_presave) we set field_ding_ticket_link with sales link to P2b, if the event is synced with P2b. We should add a check here, so that we only set this if event is not passive.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This will work properly when the #1472 PR is merged. Since, on each node presave a PUT request is sent to p2b service.(See discussion in PR.)
