### PR TITLE
4582: Ensure we use correct field to get phone number

### DIFF
--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -310,7 +310,7 @@ function ding_place2book_node_presave($node) {
   try {
     $p2b = ding_place2book_instance();
     $event = $p2b->getEvent($event_maker_id, $event_id);
-    if (!$event->passive) {
+    if (empty($event->passive)) {
       $node_wrapper
         ->field_ding_event_ticket_link
         ->url

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -637,7 +637,7 @@ function _ding_p2b_get_address_data($node) {
       $data[$name] = drupal_array_get_nested_value($lib, $option);
     }
   }
-  $data['phone'] = empty($data['phone']) ? t('None') : $data['phone'];
+  $data['phone'] = empty($data['phone']) ? 'None' : $data['phone'];
   $data['address2'] = '';
 
   return $data;

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -635,9 +635,14 @@ function _ding_p2b_get_address_data($node) {
         $option[0] = 'field_ding_library_addresse';
       }
       $data[$name] = drupal_array_get_nested_value($lib, $option);
+
+      // If we still couldn't find the value or it is for some other reason
+      // empty, ensure that we send an empty string as expected by the API.
+      if (empty($data[$name])) {
+        $data[$name] = '';
+      }
     }
   }
-  $data['phone'] = empty($data['phone']) ? 'None' : $data['phone'];
   $data['address2'] = '';
 
   return $data;

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -623,11 +623,15 @@ function _ding_p2b_get_address_data($node) {
   foreach ($options as $name => $option) {
     $result = NULL;
     $data[$name] = drupal_array_get_nested_value($node, $option, $result);
+
+    // If we couldn't find the required data on the event node, we'll have a
+    // look at the library node.
     if (($result === FALSE || empty($data[$name])) && $lib) {
       if ($name == 'name') {
         $option = array('title');
       }
-      else {
+      // The field for location data is named differently on ding_library nodes.
+      elseif ($option[0] == 'field_ding_event_location') {
         $option[0] = 'field_ding_library_addresse';
       }
       $data[$name] = drupal_array_get_nested_value($lib, $option);

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -586,12 +586,6 @@ function _ding_p2b_get_address_data($node) {
       0,
       'thoroughfare',
     ),
-    "address2" => array(
-      'field_ding_event_location',
-      LANGUAGE_NONE,
-      0,
-      'premise',
-    ),
     "postal_code" => array(
       'field_ding_event_location',
       LANGUAGE_NONE,
@@ -643,7 +637,6 @@ function _ding_p2b_get_address_data($node) {
       }
     }
   }
-  $data['address2'] = '';
 
   return $data;
 }

--- a/modules/ding_place2book/lib/p2b/P2b.php
+++ b/modules/ding_place2book/lib/p2b/P2b.php
@@ -615,7 +615,7 @@ class P2b {
         $this->p2bCheckRequired($required[$key], $given[$key]);
       }
       else {
-        $value = empty($given[$key]) && $given[$key] !== '0';
+        $value = !isset($given[$key]);
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4582

#### Description

Before every option not found on event node that was not 'name' was
incorrectly using the address field to look for phone number on library
node. Therefore the phonenumber was never actually send to p2b API, but
instead the translated value of 'None'.

This PR changes the logic so that we used the correct field_name. 

Also ensure that we send empty string if we can't find value as expected by the p2b API.

It looks like we have never send the phone number, regardless of whether it's set on library phone field, and p2b API have just started to react on this now. I have verified this by looking at what is send from our production site, which is still using last release:

```
[address1] => Willy Sørensens Plads 1
[address2] =>
[postal_code] => 7100
[city] => Vejle
[country] => DK
[phone] => Ingen
[name] => Vejle Bibliotek
```

And we also get the error now in production, when trying to create p2b-synced events. So something has changed in p2b API.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
