### PR TITLE
4514: Do no prevent access to /user

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -39,18 +39,6 @@ function ding_user_preprocess_html(&$variables) {
       drupal_add_http_header('Cache-Control', 'no-store, must-revalidate');
       drupal_add_http_header('Pragma', 'no-cache');
     }
-    elseif (count($args) == 1 || isset($args[1]) && in_array($args[1], array('login', 'password'))) {
-      // Redirect anonymous user to front page login. This is to prevent the
-      // library user from seeing /user, login and password page. Unless in
-      // maintenance_mode, there's no front page login when in maintenance_mode,
-      // and a redirect prevent login.
-      if (!variable_get('maintenance_mode', 0)) {
-        if (module_exists('ding_user_form')) {
-          // If user forms are enabled goto the login dropdown.
-          drupal_goto('', array('fragment' => 'login'));
-        }
-      }
-    }
   }
 }
 

--- a/themes/ddbasic/sass/components/form/form-user-login.scss
+++ b/themes/ddbasic/sass/components/form/form-user-login.scss
@@ -45,7 +45,6 @@
   }
   .form-item {
     width: 100%;
-    float: left;
     margin: 0 0 15px;
     > label {
       display: none;
@@ -64,6 +63,7 @@
   }
   .form-actions {
     margin-bottom: 20px;
+    max-width: 400px;
   }
   .submit-button-with-icon {
     .color-and-icon {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4514

#### Description

The is an alternative to #1526 

Some sites use single singon systems such as Adgangsplatformen to
authenticate patrons but use standard Drupal users for library
personel.

We do not want to prevent these users from logging in event though
the use ding_user_form module might also be enabled.

Preventing such two modules from being enabled at the same time is
cumbersome so instead we remove the code which prevents users
from accessing /user.

This will allow library personel to log into the site regardless of
which modules are enabled.

In the current state form items are floated left. There does not
seem to be a reason for this. They are already in a container which
uses floats for positioning and they are positioned directly above/
below each other.

Also add a max-width for the form actions. This ensures that the
login button will not be longer that form items which currently
also have a 400px max-width.

The login form in the popup bar already have more specific styling
which overrides the newly added max-width value.

#### Screenshot of the result

Display of login forms in Internet Explorer 11 and Edge after changes in this PR:

<img width="720" alt="Dashboard 2019-10-01 12-35-41" src="https://user-images.githubusercontent.com/73966/65955653-ec046500-e448-11e9-9383-bc039280df59.png">

<img width="710" alt="Dashboard 2019-10-01 12-34-57" src="https://user-images.githubusercontent.com/73966/65955655-ec9cfb80-e448-11e9-8045-b79416857832.png">

Display of login form before CSS changes:

<img width="719" alt="Login | Ding2 2019-10-01 12-41-35" src="https://user-images.githubusercontent.com/73966/65955733-181fe600-e449-11e9-9aa6-e2158fc74070.png">

Display of login form before enabling `ding_user_form` (for reference):

<img width="719" alt="Login | Ding2 2019-10-01 12-39-15" src="https://user-images.githubusercontent.com/73966/65955799-2ff76a00-e449-11e9-83f1-4954d2e0f87b.png">



#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.