### PR TITLE
4519: Adjust header positioning when admin shortcuts are displayed

### DIFF
--- a/themes/ddbasic/sass/components/header.scss
+++ b/themes/ddbasic/sass/components/header.scss
@@ -620,7 +620,7 @@
     $_selectors-top-values--search-form: (
       // .admin-menu does not need the base value added.
       '.admin-menu': $admin-menu-height - $_base-top-value,
-      '.admin-menu-with-shortcuts': $toolbar-height,
+      '.admin-menu-with-shortcuts': 0,
       '.toolbar': $toolbar-height,
       '.search-form-extended': $search-form-extended-height,
       '.search-form-extended.admin-menu': $search-form-extended-height + $admin-menu-height,
@@ -687,7 +687,7 @@
     $_selectors-top-values--navigation-wrapper: (
       '.mobile-search-is-open': $header-height,
       '.admin-menu': $topbar-height + $admin-menu-height,
-      '.admin-menu-with-shortcuts': $toolbar-height,
+      '.admin-menu-with-shortcuts': $topbar-height * 2,
       '.toolbar': $toolbar-height,
       '.search-form-extended.admin-menu': $topbar-height + $admin-menu-height,
       '.search-form-extended.admin-menu-with-shortcuts': $topbar-height + $toolbar-height,


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4519

#### Description

The navigation wrapper is currently positioned under the topper when
shortcuts are displayed. Move it down to display it fully.

Once that is moved we can keep the search pane in the current
position.

#### Screenshot of the result

Current state:

<img width="896" alt="Mozilla Firefox 2019-10-01 15-28-57" src="https://user-images.githubusercontent.com/73966/65966429-5f65a100-e460-11e9-9e48-8d4ec05e5c21.png">

After with shortcuts closed

<img width="896" alt="Ding2 | 2019-10-01 15-28-28" src="https://user-images.githubusercontent.com/73966/65966475-70161700-e460-11e9-8ec9-e022335394c2.png">

After with shortcuts open

<img width="896" alt="Ding2 | 2019-10-01 15-28-13" src="https://user-images.githubusercontent.com/73966/65966480-74423480-e460-11e9-9bf7-53e460fd0881.png">


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.