### PR TITLE
4393: Fix broken tabs in rolltab

### DIFF
--- a/modules/ding_nodelist/js/rolltab.js
+++ b/modules/ding_nodelist/js/rolltab.js
@@ -45,7 +45,7 @@
       });
 
       // Add click event on selected tab to redirect user to selected tab node.
-      $(".ui-tabs-nav-item span").click(function () {
+      $(".ui-tabs-nav-item span[datasrc]").click(function () {
         window.location.href = $(this).attr('datasrc');
         return false;
       });


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4393 

#### Description

The code in the handler needs the data attribute and if it's missing it
will redirect to /undefined. This happens if you have a ding_nodelist
rolltab and a normal rolltab on the same page. The normal rolltab
doesn't have the data-attribute and the tabs will redirect to
/undefined, because the selector also targets those.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
