### PR TITLE
4161: Implement TOS active accept

### DIFF
--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -79,6 +79,7 @@ function ding_debt_debts_form($form, &$form_state, $debts, $has_invoiced_fees, $
     $form['accept_terms'] = array(
       '#type' => 'checkbox',
       '#title' => t('I accept the terms of service'),
+      '#required' => TRUE,
     );
 
     $provider = ding_provider_get_provider_module_name('payment');

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -234,4 +234,3 @@ function ding_debt_debts_perform_payment($debts, $amount, &$form_state) {
     }
   }
 }
-

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -76,6 +76,11 @@ function ding_debt_debts_form($form, &$form_state, $debts, $has_invoiced_fees, $
       '#value' => $debts,
     );
 
+    $form['accept_terms'] = array(
+      '#type' => 'checkbox',
+      '#title' => t('I accept the terms of service'),
+    );
+
     $provider = ding_provider_get_provider_module_name('payment');
     if (!empty($provider)) {
       $form['pay_selected'] = array(
@@ -84,6 +89,11 @@ function ding_debt_debts_form($form, &$form_state, $debts, $has_invoiced_fees, $
         '#value' => t('Pay selected debts'),
         '#suffix' => '</div>',
         '#submit' => array('ding_debt_debts_form_submit_pay_selected'),
+        '#states' => array(
+          'disabled' => array(
+            ':input[name="accept_terms"]' => array('checked' => FALSE),
+          ),
+        ),
       );
 
       $form['pay_all'] = array(
@@ -92,6 +102,11 @@ function ding_debt_debts_form($form, &$form_state, $debts, $has_invoiced_fees, $
         '#value' => t('Pay all debts'),
         '#suffix' => '</div>',
         '#submit' => array('ding_debt_debts_form_submit_pay_all'),
+        '#states' => array(
+          'disabled' => array(
+            ':input[name="accept_terms"]' => array('checked' => FALSE),
+          ),
+        ),
       );
     }
   }

--- a/themes/ddbasic/sass/components/form/form-class.scss
+++ b/themes/ddbasic/sass/components/form/form-class.scss
@@ -12,6 +12,13 @@
   input[type=submit] {
     width: auto;
     margin-bottom: 20px;
+
+    &:disabled,
+    &:disabled:hover {
+      background-color: $grey;
+      color: $grey-dark;
+      cursor: not-allowed;
+    }
   }
   .form-item {
     max-width: 400px;
@@ -86,6 +93,12 @@
     width: auto;
     padding-right: 80px;
   }
+}
+
+// Fix for TOS accept checkbox in ding_debts form. The materials above the
+// checkbox is floated so we need to clear for it to appear correctly.
+.pane-debts .form-item-accept-terms label {
+  clear: both;
 }
 
 .node-ding-event {

--- a/translations/da.po
+++ b/translations/da.po
@@ -67546,3 +67546,7 @@ msgstr "Gratis"
 msgctxt "Rating"
 msgid "Rate this !number / 5 stars"
 msgstr "Bedøm dette !number / 5 stjerner"
+
+#: /user/me/status-debts
+msgid "I accept the terms of service"
+msgstr "Jeg accepterer betalingsbetingelserne"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4161

#### Description

Adds Terms of service active accept as required by EU-law. More information on redmine: https://platform.dandigbib.org/issues/4161#note-12 

There was no styling of disabled buttons in our main theme, so I had to add that also.

I added a translation of "I accept the terms of service". Should I trigger a translation import in an update hook or is that something we take care of once each release?

#### Screenshot of the result

![4161-no-accept](https://user-images.githubusercontent.com/5011234/65130636-1f350600-d9fe-11e9-99cd-80207fe41729.png)

![4161-accept](https://user-images.githubusercontent.com/5011234/65130641-25c37d80-d9fe-11e9-872f-d6a612dc733a.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
