### PR TITLE
4520: Re-adding popup javascript with drupal command

### DIFF
--- a/modules/ding_popup/ding_popup.info
+++ b/modules/ding_popup/ding_popup.info
@@ -5,5 +5,3 @@ version = "7.x-0.4"
 core = 7.x
 files[] = ding_popup.module
 files[] = ding_popup.test
-scripts[] = ding_popup-popupbar.js
-scripts[] = ding_popup.js

--- a/modules/ding_popup/ding_popup.module
+++ b/modules/ding_popup/ding_popup.module
@@ -5,10 +5,6 @@
  * Common popup functionality for Ding!
  */
 
-/* Attached scripts is handled via jquery AJAX call from jQuery.ajaxTransport, 
-   where async is set to false, and will trigger a warning in Gecko 30.0;
-   For now, add javascripts in module.info */
-
 /**
  * Ajax command to open a popup.
  */
@@ -19,6 +15,10 @@ function ajax_command_ding_popup($name, $title, $html, $options = array()) {
     'extra_data' => array(),
     'refresh' => FALSE,
   );
+
+  $path = drupal_get_path('module', 'ding_popup');
+  drupal_add_js($path . '/ding_popup-popupbar.js');
+  drupal_add_js($path . '/ding_popup.js', 'file');
 
   return array(
     'command' => 'ding_popup',
@@ -35,6 +35,10 @@ function ajax_command_ding_popup($name, $title, $html, $options = array()) {
  * Ajax command to close a popup.
  */
 function ajax_command_ding_popup_close($name, $refresh = FALSE) {
+  $path = drupal_get_path('module', 'ding_popup');
+  drupal_add_js($path . '/ding_popup-popupbar.js');
+  drupal_add_js($path . '/ding_popup.js', 'file');
+
   return array(
     'command' => 'ding_popup_close',
     'name' => $name,


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4520

#### Description

When not added this way the Drupal main ajax framework is not loaded
and the JavaScript fails a stops execution. Using drupal_add_js
ensures that the core javascript framework is always loaded.

#### Screenshot of the result

The error when loaded in info file.

![Skærmbillede 2019-09-25 kl  14 31 57](https://user-images.githubusercontent.com/111397/65601705-dbfd0900-dfa2-11e9-8a90-7581992706ad.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.
