### PR TITLE
4381: Disable Autologout once Adgangsplatformen is installed

### DIFF
--- a/modules/ding_base/ding_base.info
+++ b/modules/ding_base/ding_base.info
@@ -2,7 +2,6 @@ name = Ding base
 core = 7.x
 package = Ding!
 project = ding_base
-dependencies[] = autologout
 dependencies[] = ctools
 dependencies[] = ding_permissions
 dependencies[] = globalredirect

--- a/modules/ding_base/ding_base.install
+++ b/modules/ding_base/ding_base.install
@@ -89,6 +89,13 @@ function ding_base_update_dependencies() {
     // to Drupal default (1.4) if no specific admin theme version has been set.
     'jquery_update' => 7001,
   );
+  // Disable Autologout module. Autologout combined with single signout from
+  // Adgangsplatformen will log the user out of all platforms automatically when
+  // inactive on one of them.
+  $dependencies['ding_base'][7008] = array(
+    // Enables Adgangsplatformen.
+    'ding2' => 7069,
+  );
 
   return $dependencies;
 }
@@ -200,4 +207,11 @@ function ding_base_update_7006() {
  */
 function ding_base_update_7007() {
   _jquery_update_set_theme_version('seven', '1.7');
+}
+
+/**
+ * Disable Autologout module.
+ */
+function ding_base_update_7008() {
+  module_disable(['autologout']);
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4381

#### Description

Autologout in combination with single signout from Adgangsplatformen
will log out the user from all platforms when inactive on one. That
is not helpful - especially in combination with platforms used for
passive media consumption.

We do not remove the module entirely as some libraries may want to
retain the autologout functionality. They will have to reenable it
themselves subsequently.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.