### PR TITLE
4612: Improve redirection to /user/me from /user/uid in urls

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -268,7 +268,7 @@ function ding_user_entity_info_alter(&$entity_info) {
  */
 function ding_user_deliver_html_page($page_callback_result) {
   if ($page_callback_result == MENU_ACCESS_DENIED) {
-    drupal_deliver_page(MENU_NOT_FOUND);
+    drupal_goto('<front>');
   }
   else {
     drupal_deliver_html_page($page_callback_result);

--- a/modules/ding_user_frontend/ding_user_frontend.module
+++ b/modules/ding_user_frontend/ding_user_frontend.module
@@ -274,18 +274,13 @@ function ding_user_frontend_build_menu($path = NULL) {
  */
 function ding_user_frontend_url_outbound_alter(&$path, &$options, $original_path) {
   global $user;
-  if (preg_match('/^user\/(\d+)\/(.*)$/', $path, $matches)) {
+  if (preg_match('/^user\/(\d+)\/?(.*)$/', $path, $matches)) {
     // To allow site administrators to edit other user they have to be filter
     // out of this alter. When accessing another drupal user account.
-    if ($user->uid == $matches[1] && !(in_array("administrators", $user->roles) || in_array("local administrator", $user->roles))) {
+    if ($user->uid == $matches[1]) {
       // This was not the above case, so we change the path to use "me".
-      $path = 'user/me/' . $matches[2];
+      $path = !empty($matches[2]) ? 'user/me/' . $matches[2] : 'user/me';
     }
-  }
-
-  // Fix user path (only for better paths to the user) for provider users.
-  if (preg_match('/^user\/(\d+)$/', $path, $matches) && $user->uid == $matches[1]) {
-    $path = 'user/me';
   }
 }
 
@@ -296,6 +291,9 @@ function ding_user_frontend_url_outbound_alter(&$path, &$options, $original_path
  * ding_user_frontend_build_uniform_menu_link().
  */
 function ding_user_frontend_url_inbound_alter(&$path, $original_path, $path_language) {
+  // Store the path. This allows us to check whether we modified it or not.
+  ding_user_frontend_original_path($original_path);
+
   if (preg_match('/^user\/me\/{0,1}(.*)$/', $path, $matches)) {
     global $user;
     $uid = user_is_logged_in() ? $user->uid : 0;
@@ -309,6 +307,44 @@ function ding_user_frontend_url_inbound_alter(&$path, $original_path, $path_lang
       }
     }
   }
+}
+
+/**
+ * Implements hook_init().
+ */
+function ding_user_frontend_init() {
+  global $user;
+  // If the original path contains a user id corresponding to a patron instead
+  // of me then assume that the user intend to access their own profile and
+  // redirect to /user/me. drupal_goto() will alter the outbound url before the
+  // redirect.
+  if (preg_match('/^user\/(\d+)\/?(.*)$/', ding_user_frontend_original_path(), $matches)) {
+    if ($user->uid == $matches[1]) {
+      drupal_goto(ding_user_frontend_original_path());
+    }
+  }
+}
+
+/**
+ * Store/retrieve the original path used to access the current page.
+ *
+ * The original path is the one before we and potentially others have modified
+ * it using hook_url_inbound_alter().
+ *
+ * @param string|null $path
+ *   The path to store. If NULl then the path will not be set.
+ *
+ * @return string
+ *   The original path.
+ */
+function ding_user_frontend_original_path($path = NULL) {
+  static $original_path;
+
+  if (!empty($path)) {
+    $original_path = $path;
+  }
+
+  return $original_path;
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4612

#### Description

This prevents uids from being picked up in trackers which can lead
to linking of user identity to specific user behavior.

Before this change users could access urls in the /user/uid format.
If not logged in then this url would display “page not found”. If the
user was logged in then this url would work just as well as the
preferred /user/me format.

To avoid these urls from being tracked we redirect immediately to
the frontpage for user pages without access and for users seeing
their own profile then redirect to /user/me.

Uids will still show up in urls where an administrative user accesses
another user but that is acceptable.

The change needed here can cause a lot of redirect trouble. I have 
tried to test the following combinations:

Active user / Viewed user  | Another user | Another editor | Another admin | The current user
-- | -- | -- | -- | --
**Anonymous** | Redirect to frontpage | Show profile with alias | Redirect to frontpage |  -
**User** | Redirect to frontpage | Show profile with alias | Redirect to frontpage | Redirect to /user/me
**Editor** | Redirect to frontpage | Show profile with alias | Redirect to frontpage | Show own profile with alias
**Admin** | Show profile with UID | Show profile with alias | Redirect to frontpage | Show own profile with alias

The important part here is the fact that the only user role able to see an uid is an administrator and tracking this url should not lead to any subsequent tracking of the user with the uid.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Gitcop failure is caused by not being able to handle fancy quotes.