### PR TITLE
3800: Interlibrary loans (changes to core for the ding_ill module)

### DIFF
--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -251,10 +251,6 @@ function ding_availability_holdings($provider_ids) {
           'There are @count users in queue to loan the material.');
       }
 
-      if ($total_and_ordered_count == 0) {
-        ddbasic_body_class('no-holdings');
-      }
-
       // Theme the output.
       $item['html'] = theme('ding_holdings', $variables);
     }

--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -251,6 +251,10 @@ function ding_availability_holdings($provider_ids) {
           'There are @count users in queue to loan the material.');
       }
 
+      if ($total_and_ordered_count == 0) {
+        ddbasic_body_class('no-holdings');
+      }
+
       // Theme the output.
       $item['html'] = theme('ding_holdings', $variables);
     }

--- a/modules/ding_availability/js/ding_availability_labels.js
+++ b/modules/ding_availability/js/ding_availability_labels.js
@@ -139,7 +139,7 @@
 
           if (group.length === 0) {
             var msg = Drupal.t('Not available');
-            if (Drupal.settings.ding_ill) {
+            if (Drupal.settings.hasOwnProperty('ding_ill')) {
               var msg = Drupal.t('Order from another library');
             }
             group = $('<p class="js-unavailable">' + msg + ': </p>');

--- a/modules/ding_availability/js/ding_availability_labels.js
+++ b/modules/ding_availability/js/ding_availability_labels.js
@@ -138,7 +138,11 @@
           group = $('.js-unavailable', groups_wrapper);
 
           if (group.length === 0) {
-            group = $('<p class="js-unavailable">' + Drupal.t('Not available') + ': </p>');
+            var msg = Drupal.t('Not available');
+            if (Drupal.settings.ding_ill) {
+              var msg = Drupal.t('Order from another library');
+            }
+            group = $('<p class="js-unavailable">' + msg + ': </p>');
             groups_wrapper.append(group);
           }
         }

--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -162,15 +162,17 @@ body > .ding2-site-template {
   padding: 20px 80px 14px 15px;
   border-radius: $round-corner;
   &.reserve-button,
-  &.button-see-online {
+  &.button-see-online,
+  &.button-order {
     background-color: $black;
     color: $white;
-  }
-  &:hover {
-    background-color: $grey-dark;
-    color: $white;
+    &:hover {
+      background-color: $grey-dark;
+      color: $white;
+    }
   }
   &.button-see-online,
+  &.button-order,
   &.other-formats {
     display: block;
   }

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -712,6 +712,9 @@
         clear: both;
         padding: 28px 0 26px;
         border-top: 1px solid $charcoal-opacity-light;
+        .no-holdings & {
+          display: none;
+        }
       }
       .group-material-details {
         clear: both;

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -149,7 +149,8 @@
           left: 20px;
         }
         &.reserve-button,
-        &.button-see-online {
+        &.button-see-online,
+        &.button-order {
           right: 20px;
         }
 
@@ -666,7 +667,8 @@
         margin-top: 30px;
       }
       .action-button,
-      .button-see-online {
+      .button-see-online,
+      .button-order {
 
         padding-right: 15px;
         margin-bottom: 15px;

--- a/themes/ddbasic/sass/p2/p2-entity-buttons.scss
+++ b/themes/ddbasic/sass/p2/p2-entity-buttons.scss
@@ -158,7 +158,7 @@
   .buttons {
     list-style: none;
     margin: 0;
-    padding: 0;
+    padding-left: 0;
     li a {
       @extend %button;
       float: right;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3800

#### Description

* Hides holdings when not available
* Styling for new button for interlibrary loans
* Shows a message when the material is available for interlibrary loan

#### Screenshot of the result
![Screenshot 2019-09-09 at 16 26 24](https://user-images.githubusercontent.com/514013/64539367-a4455e80-d31e-11e9-9bd8-42a7c2b71caa.png)
![Screenshot 2019-09-09 at 16 23 50](https://user-images.githubusercontent.com/514013/64539374-a8717c00-d31e-11e9-8024-78fe1668103d.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Buttons looks a bit odd on my local environment, however, this problem shows up without any changes from the current master branch:

![Screenshot 2019-09-09 at 15 49 19](https://user-images.githubusercontent.com/514013/64539552-f8504300-d31e-11e9-98c6-9b66d57b8b7c.png)
