### PR TITLE
4212: Return NULL as expected if no objects was found

### DIFF
--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -517,7 +517,7 @@ function opensearch_execute(TingClientRequest $request) {
         $request->setLocalIds($original_local_ids);
       }
 
-      // If response is empty array it means ther was no objects found for the
+      // If response is empty array it means there was no objects found for the
       // passed ids. In this case we need to return NULL as expected by the
       // caller.
       if (empty($response)) {

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -516,6 +516,13 @@ function opensearch_execute(TingClientRequest $request) {
       if ($original_local_ids) {
         $request->setLocalIds($original_local_ids);
       }
+
+      // If response is empty array it means ther was no objects found for the
+      // passed ids. In this case we need to return NULL as expected by the
+      // caller.
+      if (empty($response)) {
+        $response = NULL;
+      }
     }
 
     // Update the cache with the raw response object from the data well for


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4212

#### Description

This change should be merged together with: https://github.com/ding2/ting-client/pull/31.

Now that we handle missing object errors and not returning errors as real objects, there is now a chance that an object request will return NULL in the current state of the code.

[Our caching logic doesn't like this](https://github.com/ding2/ding2/blob/master/modules/opensearch/opensearch.client.inc#L509).

This is very fragile and I think the best course of action is to make TingClientObjectRequest return empty array if nothing was found, which I have implemented in https://github.com/ding2/ting-client/pull/31. 

It's still expected that we return NULL from opensearch_execute() if nothing was found, so this check is now needed.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
