### PR TITLE
4367: Header lenght changed and min-height removed

### DIFF
--- a/themes/ddbasic/sass/components/node/campaign.scss
+++ b/themes/ddbasic/sass/components/node/campaign.scss
@@ -52,13 +52,15 @@
       z-index: 1;
     }
     .ding-campaign-text {
-      @include span-columns(7);
+      @include span-columns(10);
       position: relative;
       padding: 50px 30px;
       color: $white;
       z-index: 2;
-      @include media($mobile) {
+      @include media($tablet) {
         @include span-columns(12);
+      }
+      @include media($mobile) {
         min-height: auto;
       }
     }

--- a/themes/ddbasic/sass/components/node/campaign.scss
+++ b/themes/ddbasic/sass/components/node/campaign.scss
@@ -147,13 +147,14 @@
   }
   // text only layout
   &.text {
+    min-height: 0;
     background: $color-primary;
     .ding-campaign-text {
       @include span-columns(12);
       padding: 40px 30px;
       .ding-campaign-headline {
-        @include span-columns(8);
-        @include media($mobile) {
+        @include span-columns(10);
+        @include media($tablet) {
           @include span-columns(12);
         }
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4367

#### Description

For the campaign type "text", the header length is changed to be longer and the min-height is removed. For the campaign type "text-on-image", the text width is changed to be longer.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/22191849/61117131-31427780-a496-11e9-89b4-88c21eb655a9.png)

![image](https://user-images.githubusercontent.com/22191849/62037406-04ab9100-b1f4-11e9-994b-63bf7e8a78bb.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No further comments.
