### PR TITLE
4173 by Inlead: Make sure default panel is reverted upon change.

### DIFF
--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
@@ -119,3 +119,16 @@ function ding_sections_term_panel_purge_variant() {
     page_manager_delete_task_handler($handler);
   }
 }
+
+/**
+ * Restore base panel page to default settings.
+ */
+function ding_sections_term_panel_update_7001(&$sandbox) {
+  $handler = page_manager_load_task_handler('term_view', '', 'term_section_panel_context');
+  if ($handler) {
+    page_manager_delete_task_handler($handler);
+  }
+
+  $handler = ding_sections_term_panel_get_handler();
+  page_manager_save_task_handler($handler);
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4173

#### Description

Added hook_update() to restore Section "base" panel page settings to defaults from code.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.