### PR TITLE
Fixed ding-list button padding

### DIFF
--- a/themes/ddbasic/sass/p2/p2-entity-buttons.scss
+++ b/themes/ddbasic/sass/p2/p2-entity-buttons.scss
@@ -158,6 +158,7 @@
   .buttons {
     list-style: none;
     margin: 0;
+    padding: 0;
     li a {
       @extend %button;
       float: right;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4114

#### Description

Removed default padding on .button ul element, that breaked the alignment with p2 list buttons.

#### Screenshot of the result

![Screenshot 2019-08-12 at 15 03 04](https://user-images.githubusercontent.com/30495061/62866912-5420af80-bd12-11e9-9a1f-48017c465406.png)

