### PR TITLE
4568: Deep clone opensearch static cache

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -660,17 +660,23 @@ function _opensearch_cache(TingClientRequest $request, $response = NULL) {
   // and we want to retrieve the cache value and where $value is set to NULL
   // explicitly.
   if (func_num_args() == 2) {
-    // Update the cache with the provided value.
-    $static_cache[$cid] = $response;
+    // Update the cache with the provided value. If you here just assign the
+    // response to the static variable here even though it's deep clone in the
+    // return statement changes to the collections inside the object from
+    // outside this function changes the cached object.
+    $static_cache[$cid] = _opensearch_deep_clone($response);
     if ($ttl = variable_get('opensearch_cache_lifetime', OPENSEARCH_DEFAULT_CACHE_LIFETIME)) {
       cache_set($cid, $response, 'cache_opensearch', REQUEST_TIME + $ttl);
     }
-    return $response;
+
+    return _opensearch_deep_clone($response);
   }
   else {
-    // Try to retrieve value from cache.
+    // Try to retrieve value from static cache.
     if (array_key_exists($cid, $static_cache)) {
-      return $static_cache[$cid];
+      $data = $static_cache[$cid];
+
+      return _opensearch_deep_clone($data);
     }
 
     $cache = cache_get($cid, 'cache_opensearch');
@@ -679,11 +685,28 @@ function _opensearch_cache(TingClientRequest $request, $response = NULL) {
 
       // Update the static cache with the database cache content to speed up the
       // next request for the same data.
-      $static_cache[$cid] = $data;
+      $static_cache[$cid] = _opensearch_deep_clone($data);
 
-      return $data;
+      return _opensearch_deep_clone($data);
     }
   }
+}
+
+/**
+ * Deep clone data structure using serialization.
+ *
+ * This should be use when working with static cache data that contains objects
+ * or objects in arrays. We need to do a deep clone so changes to objects
+ * out-side the cache will not change the objects in the static cache.
+ *
+ * @param mixed $data
+ *   Data structure to clone.
+ *
+ * @return mixed
+ *   Clone off the inputted data structure.
+ */
+function _opensearch_deep_clone($data) {
+  return unserialize(serialize($data));
 }
 
 /**

--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -423,7 +423,7 @@ function opensearch_xautoload(LocalDirectoryAdapter $adapter) {
  * permissions, a warning if the data well was queried more than once.
  */
 function opensearch_page_alter(&$page) {
-  $calls = &drupal_static('opensearch_execute_cache');
+  $calls = &drupal_static('opensearch_execute_cache', array());
   if (count($calls) > 5) {
     $calls_str = array();
     foreach ($calls as $call) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4568

#### Description

When search the data-well that static cache in opensearch do not return the same result if you make the same request within the same execution.

The `collection` part of objects changes inside the static cache between calls.

#### Screenshot of the result

Cache content on first call:
<img width="498" alt="Cache første kald" src="https://user-images.githubusercontent.com/111397/66161875-86bd9900-e62d-11e9-99cc-d9bd971986e4.png">

Cache content on second call:
<img width="551" alt="Cache anden kald" src="https://user-images.githubusercontent.com/111397/66161886-8b824d00-e62d-11e9-9ef1-7e631c6d08f6.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

I'm not sure why we need to deep clone when setting the `$response` into the cache as all return statements are doing clone. But if you don't do this the object still changes between calls. I have test in both php 7.0 and 7.2 it's the same, so it don't seam to be an php error.