### PR TITLE
4573: Fallback to CPR when it exists from adgangsplatformen

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -450,7 +450,13 @@ function _ding_adgangsplatformen_provider_login(array $user_info) {
 
   try {
     $account = ding_user_authenticate(array(
-      'name' => $user_info['attributes']['userId'],
+      //
+      // HACK: Use CPR when exists as users may have both (CPR and card no.)
+      //       attached to their FBS user and both can then be used to login at
+      //       adgangsplatformen. But pre-authenticate can't use the card no.
+      //       so fallback to CPR if it's given.
+      //
+      'name' => is_null($user_info['attributes']['cpr']) ? $user_info['attributes']['userId'] : $user_info['attributes']['cpr'],
       //
       // HACK: The pincode used here should be removed later on.
       //       This only exists to get around pre-authentication issues


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4573

#### Description

Use CPR when exists as users may have both (CPR and card no.)  attached to their FBS user and both can then be used to login at  adgangsplatformen. But pre-authenticate can't use the card no.  so fallback to CPR if it's given.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments