### PR TITLE
4555: Fix reservation webtrekk event on teaser view

### DIFF
--- a/modules/ding_ting_frontend/ding_ting_frontend.features.field_instance.inc
+++ b/modules/ding_ting_frontend/ding_ting_frontend.features.field_instance.inc
@@ -172,7 +172,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 11,
+        'weight' => 12,
       ),
       'search_result' => array(
         'label' => 'above',
@@ -190,7 +190,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 13,
+        'weight' => 33,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -261,10 +261,11 @@ function ding_ting_frontend_field_default_field_instances() {
         'weight' => 3,
       ),
       'reference_teaser' => array(
-        'label' => 'above',
+        'label' => 'hidden',
+        'module' => 'ding_entity',
         'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 15,
+        'type' => 'ding_entity_buttons_ajax',
+        'weight' => 4,
       ),
       'search_result' => array(
         'label' => 'above',
@@ -273,16 +274,18 @@ function ding_ting_frontend_field_default_field_instances() {
         'weight' => 24,
       ),
       'teaser' => array(
-        'label' => 'above',
+        'label' => 'hidden',
+        'module' => 'ding_entity',
         'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 3,
+        'type' => 'ding_entity_buttons_ajax',
+        'weight' => 46,
       ),
       'teaser_no_overlay' => array(
-        'label' => 'above',
+        'label' => 'hidden',
+        'module' => 'ding_entity',
         'settings' => array(),
-        'type' => 'hidden',
-        'weight' => 14,
+        'type' => 'ding_entity_buttons_ajax',
+        'weight' => 11,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -359,7 +362,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting',
         'settings' => array(),
         'type' => 'ting_abstract_default',
-        'weight' => 6,
+        'weight' => 5,
       ),
       'search_result' => array(
         'label' => 'hidden',
@@ -458,7 +461,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'module' => 'ting',
         'settings' => array(),
         'type' => 'ting_author_default',
-        'weight' => 5,
+        'weight' => 4,
       ),
       'search_result' => array(
         'label' => 'hidden',
@@ -572,7 +575,7 @@ function ding_ting_frontend_field_default_field_instances() {
           'link_type' => 'object',
         ),
         'type' => 'ting_cover_default',
-        'weight' => 0,
+        'weight' => 1,
       ),
       'search_result' => array(
         'label' => 'hidden',
@@ -683,7 +686,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 12,
+        'weight' => 13,
       ),
       'search_result' => array(
         'label' => 'above',
@@ -701,7 +704,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 24,
+        'weight' => 38,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -775,7 +778,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 14,
+        'weight' => 15,
       ),
       'search_result' => array(
         'label' => 'above',
@@ -793,7 +796,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 23,
+        'weight' => 37,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -868,7 +871,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 6,
+        'weight' => 7,
       ),
       'search_result' => array(
         'label' => 'above',
@@ -887,7 +890,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 22,
+        'weight' => 36,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -981,7 +984,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
-        'weight' => 21,
+        'weight' => 35,
       ),
       'ting_reference_preview' => array(
         'label' => 'above',
@@ -1068,6 +1071,7 @@ function ding_ting_frontend_field_default_field_instances() {
         'label' => 'hidden',
         'module' => 'ting',
         'settings' => array(
+          'element' => 'h2',
           'link_type' => 'object',
           'prefix_type' => 'no',
         ),
@@ -1083,7 +1087,7 @@ function ding_ting_frontend_field_default_field_instances() {
           'prefix_type' => 'no',
         ),
         'type' => 'ting_title_default',
-        'weight' => 4,
+        'weight' => 3,
       ),
       'search_result' => array(
         'label' => 'hidden',

--- a/modules/ding_ting_frontend/ding_ting_frontend.field_group.inc
+++ b/modules/ding_ting_frontend/ding_ting_frontend.field_group.inc
@@ -248,6 +248,7 @@ function ding_ting_frontend_field_group_info() {
     'children' => array(
       0 => 'ting_abstract',
       1 => 'group_inner',
+      0 => 'ding_entity_buttons',
     ),
     'format_type' => 'div',
     'format_settings' => array(
@@ -281,6 +282,7 @@ function ding_ting_frontend_field_group_info() {
     'children' => array(
       0 => 'ting_abstract',
       1 => 'group_inner',
+      0 => 'ding_entity_buttons',
     ),
     'format_type' => 'div',
     'format_settings' => array(

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -159,6 +159,10 @@
           opacity: 1;
         }
       }
+      // Hide ding list add entity button in teaser view modes.
+      .ding-list-add-button {
+        display: none;
+      }
 
       // Hover for non touch devices
       &:hover {
@@ -330,6 +334,9 @@
         @include media($tablet) {
           width: 42%;
         }
+      }
+      .ding-list-add-button {
+        display: none;
       }
     }
     .field-name-ting-type {

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -859,24 +859,6 @@ function ddbasic_process_ting_object(&$vars) {
             '#weight' => 9998,
           );
 
-          if ($vars['object']->is('library_material')) {
-            $vars['content']['group_text']['reserve_button'] = ding_reservation_ding_entity_buttons(
-              'ding_entity',
-              $vars['object'],
-              $vars['elements']['#view_mode'],
-              'ajax'
-            );
-          }
-          if ($vars['object']->is('online')) {
-            // Slice the output, so it only usese the online link button.
-            $vars['content']['group_text']['online_link'] = ting_ding_entity_buttons(
-              'ding_entity',
-              $vars['object'],
-              $vars['elements']['#view_mode'],
-              'default'
-            );
-          }
-
           // Truncate abstract.
           $vars['content']['group_text']['ting_abstract'][0]['#markup'] = add_ellipsis($vars['content']['group_text']['ting_abstract'][0]['#markup'], 330);
           break;
@@ -900,24 +882,6 @@ function ddbasic_process_ting_object(&$vars) {
             ),
             '#weight' => 9998,
           );
-
-          if ($vars['object']->is('library_material')) {
-            $vars['content']['group_text']['reserve_button'] = ding_reservation_ding_entity_buttons(
-              'ding_entity',
-              $vars['object'],
-              $vars['elements']['#view_mode'],
-              'ajax'
-            );
-          }
-          if ($vars['object']->is('online')) {
-            // Slice the output, so it only usese the online link button.
-            $vars['content']['group_text']['online_link'] = ting_ding_entity_buttons(
-              'ding_entity',
-              $vars['object'],
-              $vars['elements']['#view_mode'],
-              'default'
-            );
-          }
 
           // Truncate default title.
           $vars['static_title'] = '<div class="field-name-ting-title"><h3>' . add_ellipsis($vars['elements']['group_text']['group_inner']['ting_title'][0]['#markup'], 40) . '</h3></div>';
@@ -951,23 +915,8 @@ function ddbasic_process_ting_object(&$vars) {
             ),
           );
 
-          if ($vars['object']->is('library_material')) {
-            $vars['content']['buttons']['reserve_button'] = ding_reservation_ding_entity_buttons(
-              'ding_entity',
-              $vars['object'],
-              $vars['elements']['#view_mode'],
-              'ajax'
-            );
-          }
-          if ($vars['object']->is('online')) {
-            // Slice the output, so it only usese the online link button.
-            $vars['content']['buttons']['online_link'] = ting_ding_entity_buttons(
-              'ding_entity',
-              $vars['object'],
-              $vars['elements']['#view_mode'],
-              'default'
-            );
-          }
+          $vars['content']['buttons']['ding_entity_buttons'] = $vars['content']['ding_entity_buttons'];
+          unset($vars['content']['ding_entity_buttons']);
 
           break;
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4555

#### Description

Ding Webtrekk was failing to attach tracking event in hook_entity_view() because reservation (and also see online) button was added manually in theme layer. This was probably done because only a some ding_entity buttons is wanted in teaser views and not all returned by ding_entity_buttons hook.

I think the correct approach is to add the buttons in field config as with other view modes, so that other module have a chance to know they are there. Then any unwanted stuff must then be hanlded in the theme layer after this.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
