### PR TITLE
3021: Fix LUG migration errors

### DIFF
--- a/modules/ding_eresource/ding_eresource.features.field_base.inc
+++ b/modules/ding_eresource/ding_eresource.features.field_base.inc
@@ -217,12 +217,6 @@ function ding_eresource_field_default_field_bases() {
     'settings' => array(
       'profile2_private' => FALSE,
     ),
-    'storage' => array(
-      'active' => 1,
-      'module' => 'virtual_field',
-      'settings' => array(),
-      'type' => 'virtual_field',
-    ),
     'translatable' => 0,
     'type' => 'ting_reference',
   );

--- a/modules/ding_paragraphs/ding_paragraphs.module
+++ b/modules/ding_paragraphs/ding_paragraphs.module
@@ -150,6 +150,14 @@ function ding_paragraphs_bpi_syndicate_node_form_alter(&$form, &$context) {
  *   Exception thrown if a field is missing.
  */
 function ding_paragraphs_migrate_content_body_field($old_content_field, $new_content_field, $paragraphs_ref_field, $paragraphs_type, $content_type, &$sandbox = array()) {
+  global $user;
+  // Run updates as user 1 to ensure workflow transitions are allowed when nodes
+  // are saved. Update hooks usually run as an anonymous user. Clear static cache
+  // to ensure that nothing belonging to the previous user lingers.
+  $current_user = $user;
+  $user = user_load(1);
+  drupal_static_reset();
+
   // Make sure we have somewhere to save the old body field.
   $empty_body = empty(field_info_instance('node', $old_content_field, $content_type));
   $empty_paragraphs_text = empty(field_info_instance('paragraphs_item', $new_content_field, $paragraphs_type));
@@ -220,4 +228,7 @@ function ding_paragraphs_migrate_content_body_field($old_content_field, $new_con
     field_delete_field($old_content_field);
     field_purge_batch(1000);
   }
+
+  $user = $current_user;
+  drupal_static_reset();
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3021

#### Description

When running update hooks on an existing site two errors occurred which prevented the update process from completing. 

This PR addresses these errors. Please read commit comments for additional commentary.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.