### PR TITLE
3021: Fixed LUG migration issues

### DIFF
--- a/modules/ding_news/ding_news.install
+++ b/modules/ding_news/ding_news.install
@@ -22,7 +22,7 @@ function ding_news_install() {
 function ding_news_update_dependencies() {
   // Ding_news_update_7007 requires ding_paragraphs for the migration to work.
   $dependencies['ding_news'][7007] = array(
-    'ding2' => 7071,
+    'ding2' => 7072,
   );
 
   return $dependencies;

--- a/modules/ding_page/ding_page.install
+++ b/modules/ding_page/ding_page.install
@@ -13,7 +13,7 @@
 function ding_page_update_dependencies() {
   // Ding_page_update_7004 requires ding_paragraphs for the migration to work.
   $dependencies['ding_page'][7004] = array(
-    'ding2' => 7071,
+    'ding2' => 7072,
   );
 
   return $dependencies;

--- a/modules/ding_paragraphs/ding_paragraphs.module
+++ b/modules/ding_paragraphs/ding_paragraphs.module
@@ -206,7 +206,14 @@ function ding_paragraphs_migrate_content_body_field($old_content_field, $new_con
     $wrapper->save();
   }
 
-  $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  if ($sandbox['total'] != 0) {
+    $sandbox['#finished'] = ($sandbox['current'] / $sandbox['total']);
+  }
+  else {
+    // Handle case where the database don't have any content of the type given
+    // to the function. This will prevent never ending update loop.
+    $sandbox['#finished'] = 1;
+  }
 
   if ($sandbox['#finished'] === 1) {
     drupal_set_message(t('We processed @nodes nodes with body fields. Deleting @name...', array('@nodes' => $sandbox['total'], '@name' => $old_content_field)));


### PR DESCRIPTION
Fixed LUG migration issues

* Wrong update dependencies number to ding2 install
* Fixed division by zero when not content of type exists

#### Link to issue

https://platform.dandigbib.org/issues/3021

#### Description

There was an error running update hooks.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Re-used the old ticket form for this PR.