### PR TITLE
4514: Ensure that admin users can not be logged out

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -106,6 +106,13 @@ function ding2_install() {
     module_disable(array('overlay'));
   }
 
+  // Enable ding_user_form to allow provider login. It's enabled here as
+  //new/local sites should use "user form" and updated production should via
+  // update hooks turn on adgangsplatformen.
+  if (module_exists('ding_user_form')) {
+    module_enable(array('ding_user_form'));
+  }
+
   // Ignore any rebuild messages.
   node_access_needs_rebuild(FALSE);
 

--- a/ding2.install
+++ b/ding2.install
@@ -107,12 +107,10 @@ function ding2_install() {
   }
 
   // Enable ding_user_form to allow provider login. It's enabled here as
-  //new/local sites should use "user form" and updated production should via
+  // new/local sites should use "user form" and updated production should via
   // update hooks turn on adgangsplatformen.
-  if (module_exists('ding_user_form')) {
-    module_enable(array('ding_user_form'));
-  }
-
+  module_enable(array('ding_user_form'));
+  
   // Ignore any rebuild messages.
   node_access_needs_rebuild(FALSE);
 

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.install
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.install
@@ -14,3 +14,23 @@ function ding_adgangsplatformen_install() {
     ->condition('name', 'ding_adgangsplatformen', '=')
     ->execute();
 }
+
+/**
+ * Implements hook_enable().
+ *
+ * Disable ding_user_form to ensure that non-provider users can login.
+ */
+function ding_adgangsplatformen_enable() {
+  if (module_exists('ding_user_form')) {
+    module_disable(array('ding_user_form'), TRUE);
+  }
+}
+
+/**
+ * Disable ding_user_forms, if enabled.
+ */
+function ding_adgangsplatformen_update_7100() {
+  if (module_exists('ding_user_form')) {
+    module_disable(array('ding_user_form'), TRUE);
+  }
+}

--- a/modules/ding_user_form/ding_user_form.install
+++ b/modules/ding_user_form/ding_user_form.install
@@ -1,0 +1,16 @@
+<?php
+/**
+ * @file
+ * Handle module installation.
+ */
+
+/**
+ * Implements hook_install().
+ *
+ * Disable ding_adgangsplatformen to ensure that non-provider users can login.
+ */
+function ding_user_form_enable() {
+  if (module_exists('ding_adgangsplatformen')) {
+    module_disable(array('ding_adgangsplatformen'), TRUE);
+  }
+}

--- a/modules/ding_user_form/ding_user_form.install
+++ b/modules/ding_user_form/ding_user_form.install
@@ -6,7 +6,7 @@
  */
 
 /**
- * Implements hook_install().
+ * Implements hook_enable().
  *
  * Disable ding_adgangsplatformen to ensure that non-provider users can login.
  */

--- a/modules/ding_user_form/ding_user_form.install
+++ b/modules/ding_user_form/ding_user_form.install
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Handle module installation.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4514

#### Description

If you get `ding_adgangsplatformen` enabled but not disabled `ding_user_form` and the other way around you will end up with a site that non-provider users can't login.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments