### PR TITLE
4285 by Inlead: Adjust ding_app_content_rss_location value.

### DIFF
--- a/modules/ding_app_content_rss/ding_app_content_rss.module
+++ b/modules/ding_app_content_rss/ding_app_content_rss.module
@@ -60,9 +60,11 @@ function ding_app_content_rss_field_formatter_view($entity_type, $entity, $field
     case 'ding_app_content_rss_location':
       foreach ($items as $delta => $item) {
         $location = array();
+
+        $accepted_fields = ['name_line', 'thoroughfare', 'postal_code', 'locality', 'country'];
         if (!empty($item['name_line'])) {
-          foreach ($item as $part) {
-            if (!empty($part)) {
+          foreach ($item as $key => $part) {
+            if (!empty($part) && in_array($key, $accepted_fields)) {
               $location[] = $part;
             }
           }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4285

#### Description

This changes the output of **content-rss:arrangement-location** feed field. 
Values outputted: 'name_line', 'thoroughfare', 'postal_code', 'locality', 'country'.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.