### PR TITLE
4496: Allow access to /user

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -49,8 +49,6 @@ function ding_user_preprocess_html(&$variables) {
           // If user forms are enabled goto the login dropdown.
           drupal_goto('', array('fragment' => 'login'));
         }
-
-        drupal_goto('<front>');
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4496

#### Description

When using adgangsplatformen the /user should not redirect the frontpage for non logged in users as this page is used by all non-provider.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
