### PR TITLE
4399: Remove ticket links from existing passive events

### DIFF
--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -197,7 +197,7 @@ function ding_place2book_update_7007(&$sandbox) {
   $query = new EntityFieldQuery();
   $query->entityCondition('entity_type', 'node')
     ->entityCondition('bundle', 'ding_event')
-    ->fieldCondition('field_ding_event_date', 'value2', gmdate('Y-m-d H:i:s'), '>')
+    ->fieldCondition('field_ding_event_date', 'value2', gmdate(DATE_FORMAT_DATETIME), '>')
     ->fieldCondition('field_place2book', 'synchronize', '1', '=')
     ->fieldCondition('field_place2book', 'event_id', 'NULL', '!=')
     ->fieldCondition('field_place2book', 'event_maker_id', 'NULL', '!=');

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -219,7 +219,8 @@ function ding_place2book_update_7007(&$sandbox) {
   $chunk = array_slice($nodes, $sandbox['processed'], $limit);
 
   foreach ($chunk as $nid => $node) {
-    list($event_id, $event_maker_id) = array_values($field_place2book);
+    $field_place2book = field_get_items('node', $node, 'field_place2book');
+    list($event_id, $event_maker_id) = array_values($field_place2book[0]);
     try {
       $p2b = ding_place2book_instance();
       $event = $p2b->getEvent($event_maker_id, $event_id);

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -219,7 +219,7 @@ function ding_place2book_update_7007(&$sandbox) {
   $limit = 10;
   $chunk = array_slice($nodes, $sandbox['processed'], $limit);
 
-  foreach($chunk as $nid => $node) {
+  foreach ($chunk as $nid => $node) {
     list($event_id, $event_maker_id) = array_values($field_place2book);
     try {
       $p2b = ding_place2book_instance();
@@ -235,7 +235,7 @@ function ding_place2book_update_7007(&$sandbox) {
       watchdog_exception('ding_place2book', $ex, t('Error appeared when removing ticket link for existing passive event. Event ID: !event_id, Event Maker ID: !event_maker_id, NID: !nid'), [
         '!event_id' => $event_id,
         '!event_maker_id' => $event_maker_id,
-        '!nid' => $node->nid,
+        '!nid' => $nid,
       ]);
     }
   }
@@ -246,7 +246,7 @@ function ding_place2book_update_7007(&$sandbox) {
     $sandbox['#finished'] = $sandbox['processed'] / $sandbox['total'];
   }
   else {
-    $sandbox['#finished'] =  TRUE;
+    $sandbox['#finished'] = TRUE;
   }
 
   return t('Status: !processed / !total', [

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -203,7 +203,6 @@ function ding_place2book_update_7007(&$sandbox) {
     ->fieldCondition('field_place2book', 'event_maker_id', 'NULL', '!=');
 
   $result = $query->execute();
-  file_put_contents('/app/debug/result-2.txt', print_r($result, TRUE), FILE_APPEND);
 
   if (isset($result['node'])) {
     $nodes = entity_load('node', array_keys($result['node']));

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -178,10 +178,79 @@ function ding_place2book_update_7005(&$sandbox) {
   variable_del('ding_place2book_category_mappings');
 }
 
-
 /**
  * Enable migration module for existing sites.
  */
 function ding_place2book_update_7006() {
   module_enable(array('ding_place2book_migrate'));
+}
+
+/**
+ * Remove ticket links from existing passive events.
+ */
+function ding_place2book_update_7007(&$sandbox) {
+  $nodes = [];
+
+  // Get the ding_event nodes we need to consider. We only consider those with
+  // an event end-date that hasn't passed. We can't make any assumptions about
+  // whether the nodes are publsihed or not, so no condition on $node->status.
+  $query = new EntityFieldQuery();
+  $query->entityCondition('entity_type', 'node')
+    ->entityCondition('bundle', 'ding_event')
+    ->fieldCondition('field_ding_event_date', 'value2', gmdate('Y-m-d H:i:s'), '>');
+
+  $result = $query->execute();
+  if (isset($result['node'])) {
+    $nodes = entity_load('node', array_keys($result['node']));
+  }
+
+  if (!isset($sandbox['processed'])) {
+    $sandbox['processed'] = 0;
+    $sandbox['total'] = count($nodes);
+  }
+
+  // Potentially we have to make request to p2b for all fetched ding_event nodes
+  // so keep the amount of nodes we process each run low.
+  $limit = 10;
+  $chunk = array_slice($nodes, $sandbox['processed'], $limit);
+
+  foreach($chunk as $nid => $node) {
+    // Avoid making request if this node isn't synchronized.
+    if (!$field_place2book = ding_place2book_is_ding_event_node_synchronized($node)) {
+      continue;
+    }
+
+    list($event_id, $event_maker_id) = array_values($field_place2book);
+    try {
+      $p2b = ding_place2book_instance();
+      $event = $p2b->getEvent($event_maker_id, $event_id);
+
+      if (!empty($event->passive)) {
+        $node_wrapper = entity_metadata_wrapper('node', $node);
+        $node_wrapper->field_ding_event_ticket_link->set(NULL);
+        node_save($node);
+      }
+    }
+    catch (Exception $ex) {
+      watchdog_exception('ding_place2book', $ex, t('Error appeared when removing ticket link for existing passive event. Event ID: !event_id, Event Maker ID: !event_maker_id, NID: !nid'), [
+        '!event_id' => $event_id,
+        '!event_maker_id' => $event_maker_id,
+        '!nid' => $node->nid,
+      ]);
+    }
+  }
+
+  $sandbox['processed'] += count($chunk);
+
+  if (!empty($nodes)) {
+    $sandbox['#finished'] = $sandbox['processed'] / $sandbox['total'];
+  }
+  else {
+    $sandbox['#finished'] =  TRUE;
+  }
+
+  return t('Status: !processed / !total', [
+    '!processed' => $sandbox['processed'],
+    '!total' => $sandbox['total'],
+  ]);
 }

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -197,9 +197,14 @@ function ding_place2book_update_7007(&$sandbox) {
   $query = new EntityFieldQuery();
   $query->entityCondition('entity_type', 'node')
     ->entityCondition('bundle', 'ding_event')
-    ->fieldCondition('field_ding_event_date', 'value2', gmdate('Y-m-d H:i:s'), '>');
+    ->fieldCondition('field_ding_event_date', 'value2', gmdate('Y-m-d H:i:s'), '>')
+    ->fieldCondition('field_place2book', 'synchronize', '1', '=')
+    ->fieldCondition('field_place2book', 'event_id', 'NULL', '!=')
+    ->fieldCondition('field_place2book', 'event_maker_id', 'NULL', '!=');
 
   $result = $query->execute();
+  file_put_contents('/app/debug/result-2.txt', print_r($result, TRUE), FILE_APPEND);
+
   if (isset($result['node'])) {
     $nodes = entity_load('node', array_keys($result['node']));
   }
@@ -215,11 +220,6 @@ function ding_place2book_update_7007(&$sandbox) {
   $chunk = array_slice($nodes, $sandbox['processed'], $limit);
 
   foreach($chunk as $nid => $node) {
-    // Avoid making request if this node isn't synchronized.
-    if (!$field_place2book = ding_place2book_is_ding_event_node_synchronized($node)) {
-      continue;
-    }
-
     list($event_id, $event_maker_id) = array_values($field_place2book);
     try {
       $p2b = ding_place2book_instance();

--- a/modules/ding_place2book/ding_place2book.install
+++ b/modules/ding_place2book/ding_place2book.install
@@ -194,18 +194,23 @@ function ding_place2book_update_7007(&$sandbox) {
   // Get the ding_event nodes we need to consider. We only consider those with
   // an event end-date that hasn't passed. We can't make any assumptions about
   // whether the nodes are publsihed or not, so no condition on $node->status.
-  $query = new EntityFieldQuery();
-  $query->entityCondition('entity_type', 'node')
-    ->entityCondition('bundle', 'ding_event')
-    ->fieldCondition('field_ding_event_date', 'value2', gmdate(DATE_FORMAT_DATETIME), '>')
-    ->fieldCondition('field_place2book', 'synchronize', '1', '=')
-    ->fieldCondition('field_place2book', 'event_id', 'NULL', '!=')
-    ->fieldCondition('field_place2book', 'event_maker_id', 'NULL', '!=');
+  if (!isset($sandbox['nodes'])) {
+    $query = new EntityFieldQuery();
+    $query->entityCondition('entity_type', 'node')
+      ->entityCondition('bundle', 'ding_event')
+      ->fieldCondition('field_ding_event_date', 'value2', gmdate(DATE_FORMAT_DATETIME), '>')
+      ->fieldCondition('field_place2book', 'synchronize', '1', '=')
+      ->fieldCondition('field_place2book', 'event_id', 'NULL', '!=')
+      ->fieldCondition('field_place2book', 'event_maker_id', 'NULL', '!=');
 
-  $result = $query->execute();
+    $result = $query->execute();
 
-  if (isset($result['node'])) {
-    $nodes = entity_load('node', array_keys($result['node']));
+    if (isset($result['node'])) {
+      $nodes = array_keys($result['node']);
+    }
+  }
+  else {
+    $nodes = $sandbox['nodes'];
   }
 
   if (!isset($sandbox['processed'])) {
@@ -217,6 +222,7 @@ function ding_place2book_update_7007(&$sandbox) {
   // so keep the amount of nodes we process each run low.
   $limit = 10;
   $chunk = array_slice($nodes, $sandbox['processed'], $limit);
+  $chunk = entity_load('node', $chunk);
 
   foreach ($chunk as $nid => $node) {
     $field_place2book = field_get_items('node', $node, 'field_place2book');


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4399

#### Description

In the [previous PR](https://github.com/ding2/ding2/pull/1482) we have ensured that we don't put the p2b sales URL in the ticket link field for passive events.

However, there still might be some existing passive events with ticket links, so in this PR we add an update function which find all these and ensure that the ticket link is removed. Since this can potentially result in several request to p2b API, we use the batch API to ensure no timeouts and to give partial updates after each batch.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
