### PR TITLE
4095: Improve contrast for opening hour toggle.

### DIFF
--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -467,19 +467,19 @@ a.opening-hours-toggle {
   &::after {
     right: 0;
     top: 0;
-    background-color: $grey-dark;
-    color: $white-opacity-dark;
+    background-color: $grey-darker;
+    color: $white;
   }
   &.collapsed {
     &::after {
       content: "\e901";
       background-color: $grey;
-      color: $charcoal-opacity-dark;
+      color: $charcoal;
     }
     &:hover {
       &::after {
-        background-color: $grey-dark;
-        color: $white-opacity-dark;
+        background-color: $grey-darker;
+        color: $white;
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4095

#### Description

See https://upgrade-fbs.ddbcms.dk/biblioteker

Currently not passing proper AAA contrast ratio:

<img width="588" alt="Screenshot 2019-09-06 at 10 33 40" src="https://user-images.githubusercontent.com/12376583/64413482-daba7980-d091-11e9-95e0-4102b6d5650a.png">

My changes fixes it:
<img width="615" alt="Screenshot 2019-09-06 at 10 33 47" src="https://user-images.githubusercontent.com/12376583/64413500-e73ed200-d091-11e9-8298-b4fd3f6d73a1.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
