### PR TITLE
4494: Add agency to SSO login url

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -37,7 +37,7 @@ function ding_adgangsplatformen_init() {
 function ding_adgangsplatformen_menu() {
   $items = array();
 
-  $items['admin/config/ding/auth'] = array(
+  $items['admin/config/ding/adgangsplatformen'] = array(
     'title' => 'Adgangsplatform',
     'description' => 'Configure adgangsplatformen login',
     'page callback' => 'drupal_get_form',
@@ -46,7 +46,7 @@ function ding_adgangsplatformen_menu() {
     'file' => 'includes/ding_adgangsplatformen.admin.inc',
   );
 
-  $items['admin/config/ding/auth/settings'] = array(
+  $items['admin/config/ding/adgangsplatformen/settings'] = array(
     'title' => 'Settings',
     'type' => MENU_DEFAULT_LOCAL_TASK,
   );

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -143,7 +143,8 @@ function ding_adgangsplatformen_get_configuration() {
     'urlAccessToken' => 'https://login.bib.dk/oauth/token/',
     'urlResourceOwnerDetails' => 'https://login.bib.dk/userinfo/',
     'urlLogout' => 'https://login.bib.dk/logout/',
-    'singleLogout' => true,
+    'singleLogout' => TRUE,
+    'automaticallyAgency' => TRUE,
     'singleLogoutOrigin' => 'https://login.bib.dk/',
   ));
 
@@ -167,6 +168,8 @@ function ding_adgangsplatformen_get_configuration() {
  *   If required libraries are not loaded.
  */
 function ding_adgangsplatformen_generate_login_url($destination = '') {
+  $configuration = ding_adgangsplatformen_get_configuration();
+
   $provider = ding_adgangsplatformen_get_provider();
   $authorization_url = $provider->getAuthorizationUrl();
 
@@ -178,6 +181,14 @@ function ding_adgangsplatformen_generate_login_url($destination = '') {
   // Check if an identity provider have been set in the request.
   if (!empty($_REQUEST['idp'])) {
     $authorization_url .= '&idp=' . $_REQUEST['idp'];
+  }
+
+  // Add agency to the URL.
+  if (isset($configuration['automaticallyAgency']) && $configuration['automaticallyAgency']) {
+    $agency = variable_get('ting_agency', '');
+    if (!empty($agency)) {
+      $authorization_url .= '&agency=' . $agency;
+    }
   }
 
   return $authorization_url;

--- a/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
+++ b/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
@@ -78,6 +78,13 @@ function ding_adgangsplatformen_admin_settings_form($form, &$form_state) {
     '#default_value' => $default['singleLogout'],
   );
 
+  $form['ding_adgangsplatformen_settings']['automaticallyAgency'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Automatically select your library at adgangsplatformen (only if agency is detected)'),
+    '#return_value' => TRUE,
+    '#default_value' => $default['automaticallyAgency'],
+  );
+
   $form['ding_adgangsplatformen_settings']['singleLogoutOrigin'] = array(
     '#type' => 'textfield',
     '#title' => t('Iframe url'),


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4494

#### Description

Added option to add agency to the auth url to automatically select the library at adgangsplatformen.

#### Screenshot of the result

Added setting to `/admin/config/ding/adgangsplatformen` allow this new setting.

![Screenshot 2019-08-29 at 09 33 57](https://user-images.githubusercontent.com/111397/63920003-2c368900-ca40-11e9-8473-1265114bdfb0.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.
