### PR TITLE
4126: Add alter_request hook

### DIFF
--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -46,7 +46,7 @@ function ting_field_search_panels_pane_content_alter($content, $pane, $args, $co
  * Helper function to set/unset the alter_request static variable.
  *
  * @param mixed $alter_request
- *   bool indication whether opensearch requests should be altered.
+ *   A boolean indication whether opensearch requests should be altered.
  *   NULL to unset again.
  */
 function ting_field_search_set_alter_request($alter_request) {
@@ -157,7 +157,7 @@ function ting_field_search_get_active_profile() {
 function ting_field_search_opensearch_pre_execute($request) {
   // Find out if we should alter the request.
   $result = module_invoke_all('ting_field_search_alter_request', $request);
-  // Return if anyone returned false or nobody returned true,
+  // Return if anyone returned false or nobody returned true.
   if (in_array(FALSE, $result) || !in_array(TRUE, $result)) {
     return;
   }

--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -152,20 +152,6 @@ function ting_field_search_get_active_profile() {
 }
 
 /**
- * Implements hook_opensearch_cache_key_alter().
- *
- * If we have an active profile and context, we use this hook to modify the
- * cache key, so that ting_cache can fetch/save the correct result.
- *
- * @see ting.api.php
- */
-function ting_field_search_opensearch_cache_key_alter(&$cid, $request) {
-  if ($profile = ting_field_search_get_active_profile()) {
-    $cid .= ':' . $profile->name;
-  }
-}
-
-/**
  * Implements hook_opensearch_pre_execute().
  */
 function ting_field_search_opensearch_pre_execute($request) {

--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -21,23 +21,15 @@ function ting_field_search_ctools_plugin_directory($module, $plugin) {
 
 /**
  * Implements hook_panels_pane_prerender().
- *
- * We use this hook as a main entry for activating profiles. All the targeted
- * request-types are made from panel panes and this panels hook has the perfect
- * timing while also being invoked for cached panes.
  */
 function ting_field_search_panels_pane_prerender($pane) {
-  $supported = array('search_result', 'ting_collection', 'ting_object');
-
-  if (in_array($pane->type, $supported)) {
-    $context = $pane->type;
-  }
-
-  // If we have a supported context, attempt to activate a profile.
-  if (isset($context) && ting_field_search_get_active_profile()) {
-    // Initialize the alteration of the ting request and cache_ting by also
-    // activating the context.
-    ting_field_search_set_context($context);
+  // On search pages we want to alter the main search request of the page and
+  // Also want to ensure every material request in result get its request
+  // altered. The most convenient way is to se the alter_request static variable
+  // to TRUE, while the search result pane is being renered and usnet when it's
+  // done in ting_field_search_panels_pane_content_alter().
+  if ($pane->type == 'search_result') {
+    ting_field_search_set_alter_request(TRUE);
   }
 }
 
@@ -45,12 +37,80 @@ function ting_field_search_panels_pane_prerender($pane) {
  * Implements hook_panels_panel_content_alter().
  */
 function ting_field_search_panels_pane_content_alter($content, $pane, $args, $contexts) {
-  if (ting_field_search_get_context()) {
-    // If we have an active context; end it now that the related content has
-    // been rendered. This prevents unwanted tampering with requests initiated
-    // by other panel panes, blocks etc.
-    ting_field_search_set_context(NULL);
+  if ($pane->type == 'search_result') {
+    ting_field_search_set_alter_request(NULL);
   }
+}
+
+/**
+ * Helper function to set/unset the alter_request static variable.
+ *
+ * @param mixed $alter_request
+ *   bool indication whether opensearch requests should be altered.
+ *   NULL to unset again.
+ */
+function ting_field_search_set_alter_request($alter_request) {
+  $static = &drupal_static('ting_field_search_alter_request', NULL);
+  $static = $alter_request;
+}
+
+/**
+ * Implements hook_ting_field_search_alter_request().
+ *
+ * @see ting_field_search_opensearch_pre_execute()
+ */
+function ting_field_search_ting_field_search_alter_request($request) {
+  $alter_request = NULL;
+
+  // For new we only support alteration of the following types of requests, so
+  // return early if it's not one of these.
+  $class = get_class($request);
+  $supported_classes = array(
+    'TingClientObjectRequest',
+    'TingClientCollectionRequest',
+    'TingClientSearchRequest',
+  );
+  if (!in_array($class, $supported_classes)) {
+    return FALSE;
+  }
+
+  // First check if the static alter_request variable is set. This can be
+  // switched on/off with ting_field_search_set_alter_request(). If alteration
+  // is dependent on timing from some hook, this can be more handy instead of
+  // implementing hook_ting_field_search_alter_request().
+  $alter_request = drupal_static('ting_field_search_alter_request', NULL);
+  if (isset($alter_request)) {
+    return $alter_request;
+  }
+
+  // Special handling for object and collection requests. The request should be
+  // altered if it's for the main material of the page.
+  if ($class == 'TingClientObjectRequest' || $class == 'TingClientCollectionRequest') {
+    $path = current_path();
+    if (strpos($path, 'ting/object') === 0 || strpos($path, 'ting/collection') === 0) {
+      $parts = explode('/', $path);
+      // Require precise path and non-empty id.
+      if (count($parts) == 3 && !empty($parts[2])) {
+        $path_pid = $parts[2];
+
+        // Different ways to get the pid from request.
+        $request_pid = NULL;
+        if ($class == 'TingClientObjectRequest') {
+          if (!empty($request->getObjectIds())) {
+            $object_ids = $request->getObjectIds();
+            $request_pid = array_shift($object_ids);
+          }
+        }
+        else {
+          $request_pid = $request->getObjectId();
+        }
+
+        $alter_request = ($path_pid === $request_pid);
+      }
+    }
+  }
+
+  return $alter_request;
 }
 
 /**
@@ -92,21 +152,6 @@ function ting_field_search_get_active_profile() {
 }
 
 /**
- * Set the current search request type when a profile was activated.
- */
-function ting_field_search_set_context($request_type) {
-  $static = &drupal_static(__FUNCTION__);
-  $static = $request_type;
-}
-
-/**
- * If a profile is active this returns the associated ting request type.
- */
-function ting_field_search_get_context() {
-  return drupal_static('ting_field_search_set_context');
-}
-
-/**
  * Implements hook_opensearch_cache_key_alter().
  *
  * If we have an active profile and context, we use this hook to modify the
@@ -115,9 +160,6 @@ function ting_field_search_get_context() {
  * @see ting.api.php
  */
 function ting_field_search_opensearch_cache_key_alter(&$cid, $request) {
-  if (!ting_field_search_get_context()) {
-    return;
-  }
   if ($profile = ting_field_search_get_active_profile()) {
     $cid .= ':' . $profile->name;
   }
@@ -127,18 +169,10 @@ function ting_field_search_opensearch_cache_key_alter(&$cid, $request) {
  * Implements hook_opensearch_pre_execute().
  */
 function ting_field_search_opensearch_pre_execute($request) {
-  if (!$context = ting_field_search_get_context()) {
-    return;
-  }
-
-  // Do we support the class of this request?
-  $class = get_class($request);
-  $supported_classes = array(
-    'TingClientObjectRequest',
-    'TingClientCollectionRequest',
-    'TingClientSearchRequest',
-  );
-  if (!in_array($class, $supported_classes)) {
+  // Find out if we should alter the request.
+  $result = module_invoke_all('ting_field_search_alter_request', $request);
+  // Return if anyone returned false or nobody returned true,
+  if (in_array(FALSE, $result) || !in_array(TRUE, $result)) {
     return;
   }
 
@@ -161,7 +195,7 @@ function ting_field_search_opensearch_pre_execute($request) {
   }
 
   // Following modification should only be made on search requests.
-  if ($class == 'TingClientSearchRequest') {
+  if (get_class($request) == 'TingClientSearchRequest') {
     // Users should always be allowed to search without entering keywords when
     // using a profile.
     if (empty($request->getQuery())) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4126

**THIS PR WILL NOT WORK WITHOUT** : https://github.com/ding2/ting-client/pull/30

#### Description

Ting field search needs to take care only to alter targeted requests in `opensearch_pre_execute()` implementation. For search pages that is all search requests performed in the `search_result` pane and for material views (ting_object/ting_collection) we want to target the request for the main object of the page.

This PR introduces two mechanism for controlling this:

1. A new `hook_ting_field_search_alter_request($request)` which modules can implement to help decide whether request should be altered by returning a boolean. If anyone returns FALSE the request will not altered. If none returned FALSE and at least one returns TRUE request will be altered.
2. A static variable `$alter_request` that can be used to turn altering on/off for a series of requests if that is more convenient. In ting_field_search' default implementation of `hook_ting_field_search_alter_request()` it handles the static variable and it should be set through `ting_field_search_set_alter_request()` 

**The motivation for these changes** 

In the current implementation only a static variable is used to control alteration. Unfortunately this is not sufficient: 

If using a VIP-profile on a ting_field_search profile, that has sources that is not enabled in the main VIP-profile it will result in a 404 when viewing materials from those sources with the profile (see screenshot below).

When viewing a ting_object or ting_collection the first request is made very early in the load function: `ting_object_load()`, so the ting_object/ting_collection pane is never rendered and our hook, which set the context, is not invoked. Unfortunately there's currently no hooks available that let's us do something before an entity is loaded.

I have take a different approach in `hook_ting_field_search_alter_request()` looking at the id of the TingObject og TingCollection request and comparing that to the id URL-argument of the page. If it's the same we tell it to alter the request.

#### Screenshot of error when viewing material that is not searchable with main VIP-profile

![4126-material-404](https://user-images.githubusercontent.com/5011234/63425736-8d8fa400-c411-11e9-9ebb-46a79ae26914.PNG)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

I have also removed an unneeded hook implementation. From commit message:

"After the work with SAL the timing of the the generation of the cache
key has changed, such this implementation is not needed anymore for
opensearch to be able to serve the correct response when using profiles.

Before hook_opensearch_pre_execute was invoked after generation of cache
key and as a result it didn't take into account any modification made in
pre_execute implementation. This couldn't be changed without moving a
lot of code around, so the easiest solution at that time was to
introduce a new cache_key hook, such that ting_field_search could modify
it based on an active profile.

Hence in this commit we remove ting_field_search cache_key_alter
implementation. Since it's not needed it's better to remove to reduce
complexity."

The question is: should we remove the alter cache key completely? I added this hook to work around the issue described above. I'm not sure if there's any other use cases for this. Maybe just leave it?
