### PR TITLE
4577: Always add x-roles header

### DIFF
--- a/modules/ding_varnish/ding_varnish.module
+++ b/modules/ding_varnish/ding_varnish.module
@@ -53,14 +53,14 @@ function _ding_varnish_header() {
   global $user;
 
   // Cache response for 3 minutes to reduce request load on roll requests.
-  header('Cache-Control:public,max-age=180');
+  header('Cache-Control: public, max-age=180');
 
   // Change the cache of this response on any criteria that may determine this
   // user is coming from a different device.
-  header('Vary: Accept-Encoding,Cookie,User-Agent');
+  header('Vary: Accept-Encoding, Cookie, User-Agent');
 
   // Set custom X-Drupal-Roles header.
-  header('X-Drupal-Roles: ' . implode(',', array_keys($user->roles)));
+  header('X-Drupal-Roles: ' . implode(', ', array_keys($user->roles)));
 
   // No need to render any content. Just die.
   echo '';
@@ -125,7 +125,9 @@ function ding_varnish_init() {
 /**
  * Implements hook_page_build().
  */
-function ding_varnish_page_build() {
+function ding_varnish_page_build(&$page) {
+  global $user;
+
   // Check the static variable form init.
   $cacheable = &drupal_static('ding_varnish_init', FALSE);
   $hook_boot_headers = drupal_get_http_header();
@@ -161,10 +163,13 @@ function ding_varnish_page_build() {
   // changes after a login and not server browser cached pages. We have to set
   // the header as Drupal do in bootstrap, as this will override the default
   // header for not logged in users.
-  drupal_add_http_header('Cache-Control', 'public,max-age=' . $max_age . ',no-cache');
+  drupal_add_http_header('Cache-Control', 'public, max-age=' . $max_age . ', no-cache');
 
   // Regardless, always vary on X-Drupal-Roles.
-  drupal_add_http_header('Vary', 'X-Drupal-Roles,Accept-Encoding');
+  drupal_add_http_header('Vary', 'X-Drupal-Roles, Accept-Encoding');
+
+  // Set custom X-Drupal-Roles header.
+  header('X-Drupal-Roles: ' . implode(', ', array_keys($user->roles)));
 }
 
 /**

--- a/modules/ding_varnish/ding_varnish.module
+++ b/modules/ding_varnish/ding_varnish.module
@@ -184,11 +184,7 @@ function ding_varnish_flush_caches() {
 /**
  * Implements hook_change_maintenance_mode().
  *
- * @param Boolean $maintenance_mode
- * TRUE if the site is being set into maintenance mode.
- * FALSE if maintenance mode is being deactivated.
- *
- * Clear page cache if maintainance status has changed.
+ * Clear page cache in varnish if maintenance status has changed.
  */
 function ding_varnish_change_maintenance_mode($maintenance_mode) {
   varnish_purge_all_pages();


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4577

#### Description

Minor issues with newer version of varnish (5 - can use the same VCL file). So always set the `X-Drupal-Roles` in responses to ensure that they are available in "back response" in varnish when using vary header to hash and cache.

Also clean up headers with " " so they are formatted the same as nginx and apache do.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
