### PR TITLE
4522: Opensearch 5.2 boost configuration update

### DIFF
--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -172,6 +172,7 @@ function opensearch_boost_field_element_process($element, $form_state) {
 
   $element['weight'] = array(
     '#title' => t('Weight'),
+    '#description' => t('Must be a positive number with dot as decimal separator. Use values between 0 and 1 to downgrade.'),
     '#type' => 'textfield',
     '#default_value' => (isset($element['#value']['weight'])) ? $element['#value']['weight'] : NULL,
     '#element_validate' => array('opensearch_boost_validate_weight'),

--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -174,10 +174,20 @@ function opensearch_boost_field_element_process($element, $form_state) {
     '#title' => t('Weight'),
     '#type' => 'textfield',
     '#default_value' => (isset($element['#value']['weight'])) ? $element['#value']['weight'] : NULL,
-    '#element_validate' => array('element_validate_integer'),
+    '#element_validate' => array('opensearch_boost_validate_weight'),
   );
 
   return $element;
+}
+
+/**
+ * Element validate callback for boost weight element.
+ */
+function opensearch_boost_validate_weight($element, &$form_state) {
+  $value = $element['#value'];
+  if ($value !== '' && (!is_numeric($value) || $value <= 0)) {
+    form_error($element, t('Boost weight must be a positive number'));
+  }
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4522

#### Description

In opensearch 5.2 the boost weight value must now be a positive number and a decimal between 0 and 1 should now be used for down ranking. Hence we can not use element_validate_integer anymore.

Drupal's element_validate_number will validate float, but since we also
need to validate positive, this is not sufficient. Drupal does provide a
element_validate_integer_positive, but as the name suggest this only
works for integers. Hence we implement our own element validate callback
which does both.

In the current solution the decimal separator must be dot and not comma as requested in the case. The comma separator is a convention in Danish number formatting, but opensearch uses dot separator like all other systems. One solution would be to use `str_replace(',', '.', ..)`, but I do not think this is the correct approach. If we want to support this we could:

1. Add the [elements  module](https://www.drupal.org/project/elements) which provides a number HTML 5 element. In modern browsers, this element will follow the local number formatting in the display in frontend, but use the dot separator in memory and when form is submitted.
2.  Use the hack explained [here](https://drupal.stackexchange.com/a/228250), where intentionally add a space before the type parameter to avoid it being overriden in `theme_textfield()`. 

I think 2. is a hack and it produces invalid HTML (2 type attributes). So the question is if want to add a new module to support comma separator.

I will ask the business in the case if dot separator is acceptable.

#### Screenshot of the result

![4522-boost-weight-element](https://user-images.githubusercontent.com/5011234/66475399-8a20ac80-ea93-11e9-91ec-4ac9a9fb6c4e.PNG)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
