### PR TITLE
Update Scrutinizer: Fix stuck on "Pending — Installing Code"

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,17 +1,10 @@
-tools:
-  php_code_sniffer:
-    config:
-      standard: Drupal
-    extensions:
-      - module
-      - inc
-      - install
-      - test
-      - profile
-      - theme
-      - php
-  js_hint:
-    use_native_config: true
+build:
+  nodes:
+    analysis:
+      tests:
+        override:
+          - phpcs-run
+          - jshint-run
 
 build_failure_conditions:
   # No new issues allowed.

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="ding2">
+  <description>PHP CodeSniffer configuration ding2.</description>
+  <!-- Check all files in the current directory and below. -->
+  <file>.</file>
+  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt,md"/>
+  <config name="drupal_core_version" value="7"/>
+  <rule ref="Drupal"/>
+  <rule ref="DrupalPractice"/>
+</ruleset>


### PR DESCRIPTION
#### Link to issue

These changes doesn't affect site functionality, so I don't think it will be necessary with an issue on redmine?

#### Description

An attempt at fixing scutinizer. 

Since #1478 every PR has been hanging at "Pending — Installing Code" for the Scrutinizer tests.

I contacted Scrutinizer support team and got following answer: https://github.com/ding2/ding2/pull/1480#issuecomment-513203525

Apparently the tools sections is not supported anymore. Third party analysis tools will have to be used directly under the build section. Also using separate codesniffer config file.

https://scrutinizer-ci.com/docs/configuration
https://github.com/pfrenssen/coder#store-settings-in-a-phpcsxmldist-file

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
