### PR TITLE
4394: Only add original price if price is existing and has id

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -300,10 +300,14 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
           '#default_value' => $sale_end_at,
         );
 
-        $element['place2book']['prices_wrapper']['prices'][$key]['original_price'] = array(
-          '#type' => 'value',
-          '#value' => $price,
-        );
+        // If existing price: store the original on an internal form value for
+        // later use in submission.
+        if (isset($price->id)) {
+          $element['place2book']['prices_wrapper']['prices'][$key]['original_price'] = array(
+            '#type' => 'value',
+            '#value' => $price,
+          );
+        }
 
         $element['place2book']['prices_wrapper']['prices'][$key]['remove'] = array(
           '#type' => 'submit',


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4394

#### Description

We should only add reference to original price if the current price is
existing and have a price id in p2b. Otherwise our sync function will
try to update a non-existing price.

Note that we need to check for $price->id. It's not enough to verify
price is non-empty since it can be a clone which has data but no id.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
