### PR TITLE
4171 by Inlead: Proper fix for ctools panel title override checkbox.

### DIFF
--- a/ding2.make
+++ b/ding2.make
@@ -48,6 +48,8 @@ projects[ctools][patch][] = "https://www.drupal.org/files/issues/ctools-readd_ac
 projects[ctools][patch][] = "https://www.drupal.org/files/issues/deprecating_php4_style-2528736-23.patch"
 ; PHP7 - Uniform Variable Syntax updates are causing exported pages to not have names.
 projects[ctools][patch][] = "https://www.drupal.org/files/issues/ctools-uniform-variable-syntax-2635876-6.patch"
+; Check for jQuery differences regarding prop() vs attr().
+projects[ctools][patch][] = "https://git.drupalcode.org/project/ctools/commit/18385421a277097d8a92672808f656cc7470b69d.patch"
 
 projects[customerror][subdir] = "contrib"
 projects[customerror][version] = "1.4"

--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -256,18 +256,4 @@ function ding_ipe_filter_form_alter(&$form, &$form_state, $form_id) {
   if (strpos($form['#action'], '/panels/ajax/ipe/') !== FALSE && $form_state['modal'] == TRUE) {
     $form['#attached']['css'][] = drupal_get_path('module', 'ding_ipe_filter') . '/css/ding_ipe_filter.modal.css';
   }
-
-  // Process panels pane settings form.
-  if (isset($form_state["wrapper_callback"]) && $form_state["wrapper_callback"] == 'ctools_wizard_wrapper') {
-    // Hide "Title heading" select.
-    $form['override_title_heading']['#access'] = FALSE;
-    // Remove CTools "#dependecy" property.
-    unset($form['override_title_text']['#dependency']);
-    // Add native "#states" functionality.
-    $form['override_title_text']['#states'] = [
-      'visible' => [
-        ':input[name="override_title"]' => ['checked' => TRUE],
-      ],
-    ];
-  }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4171

#### Description

This is a proper fix for previous attempts of fixing the original issue.
See: https://github.com/ding2/ding2/pull/1434 and https://github.com/ding2/ding2/pull/1475

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/574498/62775434-4ec42a80-bab0-11e9-94cb-d1a39da1078f.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

In fact, a ctools module upgrade is suggested.