### PR TITLE
4597: Make ting-object teaser h3 instead of h2.

### DIFF
--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -933,7 +933,7 @@ function ddbasic_process_ting_object(&$vars) {
           }
 
           // Truncate default title.
-          $vars['static_title'] = '<div class="field-name-ting-title"><h2>' . add_ellipsis($vars['elements']['group_text']['group_inner']['ting_title'][0]['#markup'], 40) . '</h2></div>';
+          $vars['static_title'] = '<div class="field-name-ting-title"><h3>' . add_ellipsis($vars['elements']['group_text']['group_inner']['ting_title'][0]['#markup'], 40) . '</h3></div>';
 
           // Truncate abstract.
           $vars['content']['group_text']['ting_abstract'][0]['#markup'] = add_ellipsis($vars['content']['group_text']['ting_abstract'][0]['#markup'], 330);
@@ -944,7 +944,7 @@ function ddbasic_process_ting_object(&$vars) {
           }
 
           break;
-        
+
           // Check if teaser has rating function and remove abstract.
           if (!empty($vars['content']['group_text']['group_rating']['ding_entity_rating_action'])) {
             unset($vars['content']['group_text']['ting_abstract']);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4597

#### Description
When "overlay" is disabled, ting object teasers use h2 instead of h3. This is wrong and makes the title huge.

#### Screenshot of the result

Before:

<img width="298" alt="Screenshot 2019-11-07 at 13 52 09" src="https://user-images.githubusercontent.com/12376583/68390550-d0862b80-0165-11ea-9172-0f1e28564de2.png">


After:
<img width="1165" alt="Screenshot 2019-11-07 at 13 49 45" src="https://user-images.githubusercontent.com/12376583/68390492-b1879980-0165-11ea-8340-9fd3bd6e0e3c.png">


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
