### PR TITLE
4523 by Inlead: Fix nodelist carousel slick initialization.

### DIFF
--- a/modules/ding_nodelist/js/carousel.js
+++ b/modules/ding_nodelist/js/carousel.js
@@ -13,23 +13,21 @@
           }
         });
 
-        if ($(this).find('.ding_nodelist-items').hasClass('slick-initialized') === false) {
-          $(this).find('.ding_nodelist-items').slick({
-            nextArrow: '<i class="icon-next"></i>',
-            prevArrow: '<i class="icon-prev"></i>',
-            autoplay: true,
-            speed: 500,
-            autoplaySpeed: delay,
-            responsive: true,
-            dots: true,
-            infinite: true,
-            slidesToScroll: 1,
-            slidesToShow: 1,
-            customPaging: function (slick, index) {
-              return '<a>' + (index + 1) + '</a>';
-            }
-          });
-        }
+        $(this).find('.ding_nodelist-items:not(.slick-initialized)').slick({
+          nextArrow: '<i class="icon-next"></i>',
+          prevArrow: '<i class="icon-prev"></i>',
+          autoplay: true,
+          speed: 500,
+          autoplaySpeed: delay,
+          responsive: true,
+          dots: true,
+          infinite: true,
+          slidesToScroll: 1,
+          slidesToShow: 1,
+          customPaging: function (slick, index) {
+            return '<a>' + (index + 1) + '</a>';
+          }
+        });
       });
     }
   };

--- a/modules/ding_nodelist/js/carousel.js
+++ b/modules/ding_nodelist/js/carousel.js
@@ -13,21 +13,23 @@
           }
         });
 
-        $(this).find('.ding_nodelist-items').slick({
-          nextArrow: '<i class="icon-next"></i>',
-          prevArrow: '<i class="icon-prev"></i>',
-          autoplay: true,
-          speed: 500,
-          autoplaySpeed: delay,
-          responsive: true,
-          dots: true,
-          infinite: true,
-          slidesToScroll: 1,
-          slidesToShow: 1,
-          customPaging: function(slick, index) {
-            return '<a>' + (index + 1) + '</a>';
-          }
-        });
+        if ($(this).find('.ding_nodelist-items').hasClass('slick-initialized') === false) {
+          $(this).find('.ding_nodelist-items').slick({
+            nextArrow: '<i class="icon-next"></i>',
+            prevArrow: '<i class="icon-prev"></i>',
+            autoplay: true,
+            speed: 500,
+            autoplaySpeed: delay,
+            responsive: true,
+            dots: true,
+            infinite: true,
+            slidesToScroll: 1,
+            slidesToShow: 1,
+            customPaging: function (slick, index) {
+              return '<a>' + (index + 1) + '</a>';
+            }
+          });
+        }
       });
     }
   };


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4523

#### Description

Error thrown by ding_nodelist carousel on Slick functionality initialization was breaking Ding IPE js functionality execution.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.