### PR TITLE
3543: Fixed argument for bpi_validate_material

### DIFF
--- a/modules/ding_paragraphs/DingParagraphsBPIHelper.php
+++ b/modules/ding_paragraphs/DingParagraphsBPIHelper.php
@@ -251,11 +251,7 @@ class DingParagraphsBPIHelper {
    *   Id of validated material or FALSE on invalid material.
    */
   private function validateMaterialId($material_id) {
-    preg_match('/[^\:]+\:\s?(?P<id>.*)/', $material_id, $matches);
-    if (!isset($matches['id'])) {
-      return FALSE;
-    }
-    return bpi_validate_material($matches['id']);
+    return bpi_validate_material($material_id);
   }
 
   /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3543

#### Description

Materials shared via the BPI web service are validated when syndicating content, but apparently the signature of `bpi_validate_material` which is used for validation has been changed.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

The doc block for `bpi_validate_material` (https://github.com/ding2/ding2/blob/master/modules/bpi/bpi.module#L952-L962) states that `$ting_object_id` should be a faust number (“the number after the colon” as I understand it). Is this correct?

It seems that a full object id, e.g. `870970-basis:03258351` is required. 