### PR TITLE
3543: Fixed handling of paragraph assets in BPI content

### DIFF
--- a/modules/ding_paragraphs/ding_paragraphs.module
+++ b/modules/ding_paragraphs/ding_paragraphs.module
@@ -101,7 +101,7 @@ function ding_paragraphs_bpi_convert_to_bpi_alter(&$bpi_content, $entity, array 
       if (isset($context['with_images'])) {
         $assets = $helper->replaceFilesWithUrls($paragraphs_data);
         if (!empty($assets)) {
-          $bpi_content['assets'] += $assets;
+          $bpi_content['assets'] = array_merge($bpi_content['assets'], $assets);
         }
       }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3543

#### Description

Paragraphs images are not added correctly to assets when pushing content to the BPI web service (using `+` rather than `array_merge` will potentially discard some paragraph images).

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
