### PR TITLE
4467: Adgangsplatformen single signout

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -143,6 +143,7 @@ function ding_adgangsplatformen_get_configuration() {
     'urlAccessToken' => 'https://login.bib.dk/oauth/token/',
     'urlResourceOwnerDetails' => 'https://login.bib.dk/userinfo/',
     'urlLogout' => 'https://login.bib.dk/logout/',
+    'singleLogout' => true,
   ));
 
   // All-ways set redirect url (editing not allowed) in admin.
@@ -213,6 +214,7 @@ function ding_adgangsplatformen_logout($hooked = FALSE) {
   global $base_url;
 
   $config = ding_adgangsplatformen_get_configuration();
+  $singleLogout = $config['singleLogout'] ? 'true' : 'false';
   $token = $_SESSION['oauth2token'];
 
   // Generate logout request for the authorization service and send the request.
@@ -221,7 +223,7 @@ function ding_adgangsplatformen_logout($hooked = FALSE) {
     array(
       'external' => true,
       'query' => array(
-        'singlelogout' => 'true',
+        'singlelogout' => $singleLogout,
         'access_token' => $token,
         'redirect_uri' => $base_url,
       ),

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -144,6 +144,7 @@ function ding_adgangsplatformen_get_configuration() {
     'urlResourceOwnerDetails' => 'https://login.bib.dk/userinfo/',
     'urlLogout' => 'https://login.bib.dk/logout/',
     'singleLogout' => true,
+    'singleLogoutOrigin' => 'https://login.bib.dk/',
   ));
 
   // All-ways set redirect url (editing not allowed) in admin.
@@ -270,9 +271,11 @@ function ding_adgangsplatformen_logout_iframe() {
   // not.
   drupal_page_is_cacheable(FALSE);
   drupal_add_http_header('Status', "$status_code $reason");
+
+  $config = ding_adgangsplatformen_get_configuration();
   drupal_add_http_header(
     'X-Frame-Options',
-    'allow-from https://login.bib.dk'
+    'allow-from ' . $config['singleLogoutOrigin']
   );
 
   drupal_json_output(array('statusCode' => $status_code));

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -216,7 +216,16 @@ function ding_adgangsplatformen_logout($hooked = FALSE) {
   $token = $_SESSION['oauth2token'];
 
   // Generate logout request for the authorization service and send the request.
-  $logout_url = $config['urlLogout'] . '?access_token=' . $token . '&redirect_uri=' . $base_url;
+  $logout_url = url(
+    $config['urlLogout'],
+    array(
+      'external' => true,
+      'query' => array(
+        'singlelogout' => 'true',
+        'access_token' => $token,
+        'redirect_uri' => $base_url,
+      ),
+    ));
 
   if (!$hooked) {
     // If this was called from user registration reset the session.

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -8,7 +8,7 @@
 define('DING_ADGANGSPLATFORMEN_LOGIN_URL', 'adgangsplatformen/login');
 define('DING_ADGANGSPLATFORMEN_LOGOUT_URL', 'adgangsplatformen/logout');
 define('DING_ADGANGSPLATFORMEN_REDIRECT_URL', 'adgangsplatformen/callback');
-
+define('DING_ADGANGSPLATFORMEN_LOGOUT_IFRAME_URL', 'adgangsplaformen/logout/iframe');
 
 use \League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use \League\OAuth2\Client\Provider\GenericProvider;
@@ -61,6 +61,13 @@ function ding_adgangsplatformen_menu() {
   $items[DING_ADGANGSPLATFORMEN_LOGOUT_URL] = array(
     'title' => 'Log out',
     'page callback' => 'ding_adgangsplatformen_logout',
+    'access callback' => TRUE,
+    'type' => MENU_CALLBACK,
+  );
+
+  $items[DING_ADGANGSPLATFORMEN_LOGOUT_IFRAME_URL] = array(
+    'title' => 'Log out iframe',
+    'page callback' => 'ding_adgangsplatformen_logout_iframe',
     'access callback' => TRUE,
     'type' => MENU_CALLBACK,
   );
@@ -223,6 +230,41 @@ function ding_adgangsplatformen_logout($hooked = FALSE) {
   // Redirect the user to the logout url.
   header('Location:' . $logout_url);
   drupal_exit($logout_url);
+}
+
+/**
+ * Menu callback for iframes used by the single logout functionality.
+ *
+ * @see https://github.com/DBCDK/hejmdal/blob/master/docs/single-logout.md
+ */
+function ding_adgangsplatformen_logout_iframe() {
+  // Sites which iframe the single logout url can only access the content
+  // of the url. We cannot use default access control for this se we setup a
+  // response where the return code is mirrored in the content.
+  $status_code = 403;
+  $reason = 'Forbidden';
+  // Only log out SSO users. The user could in theory be logged in as normal.
+  // In this case Adgangsplatformen should not be allowed to logout the user.
+  if (ding_user_is_logged_in_with_sso()) {
+    $status_code = 200;
+    $reason = 'OK';
+
+    // We do not call user_logout_current_user() directly as this would cause
+    // ding_adgangsplatformen_logout() to redirect back to Adgangsplatformen.
+    session_destroy();
+  }
+
+  // Logout requests must never be cached. A cached response would cause
+  // Adgangsplatformen to think the user was logged out when it fact they were
+  // not.
+  drupal_page_is_cacheable(FALSE);
+  drupal_add_http_header('Status', "$status_code $reason");
+  drupal_add_http_header(
+    'X-Frame-Options',
+    'allow-from https://login.bib.dk'
+  );
+
+  drupal_json_output(array('statusCode' => $status_code));
 }
 
 /**

--- a/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
+++ b/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
@@ -71,5 +71,13 @@ function ding_adgangsplatformen_admin_settings_form($form, &$form_state) {
     '#default_value' => $default['urlLogout'],
   );
 
+  $form['ding_adgangsplatformen_settings']['singleLogout'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Single logout'),
+    '#description' => t('Use single logout when a user logs out of the site. This will log the user out of all sites where they are currently logged in using Adgangsplatformen.'),
+    '#return_value' => true,
+    '#default_value' => $default['singleLogout'],
+  );
+
   return system_settings_form($form);
 }

--- a/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
+++ b/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
@@ -73,10 +73,22 @@ function ding_adgangsplatformen_admin_settings_form($form, &$form_state) {
 
   $form['ding_adgangsplatformen_settings']['singleLogout'] = array(
     '#type' => 'checkbox',
-    '#title' => t('Single logout'),
-    '#description' => t('Use single logout when a user logs out of the site. This will log the user out of all sites where they are currently logged in using Adgangsplatformen.'),
-    '#return_value' => true,
+    '#title' => t('Enable single logout'),
+    '#return_value' => TRUE,
     '#default_value' => $default['singleLogout'],
+  );
+
+  $form['ding_adgangsplatformen_settings']['singleLogoutOrigin'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Iframe url'),
+    '#description' => t('The URI from which single logout can be performed.'),
+    '#default_value' => $default['singleLogoutOrigin'],
+    '#disabled' => TRUE,
+    '#states' => array(
+      'invisible' => array(
+        ':input[name="ding_adgangsplatformen_settings[singleLogout]"]' => array('checked' => FALSE),
+      ),
+    ),
   );
 
   return system_settings_form($form);

--- a/modules/ding_provider/connie/connie.auth.inc
+++ b/modules/ding_provider/connie/connie.auth.inc
@@ -7,7 +7,7 @@
 /**
  * Implements hook_auth_single_sign_on().
  */
-function fbs_auth_single_sign_on($name) {
+function connie_auth_single_sign_on($name) {
   $res = array();
 
   // Default password is the four last letters in the name.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4467

#### Description

This PR updates the Ding Adgangsplatformen module to support and use [single signout](https://github.com/DBCDK/hejmdal/blob/master/docs/single-logout.md).

A new endpoint is defined which should live up to the provided specification. The module will return status code 403 for users which should not support single signout because they have not authenticated via Adgangsplatformen. @vibjerg has nodded to this approach although it is not mentioned in the current documentation.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
