### PR TITLE
4574: Fixed index in matches in rename to /user/me

### DIFF
--- a/modules/ding_user_frontend/ding_user_frontend.module
+++ b/modules/ding_user_frontend/ding_user_frontend.module
@@ -284,7 +284,7 @@ function ding_user_frontend_url_outbound_alter(&$path, &$options, $original_path
   }
 
   // Fix user path (only for better paths to the user) for provider users.
-  if (preg_match('/^user\/(\d+)$/', $path, $matches) && $user->uid == $matches[0]) {
+  if (preg_match('/^user\/(\d+)$/', $path, $matches) && $user->uid == $matches[1]) {
     $path = 'user/me';
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4574

#### Description

The users ID can be displayed in URLs and send to webtrekk. This correct the match index and ensure the URL is renamed to `/user/me`.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments