### PR TITLE
4454: Use strict comparison when checking key

### DIFF
--- a/modules/opensearch/includes/opensearch.search.inc
+++ b/modules/opensearch/includes/opensearch.search.inc
@@ -610,7 +610,8 @@ function opensearch_search_object_ids($ids) {
 
     foreach (opensearch_get_objects($ids, TRUE) as $pid => $object) {
       $faust = explode(':', $pid)[1];
-      if ($key = array_search($faust, $ids)) {
+      $key = array_search($faust, $ids);
+      if ($key !== FALSE) {
         $translated_ids[$faust] = $pid;
         unset($ids[$key]);
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4454

#### Description

The first item in the array will have key = 0. So it will evaluate to
FALSE if we don't use strict, which means incorrect translation if it's
not a basis-post.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
