### PR TITLE
4520: Prevent JavaScript errors in administration interface.

### DIFF
--- a/modules/ding_popup/ding_popup.info
+++ b/modules/ding_popup/ding_popup.info
@@ -5,5 +5,3 @@ version = "7.x-0.4"
 core = 7.x
 files[] = ding_popup.module
 files[] = ding_popup.test
-scripts[] = ding_popup-popupbar.js
-scripts[] = ding_popup.js

--- a/modules/ding_popup/ding_popup.module
+++ b/modules/ding_popup/ding_popup.module
@@ -5,9 +5,39 @@
  * Common popup functionality for Ding!
  */
 
-/* Attached scripts is handled via jquery AJAX call from jQuery.ajaxTransport, 
-   where async is set to false, and will trigger a warning in Gecko 30.0;
-   For now, add javascripts in module.info */
+/**
+ * Implements hook_library().
+ */
+function ding_popup_library() {
+  $path = drupal_get_path('module', 'ding_popup');
+  return array(
+    'ding_popup' => array(
+      'title' => 'Ding popup',
+      'version' => '1.x',
+      'js' => array(
+        $path . '/ding_popup-popupbar.js' => array(
+          'scope' => 'footer',
+        ),
+        $path . '/ding_popup.js' => array(
+          'scope' => 'footer',
+        ),
+      ),
+      'dependencies' => array(
+        array(
+          'system',
+          'drupal.ajax',
+        ),
+      ),
+    ),
+  );
+}
+
+/**
+ * Implements hook_preprocess_html().
+ */
+function ding_popup_preprocess_html() {
+  drupal_add_library('ding_popup', 'ding_popup', true);
+}
 
 /**
  * Ajax command to open a popup.

--- a/modules/p2/ding_serendipity/ding_serendipity.module
+++ b/modules/p2/ding_serendipity/ding_serendipity.module
@@ -96,22 +96,6 @@ function ding_serendipity_menu() {
 }
 
 /**
- * AJAX command to place HTML within the serendipity.
- *
- * @param array $context
- *   The title of the BeautyTip.
- *
- * @return array
- *   JSON encoded data.
- */
-function ding_serendipity_command_refresh(array $context) {
-  return array(
-    'command' => 'ding_serendipity_refresh',
-    'data' => drupal_json_encode($context),
-  );
-}
-
-/**
  * Ajax callback function.
  */
 function ding_serendipity_ajax_callback() {

--- a/modules/p2/ding_serendipity/js/ding_serendipity.js
+++ b/modules/p2/ding_serendipity/js/ding_serendipity.js
@@ -7,36 +7,7 @@
 
 (function ($) {
   "use strict";
-
-  /**
-   * AJAX command to update the content of a serendipity pane.
-   */
-  Drupal.ding_serendipity = {};
-  Drupal.ding_serendipity.refresh_content = function(ajax, response) {
-    var
-      $serendipitypane = $('.pane-serendipity-ting-object .pane-content'),
-      $context = Drupal.settings.ding_serendipity.context;
-
-    if(response.data) {
-      var _data = JSON.parse(response.data);
-      $.extend($context, _data);
-    }
-
-    if(!Drupal.ajax['.pane-serendipity-ting-object']) {
-      Drupal.ajax['.pane-serendipity-ting-object'] = new Drupal.ajax('.pane-serendipity-ting-object .pane-content', $serendipitypane, {
-        url: 'ding/serendipity/ajax',
-        settings: {},
-        event: 'load',
-        submit: {context: $context}
-      });
-    }
-    else {
-      Drupal.ajax['.pane-serendipity-ting-object'].element_settings.submit = {context: $context};
-    }
-    $serendipitypane.trigger('load');
-  };
-  Drupal.ajax.prototype.commands.ding_serendipity_refresh = Drupal.ding_serendipity.refresh_content;
-
+  
   Drupal.behaviors.ding_serendipity = {
     attach: function (context) {
       // Bail if there's no analytics.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4520

#### Description

This is an alternate take on #1531 

AJAX commands in Ding Popup requires the existence of the Drupal AJAX
core library. This is not handled by the current definition in the
.info file.

Such an error can block the execution of other JavaScript code e.g.
the handling of the top menu.

To address this we declare the code in ding_popup a library and with the AJAX
library as a dependency.

We load the library is currently loaded for all HTML responses as we 
cannot establish exactly where popups are invoked.

By searching through the codebase it seems as if the AJAX command 
defined in ding_serendipity is not in use. Consequently we remove it.

#### Screenshot of the result

The error:

<img width="896" alt="Moduler | Ding2 2019-10-01 16-30-30" src="https://user-images.githubusercontent.com/73966/65971699-e6b71280-e468-11e9-9493-11de79e3955e.png">

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
