### PR TITLE
3585: Enable EU cookie compliance GDPR functionality

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -950,4 +950,11 @@ function ding2_update_7081() {
  */
 function ding2_update_7082() {
   ding2_set_eu_cookie_compliance_settings();
+  // jquery_update will override the version of jquery.cookie that EU cookie
+  // compliance needs, if module weights are not changed. ECC 1.31 takes care
+  // of this on update and fresh install,  but 1.28 (we used in last release)
+  // only did on update. So we ensure it's called here if someone is testing
+  // from a fresh install on last release.
+  // https://www.drupal.org/project/eu_cookie_compliance/issues/2991113
+  eu_cookie_compliance_module_set_weight();
 }

--- a/ding2.install
+++ b/ding2.install
@@ -944,3 +944,10 @@ function ding2_update_7080() {
 function ding2_update_7081() {
   ding2_translation_update();
 }
+
+/**
+ * Update EU cookie compliance settings.
+ */
+function ding2_update_7082() {
+  ding2_set_eu_cookie_compliance_settings();
+}

--- a/ding2.install
+++ b/ding2.install
@@ -950,6 +950,7 @@ function ding2_update_7081() {
  */
 function ding2_update_7082() {
   ding2_set_eu_cookie_compliance_settings();
+
   // jquery_update will override the version of jquery.cookie that EU cookie
   // compliance needs, if module weights are not changed. ECC 1.31 takes care
   // of this on update and fresh install,  but 1.28 (we used in last release)
@@ -957,4 +958,11 @@ function ding2_update_7082() {
   // from a fresh install on last release.
   // https://www.drupal.org/project/eu_cookie_compliance/issues/2991113
   eu_cookie_compliance_module_set_weight();
+
+  // Update the cookie name used by ECC to enforce all users to the new opt-out
+  // model and make them agree again. The name can be whatever so we choose the
+  // number of this update function where the settings were changed.
+  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
+  $ecc_settings['cookie_name'] = 'cookie-agreed-7082';
+  i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
 }

--- a/ding2.profile
+++ b/ding2.profile
@@ -791,10 +791,19 @@ function ding2_set_eu_cookie_compliance_settings() {
 
   // Set cookie compliance variables.
   $eu_cookie_compliance = i18n_variable_get('eu_cookie_compliance', 'da', []);
+  // Ensure we don't override any whitelisted cookies added by administrators or
+  // other modules.
+  // Note: if ding2 should whitelist more cookies separate by new line.
+  $whitelisted_cookies = 'has_js';
+  if (!empty($eu_cookie_compliance['whitelisted_cookies']) && strpos($eu_cookie_compliance['whitelisted_cookies'], $whitelisted_cookies) === FALSE) {
+    $eu_cookie_compliance['whitelisted_cookies'] .= "\r\n" . $whitelisted_cookies;
+  }
+  else {
+    $eu_cookie_compliance['whitelisted_cookies'] = $whitelisted_cookies;
+  }
   $eu_cookie_compliance = array_merge($eu_cookie_compliance, [
-    'method' => 'opt_in',
+    'method' => 'opt_out',
     'show_disagree_button' => 1,
-    'whitelisted_cookies' => 'has_js',
     'popup_info' => [
       'value' => '<h2>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse.</h2>',
       'format' => 'ding_wysiwyg',

--- a/ding2.profile
+++ b/ding2.profile
@@ -812,10 +812,10 @@ function ding2_set_eu_cookie_compliance_settings() {
   }
 
   $eu_cookie_compliance = array_merge($eu_cookie_compliance, [
-    'method' => 'opt_out',
+    'method' => 'opt_in',
     'show_disagree_button' => 1,
     'popup_info' => [
-      'value' => '<h2>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse.</h2>',
+      'value' => '<h2>Hjælp os med at forbedre oplevelsen på hjemmesiden ved at acceptere cookies.</h2>',
       'format' => 'ding_wysiwyg',
     ],
     'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',

--- a/ding2.profile
+++ b/ding2.profile
@@ -833,6 +833,7 @@ function ding2_set_eu_cookie_compliance_settings() {
     'popup_text_hex' => 'FFFFFF',
     'popup_delay' => 1000,
     'exclude_admin_pages' => TRUE,
+    'store_consent' => 'basic',
   ]);
   i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
 }

--- a/ding2.profile
+++ b/ding2.profile
@@ -833,7 +833,7 @@ function ding2_set_eu_cookie_compliance_settings() {
     'popup_text_hex' => 'FFFFFF',
     'popup_delay' => 1000,
     'exclude_admin_pages' => TRUE,
-    'store_consent' => 'basic',
+    'consent_storage_method' => 'provider',
   ]);
   i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
 }

--- a/ding2.profile
+++ b/ding2.profile
@@ -190,6 +190,9 @@ function ding2_add_settings(&$install_state) {
   // Set cookie page.
   ding2_set_cookie_page();
 
+  // Set EU cookie compliance settings.
+  ding2_set_eu_cookie_compliance_settings();
+
   // Add menu item to secondary menu.
   $link = array(
     'menu_name' => 'menu-secondary-menu',
@@ -730,30 +733,6 @@ function ding2_add_administrators_role($uid) {
  * Add page with std. cookie information.
  */
 function ding2_set_cookie_page() {
-  // Enable translation variables for EU Cookie Compliance.
-  $controller = variable_realm_controller('language');
-  $old_variables = $controller->getEnabledVariables();
-  $old_list = variable_children($old_variables);
-  $variables = array_merge($old_list, array('eu_cookie_compliance'));
-  $controller->setRealmVariable('list', $variables);
-
-  // Set cookie compliance variables
-  $eu_cookie_compliance = i18n_variable_get('eu_cookie_compliance', 'da', variable_get('eu_cookie_compliance', array()));
-  $eu_cookie_compliance = array_merge($eu_cookie_compliance, array(
-    'method' => 'default',
-    'popup_info' => array(
-      'value' => '<p>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse.</p><p>Læs mere her: <a href="' . url('cookies') . '">Hvad er cookies?</a></p>',
-      'format' => 'ding_wysiwyg',
-    ),
-    'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',
-    'show_disagree_button' => 0,
-    'popup_link' => 'cookies',
-    'popup_bg_hex' => '0D0D26',
-    'popup_text_hex' => 'FFFFFF',
-    'popup_delay' => 1000,
-  ));
-  i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
-
   $body = '<p><strong>Hvad er cookies?</strong></p>
           <p>En cookie er en lille tekstfil, som lægges på din computer, smartphone, ipad eller lignende med det formål at indhente data. Den gør det muligt for os at måle trafikken på vores site og opsamle viden om f.eks. antal besøg på vores hjemmeside, hvilken browser der bliver brugt, hvilke sider der bliver klikket på, og hvor lang tid der bruges på siden. Alt sammen for at vi kan forbedre brugeroplevelsen og udvikle nye services.</p>
           <p>Når du logger ind for at se lånerstatus, reservere m.m. sættes en såkaldt sessions-cookie. Denne cookie forsvinder, når du logger ud.</p>
@@ -797,6 +776,43 @@ function ding2_set_cookie_page() {
   // Permissions, see: ding_permissions module
   // display EU Cookie Compliance popup: anonymous user, authenticated user
   // administer EU Cookie Compliance popup: administrators, local administrator
+}
+
+/**
+ * Sets the standard ding2 settings for EU cookie compliance module.
+ */
+function ding2_set_eu_cookie_compliance_settings() {
+  // Ensure that translation variables are enabled for EU Cookie Compliance.
+  $controller = variable_realm_controller('language');
+  $old_variables = $controller->getEnabledVariables();
+  $old_list = variable_children($old_variables);
+  $variables = array_merge($old_list, array('eu_cookie_compliance'));
+  $controller->setRealmVariable('list', $variables);
+
+  // Set cookie compliance variables.
+  $eu_cookie_compliance = i18n_variable_get('eu_cookie_compliance', 'da', []);
+  $eu_cookie_compliance = array_merge($eu_cookie_compliance, [
+    'method' => 'opt_in',
+    'show_disagree_button' => 1,
+    'whitelisted_cookies' => 'has_js',
+    'popup_info' => [
+      'value' => '<h2>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse.</h2>',
+      'format' => 'ding_wysiwyg',
+    ],
+    'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',
+    'withdraw_enabled' => 1,
+    'withdraw_message' => [
+      'value' => '<h2>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse</h2><p>Du har givet os samtykke. Tryk her for at tilbagekalde.</p>',
+      'format' => 'ding_wysiwyg',
+    ],
+    'withdraw_tab_button_label' => 'Privatlivsindstillinger',
+    'withdraw_action_button_label' => 'Tilbagekald samtykke',
+    'popup_link' => 'cookies',
+    'popup_bg_hex' => '0D0D26',
+    'popup_text_hex' => 'FFFFFF',
+    'popup_delay' => 1000,
+  ]);
+  i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
 }
 
 /**

--- a/ding2.profile
+++ b/ding2.profile
@@ -819,6 +819,8 @@ function ding2_set_eu_cookie_compliance_settings() {
       'format' => 'ding_wysiwyg',
     ],
     'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',
+    'popup_disagree_button_message' => 'Mere info',
+    'disagree_button_label' => 'Afvis',
     'withdraw_enabled' => 1,
     'withdraw_message' => [
       'value' => '<h2>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse</h2><p>Du har givet os samtykke. Tryk her for at tilbagekalde.</p>',
@@ -830,6 +832,7 @@ function ding2_set_eu_cookie_compliance_settings() {
     'popup_bg_hex' => '0D0D26',
     'popup_text_hex' => 'FFFFFF',
     'popup_delay' => 1000,
+    'exclude_admin_pages' => TRUE,
   ]);
   i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
 }

--- a/ding2.profile
+++ b/ding2.profile
@@ -791,16 +791,26 @@ function ding2_set_eu_cookie_compliance_settings() {
 
   // Set cookie compliance variables.
   $eu_cookie_compliance = i18n_variable_get('eu_cookie_compliance', 'da', []);
+
+  // Ding2 whitelisted cookies. If more are needed: add to array and call this
+  // function again in an update.
+  $whitelisted_cookies = [
+    'has_js',
+  ];
+
   // Ensure we don't override any whitelisted cookies added by administrators or
   // other modules.
-  // Note: if ding2 should whitelist more cookies separate by new line.
-  $whitelisted_cookies = 'has_js';
-  if (!empty($eu_cookie_compliance['whitelisted_cookies']) && strpos($eu_cookie_compliance['whitelisted_cookies'], $whitelisted_cookies) === FALSE) {
-    $eu_cookie_compliance['whitelisted_cookies'] .= "\r\n" . $whitelisted_cookies;
+  if (empty($eu_cookie_compliance['whitelisted_cookies'])) {
+    $eu_cookie_compliance['whitelisted_cookies'] = implode("\r\n", $whitelisted_cookies);
   }
   else {
-    $eu_cookie_compliance['whitelisted_cookies'] = $whitelisted_cookies;
+    foreach ($whitelisted_cookies as $cookie) {
+      if (strpos($eu_cookie_compliance['whitelisted_cookies'], $cookie) === FALSE) {
+        $eu_cookie_compliance['whitelisted_cookies'] .= "\r\n" . $cookie;
+      }
+    }
   }
+
   $eu_cookie_compliance = array_merge($eu_cookie_compliance, [
     'method' => 'opt_out',
     'show_disagree_button' => 1,

--- a/modules/ding_user/ding_user.info
+++ b/modules/ding_user/ding_user.info
@@ -6,5 +6,6 @@ core = 7.x
 dependencies[] = ding_provider
 dependencies[] = ding_popup
 dependencies[] = ding_entity
+dependencies[] = eu_cookie_compliance
 dependencies[] = profile2
 dependencies[] = ctools

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -204,6 +204,9 @@ function ding_user_authenticate(array $user_info) {
     // Check that a profile exists for the user and if not create one.
     _ding_user_create_profile2($account);
 
+    // Attempt to upgrade an existing anonymous consent storage to this user.
+    _ding_user_upgrade_anonymous_ecc_consent($account);
+
     if ($account->data['blocks']) {
       foreach ($account->data['blocks'] as $block_code) {
         drupal_set_message(ding_user_block_reason($block_code), 'warning');
@@ -849,6 +852,36 @@ function _ding_user_create_profile2($account) {
     $profile->save();
   }
   return $profile;
+}
+
+/**
+ * Attempt to upgrade any anonymous consent from this device.
+ */
+function _ding_user_upgrade_anonymous_ecc_consent($account) {
+  $cookie_name = eu_cookie_compliance_get_settings()['cookie_name'] . '-cid';
+  if (isset($_COOKIE[$cookie_name])) {
+    $cid = $_COOKIE[$cookie_name];
+
+    // Upgrade the consent. Use try-catch as we do not in any case wanna cause
+    // issues during provider login process.
+    try {
+      db_update('eu_cookie_compliance_basic_consent')
+        ->fields(['uid' => $account->uid])
+        ->condition('cid', $cid)
+        ->execute();
+
+      watchdog('ding_user', 'Attempted consent storage upgrade for cid: %cid to provider user uid: %uid', [
+        '%cid' => $cid,
+        '%uid' => $account->uid,
+      ]);
+
+      // Remove our cid-cookie again.
+      setcookie($cookie_name, "", 1, '/');
+    }
+    catch (Exception $e) {
+      watchdog_exception('ding_user', $e);
+    }
+  }
 }
 
 /**

--- a/modules/ding_user/plugins/consent_storage/provider.inc
+++ b/modules/ding_user/plugins/consent_storage/provider.inc
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @file
+ * Provider consent storage.
+ */
+
+$plugin = [
+  'title' => t('Provider consent storage'),
+  'description' => t('ECC consent storage plugin that makes it possible to upgrade anonymous consent for provider users.'),
+  'consent_storage_callback' => 'ding_user_store_provider_user_consent',
+];
+
+/**
+ * Store record of consent in the database.
+ *
+ * This is an extention of ECC's basic consent storage plugin, that also saves
+ * a cookie for anynomous users referencing the stored consent in DB. If a
+ * provider user subsequently logs in from the same device, we can then upgrade
+ * it and link it to them.
+ *
+ * @param string $type
+ *   The consent type (for example banner or form ID).
+ *
+ * @return bool
+ *   Returns TRUE on storage success.
+ *
+ * @throws \Exception
+ */
+function ding_user_store_provider_user_consent($type) {
+  global $user;
+
+  // Unfortunately we can not call the code from the basic plugin directly,
+  // since it doesn't give us $cid, so we have to copy some code from ECC.
+  $revision_id = _eu_cookie_compliance_get_current_policy_node_revision();
+  $timestamp = time();
+  $ip_address = ip_address();
+  $uid = $user->uid;
+
+  $cid = db_insert('eu_cookie_compliance_basic_consent')
+    ->fields(array(
+      'uid' => $uid,
+      'ip_address' => $ip_address,
+      'timestamp' => $timestamp,
+      'revision_id' => $revision_id ? $revision_id : 0,
+      'consent_type' => $type,
+    ))
+    ->execute();
+
+  if (!user_is_logged_in()) {
+    // This is an anonymous consent. Store a cookie referencing the consent.
+    $cookie_name = eu_cookie_compliance_get_settings()['cookie_name'];
+    $lifetime = variable_get('eu_cookie_compliance_cookie_lifetime', 100);
+    // Use the current cookie name for ECC agreed cookied (with "-cid" appended)
+    // and also the same lifetime. This way we tie it to the current policy.
+    // Using REQUEST_TIME to get as close to the lifetime for ECC cookie.
+    setcookie($cookie_name . '-cid', $cid, REQUEST_TIME + $lifetime * 3600 * 24, '/');
+  }
+
+  return TRUE;
+}

--- a/modules/ding_webtrekk/ding_webtrekk.install
+++ b/modules/ding_webtrekk/ding_webtrekk.install
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Install file for ding_webtrekk.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function ding_webtrekk_install() {
+  ding_webtrekk_whitelist_opt_out_cookie();
+}
+
+/**
+ * Whitelist webtrekk opt-out cookie in EU cookie compliance settings.
+ */
+function ding_webtrekk_update_7001() {
+  ding_webtrekk_whitelist_opt_out_cookie();
+}
+
+/**
+ * Whitelist webtrekk opt-out cookie in EU cookie compliance settings.
+ */
+function ding_webtrekk_whitelist_opt_out_cookie() {
+  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
+  $cookie_name = 'webtrekkOptOut';
+  // Depending on whether this is run from an update, a normal install of the
+  // module after ding2 install OR installed DURING ding2 installation via
+  // module selection form, we might run before or after ding2 calls
+  // ding2_set_eu_cookie_compliance_settings(), so we need to be able to handle
+  // both cases here. Hence this check and no hook_update_dependencies().
+  if (!empty($ecc_settings['whitelisted_cookies'])) {
+    $ecc_settings['whitelisted_cookies'] .= "\r\n" . $cookie_name;
+  }
+  else {
+    $ecc_settings['whitelisted_cookies'] = $cookie_name;
+  }
+  i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
+}

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -167,28 +167,50 @@
     }
   };
 
-  // EU cookie compliance integration. When user rejects/accepts cookies in the
-  // pop-up banner this event will be fired and we act accordingly.
+  // EU cookie compliance integration.
+  // Set Webtrekk opt-out cookie. EU cookie compliance module will try to purge
+  // all cookies 5 seconds after refresh, but setting this cookie will
+  // completely prevent Webtrekk from settings any tracking cookie at all,
+  // which is better.
+  var setOptOutCookie = function setOptOutCookie() {
+    var path = Drupal.settings.basePath;
+    var date = new Date();
+    date.setDate(date.getDate() + parseInt(Drupal.settings.eu_cookie_compliance.cookie_lifetime));
+    $.cookie('webtrekkOptOut', 1, { expires: date, path: path });
+  }
+
+  // When using opt-in model ensure that the opt-out cookie is added as default
+  // if user hasn't agreed.
+  if (typeof Drupal.eu_cookie_compliance !== 'undefined' && Drupal.settings.eu_cookie_compliance.method === 'opt_in') {
+    if (!Drupal.eu_cookie_compliance.hasAgreed() && typeof $.cookie('webtrekkOptOut') === 'undefined') {
+      setOptOutCookie();
+    }
+  }
+
+  // When user rejects/accepts cookies in the pop-up banner this event will be
+  // fired and we act accordingly.
   $(document).on('eu_cookie_compliance.changeStatus', function(event, status) {
-    if (!Drupal.eu_cookie_compliance.hasAgreed()) {
+    // If user has agreed we can safely remove our webtrekk opt-out cookie.
+    if (Drupal.eu_cookie_compliance.hasAgreed()) {
+      $.removeCookie('webtrekkOptOut');
+
+      // Track the opt-in events in Webtrekk.
+      if (Drupal.settings.eu_cookie_compliance.method === 'opt_in') {
+        var eventData = {
+          linkId: 'event_optin',
+          customClickParameter: {}
+        };
+        pushEvent('click', eventData);
+      }
+    }
+    else if (Drupal.settings.eu_cookie_compliance.method === 'opt_out') {
+      setOptOutCookie();
       // Track the opt-out events in Webtrekk.
       var eventData = {
         linkId: 'event_optout',
         customClickParameter: {}
       };
       pushEvent('click', eventData);
-
-      // Set Webtrekk opt-out cookie. EU cookie compliance module will try to
-      // purge all cookies 5 seconds after refresh, but setting this cookie will
-      // completely prevent Webtrekk from settings any tracking cookie at all,
-      // which is better.
-      var path = Drupal.settings.basePath;
-      var date = new Date();
-      date.setDate(date.getDate() + parseInt(Drupal.settings.eu_cookie_compliance.cookie_lifetime));
-      $.cookie('webtrekkOptOut', 1, { expires: date, path: path });
-    }
-    else {
-      $.removeCookie('webtrekkOptOut');
     }
   });
 

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -190,18 +190,9 @@
   // When user rejects/accepts cookies in the pop-up banner this event will be
   // fired and we act accordingly.
   $(document).on('eu_cookie_compliance.changeStatus', function(event, status) {
-    // If user has agreed we can safely remove our webtrekk opt-out cookie.
+    // If user has agreed we ensure that webtrekkOptOut is removed.
     if (Drupal.eu_cookie_compliance.hasAgreed()) {
       $.removeCookie('webtrekkOptOut');
-
-      // Track the opt-in events in Webtrekk.
-      if (Drupal.settings.eu_cookie_compliance.method === 'opt_in') {
-        var eventData = {
-          linkId: 'event_optin',
-          customClickParameter: {}
-        };
-        pushEvent('click', eventData);
-      }
     }
     else if (Drupal.settings.eu_cookie_compliance.method === 'opt_out') {
       setOptOutCookie();

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -194,8 +194,12 @@
     if (Drupal.eu_cookie_compliance.hasAgreed()) {
       $.removeCookie('webtrekkOptOut');
     }
-    else if (Drupal.settings.eu_cookie_compliance.method === 'opt_out') {
-      setOptOutCookie();
+    else {
+      // In the opt-in model we will already have taken care of this.
+      if (Drupal.settings.eu_cookie_compliance.method === 'opt_out') {
+        setOptOutCookie();
+      }
+
       // Track the opt-out events in Webtrekk.
       var eventData = {
         linkId: 'event_optout',

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -195,11 +195,7 @@
       $.removeCookie('webtrekkOptOut');
     }
     else {
-      // In the opt-in model we will already have taken care of this.
-      if (Drupal.settings.eu_cookie_compliance.method === 'opt_out') {
-        setOptOutCookie();
-      }
-
+      setOptOutCookie();
       // Track the opt-out events in Webtrekk.
       var eventData = {
         linkId: 'event_optout',

--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -167,4 +167,29 @@
     }
   };
 
+  // EU cookie compliance integration. When user rejects/accepts cookies in the
+  // pop-up banner this event will be fired and we act accordingly.
+  $(document).on('eu_cookie_compliance.changeStatus', function(event, status) {
+    if (!Drupal.eu_cookie_compliance.hasAgreed()) {
+      // Track the opt-out events in Webtrekk.
+      var eventData = {
+        linkId: 'event_optout',
+        customClickParameter: {}
+      };
+      pushEvent('click', eventData);
+
+      // Set Webtrekk opt-out cookie. EU cookie compliance module will try to
+      // purge all cookies 5 seconds after refresh, but setting this cookie will
+      // completely prevent Webtrekk from settings any tracking cookie at all,
+      // which is better.
+      var path = Drupal.settings.basePath;
+      var date = new Date();
+      date.setDate(date.getDate() + parseInt(Drupal.settings.eu_cookie_compliance.cookie_lifetime));
+      $.cookie('webtrekkOptOut', 1, { expires: date, path: path });
+    }
+    else {
+      $.removeCookie('webtrekkOptOut');
+    }
+  });
+
 })(jQuery);

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -464,6 +464,9 @@ function ding_webtrekk_preprocess_html() {
   // to elements which is problematic to handle on the server.
   drupal_add_js(drupal_get_path('module', 'ding_webtrekk') . '/ding_webtrekk.js', array(
     'scope' => 'footer',
+    // Ensure we have a higher weight that EU cookie compliance script, since
+    // we use the hasAgreed() function from it.
+    'weight' => 1,
   ));
 
   drupal_add_js([

--- a/project.make
+++ b/project.make
@@ -100,6 +100,8 @@ projects[entityreference_filter][version] = "1.7"
 
 projects[eu_cookie_compliance][subdir] = "contrib"
 projects[eu_cookie_compliance][version] = "1.31"
+; Cookie-agreed data is not saved if the cookie has a non-default name.
+projects[eu_cookie_compliance][patch][] = "https://www.drupal.org/files/issues/2019-11-27/3097097-2.patch"
 
 projects[environment_indicator][subdir] = "contrib"
 projects[environment_indicator][version] = "2.8"

--- a/project.make
+++ b/project.make
@@ -99,7 +99,7 @@ projects[entityreference_filter][subdir] = "contrib"
 projects[entityreference_filter][version] = "1.7"
 
 projects[eu_cookie_compliance][subdir] = "contrib"
-projects[eu_cookie_compliance][version] = "1.28"
+projects[eu_cookie_compliance][version] = "1.31"
 
 projects[environment_indicator][subdir] = "contrib"
 projects[environment_indicator][version] = "2.8"

--- a/themes/ddbasic/sass/components/cookie.scss
+++ b/themes/ddbasic/sass/components/cookie.scss
@@ -47,7 +47,8 @@
       float: left;
       .agree-button,
       .find-more-button,
-      .hide-popup-button {
+      .hide-popup-button,
+      .decline-button {
         @extend %button;
         @include font('base');
         background: $color-secondary;

--- a/themes/ddbasic/sass/components/cookie.scss
+++ b/themes/ddbasic/sass/components/cookie.scss
@@ -5,7 +5,18 @@
 
 #sliding-popup {
   &.sliding-popup-bottom {
-    background: $black;
+    &, .eu-cookie-withdraw-banner {
+      background: $black;
+    }
+
+    #popup-text p {
+      a, a:hover {
+        color: $white;
+      }
+    }
+  }
+
+  &.sliding-popup-bottom:not(.eu-cookie-withdraw-wrapper) {
     .popup-content {
       @include wrapper;
       position: relative;
@@ -22,12 +33,6 @@
         margin: 0;
         &:nth-child(1) {
           @include font('display-small');
-        }
-        a {
-          color: $white;
-          &:hover {
-            color: $white;
-          }
         }
       }
 

--- a/themes/ddbasic/sass/components/cookie.scss
+++ b/themes/ddbasic/sass/components/cookie.scss
@@ -5,25 +5,64 @@
 
 #sliding-popup {
   &.sliding-popup-bottom {
-    &, .eu-cookie-withdraw-banner {
-      background: $black;
+    #popup-text {
+      @include font('base');
+      p {
+        a, a:hover {
+          color: $white;
+        }
+      }
+
+      // Mobile
+      @include media($mobile) {
+        float: left;
+        padding-bottom: 10px;
+      }
     }
 
-    #popup-text p {
-      a, a:hover {
-        color: $white;
+    .popup-content {
+      @include wrapper;
+      position: relative;
+    }
+
+    #popup-buttons {
+      .agree-button,
+      .find-more-button,
+      .hide-popup-button,
+      .decline-button,
+      .eu-cookie-withdraw-button {
+        @extend %button;
+        @include font('base');
+        background: $color-secondary;
+        color: $color-text-on-secondary;
+        text-shadow: none;
+        border: none;
+        box-shadow: none;
+        .no-touch & {
+          &:hover {
+            background: none;
+            background-color: $grey-dark;
+            color: $white;
+          }
+        }
+      }
+    }
+  }
+
+  &.eu-cookie-withdraw-wrapper {
+    #popup-buttons {
+      margin: 0;
+      .eu-cookie-withdraw-button {
+        padding: 4px 20px 4px 8px;
       }
     }
   }
 
   &.sliding-popup-bottom:not(.eu-cookie-withdraw-wrapper) {
     .popup-content {
-      @include wrapper;
-      position: relative;
       height: 180px;
     }
     #popup-text {
-      @include font('base');
       max-width: calc(100% - 40px);
       float: none;
       padding-top: 20px;
@@ -35,13 +74,8 @@
           @include font('display-small');
         }
       }
-
-      // Mobile
-      @include media($mobile) {
-        float: left;
-        padding-bottom: 10px;
-      }
     }
+
     #popup-buttons {
       max-width: none;
       float: left;
@@ -49,22 +83,8 @@
       .find-more-button,
       .hide-popup-button,
       .decline-button {
-        @extend %button;
-        @include font('base');
-        background: $color-secondary;
-        color: $color-text-on-secondary;
         float: left;
         margin-right: 20px;
-        text-shadow: none;
-        border: none;
-        box-shadow: none;
-        .no-touch & {
-          &:hover {
-            background: none;
-            background-color: $grey-dark;
-            color: $white;
-          }
-        }
 
         // Mobile
         @include media($mobile) {
@@ -74,6 +94,7 @@
         }
       }
     }
+
     .close {
       @include place-icon('close', $white, 60px);
       position: absolute;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3585

#### Description

- Updates EU Cookie Compliance module (ECC) to get new GDPR functionality and fix an issue with jQuery cookie library (see commit messages).
- Enable opt-in model: we now block everything incl. webtrekk by default until the user accepts.
- Add needed Drupal cookies to whitelist. Otherwise they would be blocked be by default or it the user doesn't consent.
- Webtrekk integration: use webtrekkOptOut cookie to completely deactivate. Set opt-out cookie as default in opt-in model. Listen for ECC agreed status change and set/remove opt-out cookie accordingly. Also send opt-out event when agreed status change to not accepted. Also whitelists webtrekkOptOut cookie in ECC.
- Enable withdraw consent banner. The user is able to withdraw after accepting. See screenshots in issue.
- Style withdraw banner to look like the regular ECC popup bannner. Also fixes issues where the withdraw banner was not completely hidden on first page load. Tested on both desktop/mobile.
- Enable storage of consent. We use our own consent storage plugin provided by ding_user, that makes it possible to upgrade anonymous consents, if a provider user subsequently logs in. It is an extension of the basic consent storage plugin from ECC, so they are stored in DB.
- Rename ECC agreed cookie name to enforce new opt-in model (resets agreed status and shows banner again).
- Update various other ECC settings. Also refactores setting of ECC into separate function which can be called repeately on updates and on install.

Regarding our cusomt consent storage plugin: obviously we can't be sure that the provider user logging in also was the same user who accepted as anonymoues, if fx multiple users are using the same device. I have notified DDB of this, and they still wanna go with it. We have to do our best to store consent, even if it's not perfect. The alternative would be to require login before accepting cookies, which would probably result in an even bigger loss of analytics data.

#### Screenshot of the result

Storage of consent. Example with anonymouse user (row 1) and logged in user (row 2):

![image](https://user-images.githubusercontent.com/5011234/81123312-0e0c1b80-8f33-11ea-9d50-a9fa4caa767f.png)

Withdraw banner with updated styling:

![3585-withdrawbanner-updated-styling](https://user-images.githubusercontent.com/5011234/81947112-77a9bb00-9600-11ea-971d-17c5d3dfc27d.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
