### PR TITLE
4416: Resize event called on view when images are loaded

### DIFF
--- a/themes/ddbasic/scripts/node/event.js
+++ b/themes/ddbasic/scripts/node/event.js
@@ -15,7 +15,7 @@
   // Call resize function when images are loaded.
   Drupal.behaviors.ding_event_teaser_loaded = {
     attach: function(context, settings) {
-      $('.view-ding-event .view-elements').imagesLoaded( function() {
+      $('.view-ding-event .view-elements, .view-ding-related-content .view-content').imagesLoaded( function() {
         $(window).triggerHandler('resize.ding_event_teaser');
       });
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4416

#### Description

View class added to imagesLoaded function that triggers a resize event for event teasers.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/22191849/61126657-5bebfa80-a4ad-11e9-92b8-d517a296d572.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No further comments.
