### PR TITLE
4597: Fix CSS issues with disable-overlay.

### DIFF
--- a/themes/ddbasic/sass/components/ding-carousel.scss
+++ b/themes/ddbasic/sass/components/ding-carousel.scss
@@ -67,18 +67,16 @@
   .carousel-select {
     display: none;
     width: 100%;
-    padding-right: 160px;
     float: left;
-    margin-top: -54px;
+    position: relative;
+    padding: 0;
+    margin: 0;
+    margin-bottom: 20px;
+    height: auto;
 
     // Tablet
     @include media($tablet) {
       display: block;
-    }
-
-    // Mobile
-    @include media($mobile) {
-      padding-right: 0;
     }
   }
 }

--- a/themes/ddbasic/sass/components/ding-tabroll.scss
+++ b/themes/ddbasic/sass/components/ding-tabroll.scss
@@ -187,12 +187,15 @@
       @include media($mobile) {
         @include font('base');
         position: static;
+        overflow: hidden;
+        padding: 20px;
+        box-sizing: border-box;
         background-image: none;
-        color: $color-standard-text;
+        color: $white;
         h3 {
           a {
-            padding: 14px 0 0;
-            color: $charcoal;
+            padding: 0;
+            color: $white;
           }
         }
         p {
@@ -203,23 +206,18 @@
 
     //No-overlay
     .no-overlay & {
-      .image {
-        margin-bottom: 14px;
-      }
       .info {
         position: static;
         width: 100%;
         float: left;
         background-image: none;
-        color: $color-standard-text;
-
-        @include media($mobile) {
-          padding-bottom: 0;
-        }
+        color: $white;
+        padding: 20px;
+        box-sizing: border-box;
 
         h3 {
           a {
-            color: $color-standard-text;
+            color: $white;
             padding: 0;
           }
         }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4597

#### Description

In relation to a recent (?) update, various elements have broken when you choose "disable overlay" in the DDBasic theme settings.

This aims to fix them, as best possible.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
