### PR TITLE
4169: Add opensearch specific facet description

### DIFF
--- a/modules/ding_facetbrowser/ding_facetbrowser.admin.inc
+++ b/modules/ding_facetbrowser/ding_facetbrowser.admin.inc
@@ -16,7 +16,7 @@ function ding_facetbrowser_settings($form_state) {
   $facets = variable_get('ding_facetbrowser_facets', array());
 
   $form['description'] = array(
-    '#markup' => '<p>' . t('Configure facets shown in the facetbrowser. Facet names can be found at <a href="http://oss.dbc.dk/wiki/bin/view/Databroend/OpenSearchDocIndexes">DBC wiki</a> and is usually named <em>facet.something</em>.') . '</p>',
+    '#markup' => '<p>' . t('Configure facets shown in the facetbrowser.') . '</p>',
   );
 
   $showcount = variable_get('ding_facetbrowser_showcount', 5);

--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -388,6 +388,26 @@ function opensearch_search_autocomplete_settings() {
 }
 
 /**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function opensearch_form_ding_facetbrowser_settings_alter(&$form, &$form_state) {
+  if (!$opensearch_url =  variable_get('opensearch_url', '')) {
+    return;
+  }
+
+  // If we have an opensearch URL add additional description giving link to
+  // supported facet names for the currents opensearch version.
+  // See: https://platform.dandigbib.org/issues/4169#note-6
+  $description = t('Supported facet names can be found at <a href="@url">DBC wiki</a> and is usually named <em>facet.something</em>.', [
+    '@url' => url($opensearch_url, [
+      'query' => [ 'showCqlFile' => TRUE ],
+      'fragment' => 'facet',
+    ])
+  ]);
+  $form['description']['#markup'] .= '<p>' . $description . '</p>';
+}
+
+/**
  * Implements hook_xautoload().
  *
  * Place our OpenSearch classes in the OpenSearch namespace.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4169

#### Description

Add the opensearch specific facet documentation link in a form alter in opensearch module instead of in ding_facetbrowser module.

Also make the link work for every version of opensearch by using the system's current opensearch_url.

As a side effect this splits up the description in two translatable strings which should be translated (doesn't look like the original string was translated by default):

- `t('Configure facets shown in the facetbrowser.')`
- `t('Supported facet names can be found at <a href="@url">DBC wiki</a> and is usually named <em>facet.something</em>.')`

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
