### PR TITLE
4400: Avoid double rawurlencode on "Read more"-link

### DIFF
--- a/themes/ddbasic/templates/node/node--view-mode--search-result.tpl.php
+++ b/themes/ddbasic/templates/node/node--view-mode--search-result.tpl.php
@@ -84,6 +84,6 @@
 <div class="<?php print $classes; ?> view-mode-search-result">
   <div class="content"<?php print $content_attributes; ?>>
     <?php print render($content); ?>
-    <?php print l('<div class="button">' . t('Read more') . '</div>', $node_url, array('html' => TRUE)); ?>
+    <?php print l('<div class="button">' . t('Read more') . '</div>', 'node/' . $node->nid, array('html' => TRUE)); ?>
   </div>
 </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4400

#### Description

The $node_url variable has already been passed through Drupal's url function in template_preprocess_node(), which means it has been passed through rawurlencode once. So instead of using that, we manually construct the node uri and pass that to l-function.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
