### PR TITLE
4319: Only show validation errors for price name and value

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -376,13 +376,15 @@ function ding_place2book_widget_validate($form, &$form_state) {
         // they want to add another price. We require at least one price to
         // exist though (see below).
         if (isset($price['id']) && !$has_values) {
-          form_set_error("field_place2book][und][place2book][prices_wrapper][prices][$key", t('Both Name and price value is required for prices'));
+          form_set_error("field_place2book][und][place2book][prices_wrapper][prices][$key][name", t('Both Name and price value is required for prices'));
+          form_set_error("field_place2book][und][place2book][prices_wrapper][prices][$key][value");
         }
         return $has_values;
       }, ARRAY_FILTER_USE_BOTH);
 
       if (empty($prices)) {
-        form_set_error('field_place2book][und][place2book][prices_wrapper][prices', t('At least one price should exist and both name and price value is required.'));
+        form_set_error('field_place2book][und][place2book][prices_wrapper][prices][0][name', t('At least one price should exist and both name and price value is required.'));
+        form_set_error('field_place2book][und][place2book][prices_wrapper][prices][0][value');
       }
     }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4319#note-18

#### Description

A minor follow up from the changes in #1423  

Only show validation errors for price name and value and not also on sales period like before.

#### Screenshot of the result

![4319-p2b-required-fields-only-name-value](https://user-images.githubusercontent.com/5011234/60975327-17852100-a32c-11e9-9564-f4e0f80c484c.PNG)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
