### PR TITLE
4479: Fixed behat test of auto campaigns/news

### DIFF
--- a/tests/behat/features/bootstrap/CreateNewsContext.php
+++ b/tests/behat/features/bootstrap/CreateNewsContext.php
@@ -40,7 +40,6 @@ class CreateNewsContext implements Context {
    * Example: When I fill a news page with the following"
    *  | Title     | Batman            |
    *  | Lead      | Superhero returns |
-   *  | Body      | Go Batman!        |
    *  | Keywords  | superheroes       |
    *
    * @When /^(?:|I )fill a news page with the following:$/
@@ -56,10 +55,6 @@ class CreateNewsContext implements Context {
           $lead = $value;
           break;
 
-        case 'Body':
-          $body = $value;
-          break;
-
         case 'Category':
           $category = $value;
           break;
@@ -69,7 +64,7 @@ class CreateNewsContext implements Context {
       }
     }
 
-    $this->createNewsPage->fillNewsContent($title, $lead, $body, $category);
+    $this->createNewsPage->fillNewsContent($title, $lead, $category);
   }
 
   /**

--- a/tests/behat/features/bootstrap/Page/Common/CreateNewsPage.php
+++ b/tests/behat/features/bootstrap/Page/Common/CreateNewsPage.php
@@ -36,24 +36,17 @@ class CreateNewsPage extends Page {
    *   The news title.
    * @param string $lead
    *   The news lead.
-   * @param string $body
-   *   The new body.
    * @param string $category
    *   The news category.
    *
    * @throws \Behat\Mink\Exception\ElementNotFoundException
    *   If any of the form elements are not found.
    */
-  public function fillNewsContent($title, $lead, $body, $category) {
+  public function fillNewsContent($title, $lead, $category) {
     $form = $this->getElement('Create form');
 
     $form->fillField('edit-title', $title);
     $form->fillField('edit-field-ding-news-lead-und-0-value', $lead);
-
-    // For Wysiwyg fields we need to use CkeEditor to fill the fill
-    $bodyId = 'edit-field-ding-news-body-und-0-value';
-    $script = sprintf('CKEDITOR.instances["%s"].setData("%s");', $bodyId, $body);
-    $this->getSession()->executeScript($script);
 
     $typeSelect = $this->getElement('Category select');
     $typeSelect->selectOption($category);

--- a/tests/behat/features/campaign_plus/05-create-auto-campaign.feature
+++ b/tests/behat/features/campaign_plus/05-create-auto-campaign.feature
@@ -6,15 +6,13 @@ Feature: Automatic creation of campaigns
   Background:
     Given I am logged in as a cms user with the administrators role
 
-  @api @campaign_plus @regression @no_ci
-  # Disabled because our step definition currently does not support paragraphs
+  @api @campaign_plus @regression @cci
   Scenario: Create a news page with automatic campaign and show it on search results
     Given a "News Category" term with the name superhelte
     And I go to the create news page
     And I fill a news page with the following:
       | Title    | Behatman is back  |
       | Lead     | Superhero returns |
-      | Body     | Go Behatman!      |
       | Category | superhelte        |
     And I set the campaign keywords to "superhelte, usa"
     And I save the news page


### PR DESCRIPTION
Made behat test of auto campaigns/news compatible with paragraphs module

#### Link to issue

https://platform.dandigbib.org/issues/4479

#### Description

Feature #3021 "LAYOUT UDEN GRÆNSER" changed the body field for nes from a ckeditor wysiwyg field to a paragraphs module based setup. This broke the the behat testing for campaign plus. 

This PR fixes and re-enables the test. 

#### Screenshot of the result

N/A

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

N/A
