### PR TITLE
4595: Undo removing gradient from 4095.

### DIFF
--- a/themes/ddbasic/sass/components/ding-tabroll.scss
+++ b/themes/ddbasic/sass/components/ding-tabroll.scss
@@ -135,13 +135,16 @@
     position: relative;
     padding: 0;
     .info {
+      @include linear-gradient(
+          transparent 0%,
+          $charcoal-opacity-dark 100%
+      );
       @include font('display-small');
       position: absolute;
       bottom: 0;
       left: 0;
       width: 100%;
       color: $white;
-      background: $charcoal-opacity-dark;
       padding-bottom: 25px;
       h3 {
         @include font('display');


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4595

#### Description

I've previously fixed issues with constrast, but it was a bit too much.
DDB has asked me to revert it so they can find a better design solution.

#### Screenshot of the result

Reverting back to what it was before (despite issues with contrast):

<img width="637" alt="Screenshot 2019-11-07 at 11 28 33" src="https://user-images.githubusercontent.com/12376583/68381448-091c0a00-0152-11ea-93c5-6655e5e494f2.png">


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.