### PR TITLE
4595: Set tabroll color to dark again.

### DIFF
--- a/themes/ddbasic/sass/components/ding-tabroll.scss
+++ b/themes/ddbasic/sass/components/ding-tabroll.scss
@@ -191,14 +191,14 @@
         @include font('base');
         position: static;
         overflow: hidden;
-        padding: 20px;
+        padding: 20px 0;
         box-sizing: border-box;
         background-image: none;
-        color: $white;
+        color: $color-standard-text;
         h3 {
           a {
             padding: 0;
-            color: $white;
+            color: $color-standard-text;
           }
         }
         p {
@@ -214,13 +214,13 @@
         width: 100%;
         float: left;
         background-image: none;
-        color: $white;
-        padding: 20px;
+        color: $color-standard-text;
+        padding: 20px 0;
         box-sizing: border-box;
 
         h3 {
           a {
-            color: $white;
+            color: $color-standard-text;
             padding: 0;
           }
         }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4595

#### Description

Multiple people must have been fixing the tabroll styling, because for some reason, the text has gone white with no dark background.
This sets the text back to dark.


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
