### PR TITLE
4496: Ensure user page is not cached in browser

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -25,6 +25,38 @@ function ding_user_pathauto_alias_alter(&$alias, $context) {
 }
 
 /**
+ * Implements hook_preprocess_html().
+ */
+function ding_user_preprocess_html(&$variables) {
+  $args = arg();
+  if ($args[0] == 'user') {
+    // Set default title.
+    drupal_set_title('Account');
+
+    // Check if current user is logged in.
+    if (user_is_logged_in()) {
+      // Cache control for user pages.
+      drupal_add_http_header('Cache-Control', 'no-store, must-revalidate');
+      drupal_add_http_header('Pragma', 'no-cache');
+    }
+    elseif (count($args) == 1 || isset($args[1]) && in_array($args[1], array('login', 'password'))) {
+      // Redirect anonymous user to front page login. This is to prevent the
+      // library user from seeing /user, login and password page. Unless in
+      // maintenance_mode, there's no front page login when in maintenance_mode,
+      // and a redirect prevent login.
+      if (!variable_get('maintenance_mode', 0)) {
+        if (module_exists('ding_user_form')) {
+          // If user forms are enabled goto the login dropdown.
+          drupal_goto('', array('fragment' => 'login'));
+        }
+
+        drupal_goto('<front>');
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_ctools_plugin_directory().
  *
  * It simply tells panels where to find the .inc files that define various

--- a/modules/ding_user_form/ding_user_form.module
+++ b/modules/ding_user_form/ding_user_form.module
@@ -24,33 +24,6 @@ function ding_user_form_menu() {
 }
 
 /**
- * Implements hook_preprocess_html().
- */
-function ding_user_form_preprocess_html(&$variables) {
-  $args = arg();
-  if ($args[0] == 'user') {
-    // Set default title.
-    drupal_set_title('Account');
-
-    // Check if current user is logged in.
-    if (user_is_logged_in()) {
-      // Cache control for user pages.
-      drupal_add_http_header('Cache-Control', 'no-store, must-revalidate');
-      drupal_add_http_header('Pragma', 'no-cache');
-    }
-    elseif (count($args) == 1 || isset($args[1]) && in_array($args[1], array('login', 'password'))) {
-      // Redirect anonymous user to front page login. This is to prevent the
-      // library user from seeing /user, login and password page. Unless in
-      // maintenance_mode, there's no front page login when in maintenance_mode,
-      // and a redirect prevent login.
-      if (!variable_get('maintenance_mode', 0)) {
-        drupal_goto('', array('fragment' => 'login'));
-      }
-    }
-  }
-}
-
-/**
  * Implements hook_form_alter().
  *
  * Modify user login form to use our backend and changes the form fields types


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4496

#### Description

Set the old cache headers (to prevent browsers in caching user pages) by moving them from ding_user_form to ding_user.

Restore cache headers from before adgangsplatformen.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.