### PR TITLE
3826: Use pin-code during the SSO process

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -334,6 +334,18 @@ function ding_adgangsplatformen_callback() {
       $user_info = $response->getBody()->getContents();
       $user_info = drupal_json_decode($user_info);
 
+      //
+      // HACK: this invalidates the access token and should be removed later on.
+      //       This only exists to get around pre-authentication issues
+      //       currently in FBS.
+      //
+      $request = $provider->getAuthenticatedRequest('DELETE', 'https://login.bib.dk/oauth/revoke', $access_token);
+      $response = $provider->getResponse($request);
+      if ($response->getStatusCode() != 200) {
+        watchdog('ding_adgangsplatformen', "https://login.bib.dk/oauth/revoke returned status code: %code", array('%code' => $response->getStatusCode()), WATCHDOG_CRITICAL);
+      }
+      unset($_SESSION['oauth2token']);
+
       if (module_exists('ding_registration') && ding_registration_is_registration_request()) {
         // This is an self registration request, so we store the information in
         // the current session. So it can be used to create the user in the
@@ -439,7 +451,14 @@ function _ding_adgangsplatformen_provider_login(array $user_info) {
   try {
     $account = ding_user_authenticate(array(
       'name' => $user_info['attributes']['userId'],
+      //
+      // HACK: The pincode used here should be removed later on.
+      //       This only exists to get around pre-authentication issues
+      //       currently in FBS.
+      //
+      'pass' => isset($user_info['attributes']['pincode']) ?? $user_info['attributes']['pincode'],
       'extra' => $user_info,
+      'single_sign_on' => !is_null($user_info['attributes']['cpr']),
     ));
 
     if ($account !== FALSE) {

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -135,7 +135,7 @@ function ding_user_authenticate(array $user_info) {
   $account = FALSE;
 
   try {
-    if (!array_key_exists('pass', $user_info)) {
+    if (array_key_exists('single_sign_on', $user_info) && $user_info['single_sign_on'] == TRUE) {
       // No password provided by the authentication request (not even the empty
       // string), so we assume that this is a single-sign-on request.
       $auth_res = ding_provider_invoke('auth', 'single_sign_on', $user_info['name']);
@@ -146,7 +146,7 @@ function ding_user_authenticate(array $user_info) {
     }
     else {
       // Normal user log in request.
-      $auth_res = ding_provider_invoke('user', 'authenticate', $user_info['name'], $user_info['pass'], $sso);
+      $auth_res = ding_provider_invoke('user', 'authenticate', $user_info['name'], $user_info['pass']);
     }
   }
   catch (DingProviderNoProvider $exception) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3826

#### Description

This is some-what a temporally hack to get around issues with pre-authenticate in FBS and allow all types of users to use adgangsplatformen. 

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Please not that this hack requires that we disable the access token as soon as it has been used. The side effect is that the token can not be used later on to make request to the open-platform etc. This is due to security considerations and the information that the token now gives access to.