### PR TITLE
4625 by Inlead: Adopt with recent service changes.

### DIFF
--- a/modules/bpi/bpi.images.inc
+++ b/modules/bpi/bpi.images.inc
@@ -44,7 +44,7 @@ function bpi_syndicate_images($type = 'ajax') {
  *
  * @ingroup forms
  */
-function bpi_assets_form($form, $form_state, $assets = array()) {
+function bpi_assets_form(array $form, array $form_state, $assets = array()) {
   if (!empty($assets)) {
     $form['bpi_assets'] = array(
       '#type' => 'fieldset',
@@ -86,7 +86,7 @@ function bpi_assets_form($form, $form_state, $assets = array()) {
  *
  * @ingroup forms
  */
-function bpi_assets_form_submit($form, &$form_state) {
+function bpi_assets_form_submit(array $form, array &$form_state) {
   $bpi_assets = $_SESSION['bpi']['assets'];
 
   $assets = array();
@@ -144,7 +144,7 @@ function bpi_assets_form_submit($form, &$form_state) {
  *
  * @ingroup forms
  */
-function bpi_asset_action_ajax_callback($form, &$form_state) {
+function bpi_asset_action_ajax_callback(array $form, array &$form_state) {
   ctools_include('ajax');
 
   $commands = array();
@@ -168,7 +168,7 @@ function bpi_asset_action_ajax_callback($form, &$form_state) {
  *
  * @ingroup forms
  */
-function bpi_asset_cancel_ajax_callback($form, &$form_state) {
+function bpi_asset_cancel_ajax_callback(array $form, array &$form_state) {
   $commands = array();
 
   $commands[] = ajax_command_ding_popup_close(
@@ -207,7 +207,7 @@ function bpi_fetch_image($filename, $image_url) {
   if (!file_prepare_directory($directory, FILE_CREATE_DIRECTORY | FILE_MODIFY_PERMISSIONS)) {
     watchdog(
       'bpi',
-      t('Failed to create directory: %directory'),
+      'Failed to create directory: %directory',
       array('%directory' => $directory),
       WATCHDOG_ERROR
     );

--- a/modules/bpi/bpi.images.inc
+++ b/modules/bpi/bpi.images.inc
@@ -22,9 +22,7 @@ function bpi_syndicate_images($type = 'ajax') {
 
   $form = drupal_get_form('bpi_assets_form', $assets);
   $commands = array();
-
   ctools_include('modal');
-  ctools_modal_add_js();
   $commands[] = ctools_modal_command_display(t('Syndicate images'), drupal_render($form));
 
   return array('#type' => 'ajax', '#commands' => $commands);
@@ -58,7 +56,7 @@ function bpi_assets_form($form, $form_state, $assets = array()) {
         $form['bpi_assets']['asset::' . $type . '::' . $index] = array(
           '#type' => 'checkbox',
           '#default_value' => 1,
-          '#prefix' => '<div class="bpi-syndicate-asset"><img src="' . $asset['path'] . '" width="100" height="100" />' . '<br/> (' . bpi_get_image_display_name($asset['type']) . ')',
+          '#prefix' => '<div class="bpi-syndicate-asset"><img src="' . $asset['path'] . '" width="100" height="100" />' . '<br/> (' . bpi_get_image_display_name($type) . ')',
           '#suffix' => '</div>',
         );
       }
@@ -110,17 +108,14 @@ function bpi_assets_form_submit($form, &$form_state) {
   $syndicated_images = array();
   $status = TRUE;
   foreach ($assets as $asset) {
-    $filename = $asset['type'] . '/' . uniqid() . '.' . $asset['extension'];
+    $filename = basename($asset['path']);
     $managed_file = bpi_fetch_image('public://bpi/' . $filename, $asset['path']);
 
     if (!is_object($managed_file)) {
       $status = FALSE;
     }
     else {
-      if (!isset($syndicated_images[$asset['type']])) {
-        $syndicated_images[$asset['type']] = array();
-      }
-      $syndicated_images[$asset['type']][] = $asset + array('@managed_file' => $managed_file);
+      $syndicated_images[$asset['name']][] = $asset + array('@managed_file' => $managed_file);
     }
   }
 
@@ -284,7 +279,7 @@ function bpi_clear_syndicated_images() {
  */
 function bpi_get_image_display_name($image_type) {
   $types = array(
-    'body' => t('Inline image'),
+    'embedded' => t('Inline image'),
     'list_image' => t('List image'),
     'title_image' => t('Title image'),
   );

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -360,6 +360,9 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
       drupal_add_js(drupal_get_path('module', 'bpi') . '/js/bpi.scripts.js', 'file');
       drupal_add_js(drupal_get_path('module', 'ding_popup') . '/ding_popup.js', 'file');
       drupal_add_css(drupal_get_path('module', 'bpi') . '/css/bpi-admin.styles.css', 'file');
+      ctools_include('modal');
+      ctools_modal_add_js();
+
       $_SESSION['bpi']['assets'] = $bpi_assets;
     }
     elseif ($syndicated_images === FALSE) {
@@ -486,7 +489,8 @@ function bpi_place_images(array &$form, $current_language, array $syndicated_ima
       foreach ($image_field_names as $image_field_name) {
         if (bpi_is_bpi_image_field($image_field_name, $node, $image_type)) {
           $field = &$form[$image_field_name][$current_language];
-          $cardinality = isset($field['#cardinality']) ? $field['#cardinality'] : 1;
+          $field_info = field_info_field($field['#field_name']);
+          $cardinality = $field_info['cardinality'];
           // The cardinality of a field with an unlimited number of values is -1.
           if ($cardinality < 0) {
             $cardinality = PHP_INT_MAX;
@@ -494,7 +498,10 @@ function bpi_place_images(array &$form, $current_language, array $syndicated_ima
           $number_of_images_to_place = min(count($images), $cardinality);
           for ($i = 0; $i < $number_of_images_to_place; $i++) {
             if (is_object($images[$i]['@managed_file'])) {
-              $field[$i]['#default_value'] = array('fid' => $images[$i]['@managed_file']->fid);
+              // A totally hacky way of building media field default items.
+              $element_build = $field[0];
+              $element_build['#default_value'] = array('fid' => $images[$i]['@managed_file']->fid);
+              $field[$i] = $element_build;
             }
           }
         }
@@ -547,8 +554,8 @@ function bpi_place_inline_images($field_name, $content, $current_language, array
           ),
           'type' => 'media',
           'attributes' => array(
-            'width' => $image['width'],
-            'height' => $image['height'],
+            'width' => $file->metadata->width,
+            'height' => $file->metadata->height,
             'alt' => isset($image['alt']) ? $image['alt'] : $image['name'],
             'title' => isset($image['title']) ? $image['title'] : $image['name'],
             'class' => 'media-element file-default',


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4625

#### Description

This PR restores the original flow for pulling images during syndication of new content from BPI service. There is a long history for this logic to be broken and this is restored via this change-set. Images from title/list image fields are placed correspondingly during syndication along with inline images inserted into body via WYSIWYG.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Relying on https://github.com/ding2/bpi-client/pull/16.
