### PR TITLE
4507: Ensure session variable is removed completely

### DIFF
--- a/modules/ting_field_search/ting_field_search.module
+++ b/modules/ting_field_search/ting_field_search.module
@@ -671,6 +671,13 @@ function ting_field_search_search_block_submit($form, &$form_state) {
     // area where messages should have been.
     if (empty($messages)) {
       unset($_SESSION['messages']['error']);
+
+      // If there's no other types of messages left, ensure that the session
+      // variable is removed completely to avoid creation of unwanted session
+      // cookie.
+      if (empty($_SESSION['messages'])) {
+        unset($_SESSION['messages']);
+      }
     }
   }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4507

#### Description

Ensure that the messages session variable is removed completely when removing errors to allow empty search with profile.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
