### PR TITLE
4579: Added optional extra to provider login call

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -123,10 +123,13 @@ function ding_user_authenticate(array $user_info) {
   $account = FALSE;
 
   try {
+    // Check if more info is provide from the user login form or SSO provider and default to empty array.
+    $extra = $user_info['extra'] ?? [];
+
     if (array_key_exists('single_sign_on', $user_info) && $user_info['single_sign_on'] == TRUE) {
       // No password provided by the authentication request (not even the empty
       // string), so we assume that this is a single-sign-on request.
-      $auth_res = ding_provider_invoke('auth', 'single_sign_on', $user_info['name']);
+      $auth_res = ding_provider_invoke('auth', 'single_sign_on', $user_info['name'], $extra);
 
       // Store value in session to be used later on to check if user was signed
       // in with SSO.
@@ -134,7 +137,7 @@ function ding_user_authenticate(array $user_info) {
     }
     else {
       // Normal user log in request.
-      $auth_res = ding_provider_invoke('user', 'authenticate', $user_info['name'], $user_info['pass']);
+      $auth_res = ding_provider_invoke('user', 'authenticate', $user_info['name'], $user_info['pass'], $extra);
     }
   }
   catch (DingProviderNoProvider $exception) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4579

#### Description

When login in at eReolen we need more information from the login form and from adgangsplatformen to preform the login at the provider. This allow us to send this information via the `$user_info['extra']`in the call to `ding_user_authenticate` and forward that to the active provider.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.