### PR TITLE
4524: Styling corrections for paragraphs

### DIFF
--- a/themes/ddbasic/sass/components/node/news.scss
+++ b/themes/ddbasic/sass/components/node/news.scss
@@ -379,21 +379,12 @@
       @include media($tablet) {
         @include span-columns(6);
         margin-right: 0;
-
-        &.has-paragraphs {
-          @include span-columns(8);
-        }
       }
 
       // Mobile
       @include media($mobile) {
         @include span-columns(12);
         margin-right: 0;
-
-        // Override tablet layout.
-        &.has-paragraphs {
-          @include span-columns(12);
-        }
       }
     }
     h1 {

--- a/themes/ddbasic/sass/components/node/paragraphs.scss
+++ b/themes/ddbasic/sass/components/node/paragraphs.scss
@@ -20,11 +20,8 @@
   }
 
   .ting-object {
-    @include display(flex);
-    
     .ting-object-left {
       margin-right: 2%;
-      @include flex(0 1 auto);
 
       .ting-cover > img {
         min-width: 50px;
@@ -33,10 +30,6 @@
     }
 
     .ting-object-right {
-      @include display(flex);
-      @include flex-wrap(wrap);
-      @include flex(1 1 auto);
-
       .field-name-ting-type {
         display: none;
       }
@@ -89,14 +82,6 @@
   @include media($notebook) {
     width: 100%;
   }
-
-  @include media($tablet) {
-    width: 100%;
-  }
-
-  @include media($mobile) {
-    width: 100%;
-  }
 }
 
 .paragraphs-block--half-right {
@@ -105,14 +90,6 @@
   width: 50%;
 
   @include media($notebook) {
-    width: 100%;
-  }
-
-  @include media($tablet) {
-    width: 100%;
-  }
-
-  @include media($mobile) {
     width: 100%;
   }
 }
@@ -155,20 +132,27 @@
 // container width.
 .paragraphs-block--carousel,
 .paragraphs-block--materials-list {
-  width: 150%;
 
-  @include media($notebook) {
-    width: 163%;
+  .node-ding-news  & {
+    width: flex-grid(7, 6);
+
+    @include media($tablet) {
+      width: flex-grid(12, 6);
+    }
+    @include media($mobile) {
+      width: 100%;
+    }
   }
+  .node-ding-page & {
+    width: flex-grid(8, 7);
 
-  @include media($tablet) {
-    width: 152%;
+    @include media($tablet) {
+      width: flex-grid(12, 8);
+    }
+    @include media($mobile) {
+      width: 100%;
+    }
   }
-
-  @include media($mobile) {
-    width: 100%;
-  }
-
   .ting-object {
     margin-bottom: 10px;
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4524

#### Description

Flexbox styling removed from ting-object in paragraph blocks. It didn't seem to do anything, but was causing problems.

Widths for .paragraphs-block--carousel and .paragraphs-block--materials-list are changed to use grid function from the grid library, so they don’t break out of the grid.

Redundant media queries have been removed.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/22191849/65256640-280e0080-db00-11e9-8337-c5c04f1a0a15.png)

![image](https://user-images.githubusercontent.com/22191849/65256729-48d65600-db00-11e9-8f3c-f780e3814ccc.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No further comments.
