### PR TITLE
4604: Improve handling of "Closed" text for opening hours

### DIFF
--- a/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/ding_ddbasic_opening_hours.module
+++ b/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/ding_ddbasic_opening_hours.module
@@ -146,7 +146,11 @@ function ding_ddbasic_opening_hours_get_category_name($category_tid) {
 }
 
 /**
- * Get weight of an opening hours category tid.
+ * Get unique weight of an opening hours category tid.
+ *
+ * Unlike Drupal weights were multiple values can have the same weight this
+ * function will return a unique weight for each category. This makes weights
+ * suitable for array keys etc.
  */
 function ding_ddbasic_opening_hours_get_category_weight($category_tid) {
   $weight = &drupal_static(__FUNCTION__, array());
@@ -157,7 +161,15 @@ function ding_ddbasic_opening_hours_get_category_weight($category_tid) {
     }
     else {
       $term = taxonomy_term_load($category_tid);
-      $weight[$category_tid] = $term->weight;
+      $term_weight = (int) $term->weight;
+      // To ensure that we do not return an already used weight we bump this
+      // weight by one until we hit a free value. Any subsequent term which
+      // already have this weight assigned will also get a new weight but
+      // should appear in the same order as before.
+      while (array_search($term_weight, $weight) !== FALSE) {
+        $term_weight++;
+      }
+      $weight[$category_tid] = $term_weight;
     }
   }
   return $weight[$category_tid];

--- a/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/ding_ddbasic_opening_hours.theme.inc
+++ b/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/ding_ddbasic_opening_hours.theme.inc
@@ -26,18 +26,6 @@ function template_preprocess_ding_ddbasic_opening_hours_week(&$variables) {
   $structured = array();
   $categories = array();
 
-  // Load all categories.
-  $machine_name = variable_get('opening_hours_category_vocabulary_ding_library', 0);
-  if (!empty($machine_name)) {
-    $vocabulary = taxonomy_vocabulary_machine_name_load($machine_name);
-
-    if ($vocabulary) {
-      foreach (taxonomy_get_tree($vocabulary->vid, 0, 1) as $term) {
-        $categories[ding_ddbasic_opening_hours_get_category_weight($term->tid)] = $term->name;
-      }
-    }
-  }
-
   if (!empty($variables['timespan'])) {
     $timespan = $variables['timespan'];
   }
@@ -50,6 +38,10 @@ function template_preprocess_ding_ddbasic_opening_hours_week(&$variables) {
   );
   $instances = array_filter($instances, '_opening_hours_exclude_blocked');
 
+  $category_tids = array_unique(array_map(function (stdClass $instance) {
+    return $instance->category_tid;
+  }, $instances));
+
   // Add closed days.
   for ($day = $timespan[0]; $day <= $timespan[1]; $day += DING_DDBASIC_OPENING_HOURS_ONE_DAY) {
     $date = date('Y-m-d', $day);
@@ -61,16 +53,21 @@ function template_preprocess_ding_ddbasic_opening_hours_week(&$variables) {
     }
 
     if ($closed === TRUE) {
-      $instances[] = (object) array(
-        'instance_id' => -1,
-        'nid' => $variables['node']->nid,
-        'start_time' => '0',
-        'end_time' => '0',
-        'category_tid' => NULL,
-        'date' => $date,
-        'closed' => TRUE,
-        'notice' => t('Closed'),
-      );
+      // If a day is closed then generate closed instanced for each available
+      // category.
+      $closed_instances = array_map(function ($category_tid) use ($variables, $date) {
+        return (object) [
+          'instance_id' => -1,
+          'nid' => $variables['node']->nid,
+          'start_time' => '0',
+          'end_time' => '0',
+          'category_tid' => $category_tid,
+          'date' => $date,
+          'closed' => true,
+          'notice' => t('Closed'),
+        ];
+      }, $category_tids);
+      $instances = array_merge($instances, $closed_instances);
     }
   }
 
@@ -137,41 +134,6 @@ function template_preprocess_ding_ddbasic_opening_hours_week(&$variables) {
     '@from' => format_date($timespan[0], 'custom', 'd.m'),
     '@to' => format_date($timespan[1], 'custom', 'd.m'),
   ));
-
-  // Set first real category for "closed" days (-1).
-  $default = -1;
-  foreach ($structured as $day) {
-    $weights = array_keys($day['cols']);
-    foreach ($weights as $weight) {
-      if ($weight !== $default) {
-        $default = $weight;
-        break 2;
-      }
-    }
-  }
-
-  // Remove the -1 category.
-  unset($categories[-1]);
-
-  // Close notice.
-  $notice = '<span class="opening-hours-table-notice">' . t('Closed') . '</span>';
-
-  // Default category found, so move data around.
-  foreach ($structured as &$day) {
-    if (array_key_exists(-1, $day['cols'])) {
-      isset($day['cols'][$default]) ? $day['cols'][$default] += $day['cols'][-1] : $day['cols'][$default] = $day['cols'][-1];
-      unset($day['cols'][-1]);
-    }
-
-    // Fill in closed in empty fields.
-    if (count($day['cols']) !== count($categories)) {
-      foreach ($categories as $key => $category) {
-        if (!isset($day['cols'][$key])) {
-          $day['cols'][$key] = $notice;
-        }
-      }
-    }
-  }
 
   $variables['table'] = ding_ddbasic_opening_hours_table(
     $title,


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4604

#### Description

In the current form opening hours are not displayed correctly for some libraries if they:

1. Have not altered the weights of the opening hours category terms
2. Do not use categories

Issue 1 is caused by the fact that the code e.g. L125 uses weights for array entries. However Drupal weights are not unique. Terms will get a unique weight once reordered by an editor butby default the weight of all terms is 0.  This will cause opening hours for one category to override others.

We handle this by generating a unique "weight" for each category. Categories with same Drupal weights are assigned an increasing weight to avoid collisions. Any subsequent collisions are handled by increased more weights. This should result in the same order as before but with unique values.

Issue 2 seems to be caused by faulty merging of the default row of opening hours containing "Closed" texts into other categories to prevent it from appearing. This causes libraries which do not use categories to appear as if closed every day.

We handle this by replacing the faulty merging by a process which generates "Closed" text for each category from the start.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

GitCop does not like the fancy quote marks 😕 .