### PR TITLE
2996: Wider columns and larger base font

### DIFF
--- a/themes/ddbasic/sass/components/node/event.scss
+++ b/themes/ddbasic/sass/components/node/event.scss
@@ -327,7 +327,7 @@
         }
       }
       > .right {
-        @include span-columns(5);
+        @include span-columns(6);
 
         // Tablet
         @include media($tablet) {

--- a/themes/ddbasic/sass/components/node/news.scss
+++ b/themes/ddbasic/sass/components/node/news.scss
@@ -369,7 +369,7 @@
       }
     }
     .ding-news-right {
-      @include span-columns(5);
+      @include span-columns(6);
 
       // Tablet
       @include media($tablet) {

--- a/themes/ddbasic/sass/components/node/page.scss
+++ b/themes/ddbasic/sass/components/node/page.scss
@@ -100,7 +100,7 @@
     }
     .field-name-field-ding-page-lead,
     .field-name-field-ding-page-body {
-      @include span-columns(5 of 8);
+      @include span-columns(7 of 8);
       margin-bottom: 30px;
       p:last-child {
         margin-bottom: 0;

--- a/themes/ddbasic/sass/configuration/_typography.scss
+++ b/themes/ddbasic/sass/configuration/_typography.scss
@@ -28,7 +28,7 @@ $weight-normal: 400;
 @mixin font($name) {
   @if $name == 'base' {
     font-family: $font-family;
-    font-size: 14px;
+    font-size: 16px;
     line-height: 20px;
     font-weight: $weight-normal;
   }

--- a/themes/ddbasic/sass/p2/p2-entity-buttons.scss
+++ b/themes/ddbasic/sass/p2/p2-entity-buttons.scss
@@ -158,6 +158,7 @@
   .buttons {
     list-style: none;
     margin: 0;
+    padding: 0;
     li a {
       @extend %button;
       float: right;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/2996

#### Description

Changes to the scss to handle wider columns and larger base font

#### Screenshot of the result

<img width="1166" alt="Screenshot 2019-08-19 12 21 06" src="https://user-images.githubusercontent.com/332915/63258644-c64a4480-c27c-11e9-9a96-d04c74e032af.png">
<img width="1081" alt="Screenshot 2019-08-19 12 20 21" src="https://user-images.githubusercontent.com/332915/63258645-c64a4480-c27c-11e9-9182-31121e5dafc7.png">
<img width="1065" alt="Screenshot 2019-08-19 12 19 40" src="https://user-images.githubusercontent.com/332915/63258647-c64a4480-c27c-11e9-9139-abaad9017bb3.png">

#### Checklist

- [X] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
