### PR TITLE
4598 by Inlead: Replace "Relevant Campaign" with "Relevant Campaign Plus"

### DIFF
--- a/modules/ding_campaign_plus/ding_campaign_plus.install
+++ b/modules/ding_campaign_plus/ding_campaign_plus.install
@@ -75,3 +75,36 @@ function ding_campaign_plus_update_7001() {
   // Do a lightweight purge to catch any issues early in the deployment.
   field_purge_batch(10);
 }
+
+/**
+ * Replace Relevant Campaign with Relevant Campaign Plus.
+ */
+function ding_campaign_plus_update_7002() {
+  $campaign_panes = db_select('panels_pane', 'pp')
+    ->fields('pp')
+    ->condition('type', 'campaign')
+    ->condition('subtype', 'campaign')
+    ->execute()
+    ->fetchAll();
+
+  foreach ($campaign_panes as $campaign_pane) {
+    $conf = unserialize($campaign_pane->configuration);
+    unset($conf['ding_campaign_count']);
+    unset($conf['ding_campaign_offset']);
+    unset($conf['ding_campaign_image_style']);
+
+    $conf['style'] = 'box';
+
+    $final = serialize($conf);
+
+    db_update('panels_pane')
+      ->fields([
+        'type' => 'ding_campaign_plus',
+        'subtype' => 'ding_campaign_plus',
+        'configuration' => $final,
+      ])
+      ->condition('type', 'campaign')
+      ->condition('subtype', 'campaign')
+      ->execute();
+  }
+}

--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
@@ -180,14 +180,11 @@ function ding_sections_term_panel_get_handler() {
     $pane = new stdClass();
     $pane->pid = 'new-21812a33-baf5-462c-856c-baaa99916d1a';
     $pane->panel = 'primary';
-    $pane->type = 'campaign';
-    $pane->subtype = 'campaign';
+    $pane->type = 'ding_campaign_plus';
+    $pane->subtype = 'ding_campaign_plus';
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'ding_campaign_count' => 3,
-      'ding_campaign_offset' => 0,
-      'ding_campaign_image_style' => 'ding_campaign_p_25',
       'context' => array(
         0 => 'empty',
         1 => 'empty',
@@ -197,6 +194,7 @@ function ding_sections_term_panel_get_handler() {
       'override_title' => 0,
       'override_title_text' => '',
       'override_title_heading' => 'h2',
+      'style' => 'box',
     );
     $pane->cache = array();
     $pane->style = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4598

#### Description

We should replace "Relevant Campaign" with "Relevant Campaign Plus" on frontpage and ding_section default page..

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
