### PR TITLE
Core: Update packages before installing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,6 +87,7 @@ jobs:
     - run:
         name: Configure PHP for Drupal
         command: |
+          sudo apt-get update
           sudo apt install -y libpng-dev mysql-client
           sudo -E docker-php-ext-install gd pdo_mysql
           sudo chmod 0777 $PHP_INI_DIR/conf.d
@@ -136,6 +137,7 @@ jobs:
     - run:
         name: Configure PHP for Drupal
         command: |
+          sudo apt-get update
           sudo apt install -y libpng-dev mysql-client
           sudo -E docker-php-ext-install gd pdo_mysql
           sudo chmod 0777 $PHP_INI_DIR/conf.d
@@ -183,6 +185,7 @@ jobs:
     - run:
         name: Configure PHP for Drupal
         command: |
+          sudo apt-get update
           sudo apt install -y libpng-dev mysql-client
           sudo -E docker-php-ext-install gd pdo_mysql
           sudo chmod 0777 $PHP_INI_DIR/conf.d


### PR DESCRIPTION
Builds currently fail because of missing libpng files. Try to update
Package index before installing.