### PR TITLE
4600: Fix wrong link on overdue loans block

### DIFF
--- a/modules/ding_user_frontend/plugins/content_types/user_overview.inc
+++ b/modules/ding_user_frontend/plugins/content_types/user_overview.inc
@@ -64,7 +64,7 @@ function ding_user_frontend_user_overview_content_type_render($subtype, $conf, $
     if ($overdues > 0) {
       $list[DING_USER_FRONTEND_LIST_LOANS_OVERDUE] = array(
         'data' =>
-        '<a href="' . url($uri['path'] . '/status-loans') . '" class="signature-label"><span class="icon"></span>' . t('Loans overdue') . '</a>' . '<span class="label warn">' . $overdues . '</span>',
+        '<a href="' . url($uri['path'] . '/status-loans-overdue') . '" class="signature-label"><span class="icon"></span>' . t('Loans overdue') . '</a>' . '<span class="label warn">' . $overdues . '</span>',
         'class' => array('warn'),
       );
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4600

#### Description

Fixes wrong link on overdue loans block.

#### Screenshot of the result

![4600-overdue-loans-wrong-link](https://user-images.githubusercontent.com/5011234/67855894-aef8c480-fb13-11e9-9072-3670dd60bf0e.PNG)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
