### PR TITLE
4153: Removed messages border

### DIFF
--- a/themes/ddbasic/sass/components/messages.scss
+++ b/themes/ddbasic/sass/components/messages.scss
@@ -68,7 +68,6 @@
         padding: 5px 0;
         margin: 5px 0;
         color: $color-standard-text;
-        border-bottom: 1px solid $grey;
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4153

#### Description

Removed messages bottom border

#### Screenshot of the result

![Screenshot 2019-10-23 at 11 39 01](https://user-images.githubusercontent.com/30495061/67379822-bc4d0680-f589-11e9-958e-543d2e4678ed.png)
