### PR TITLE
4633: Make Adgangsplatformen handle non-privileged clients

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -456,7 +456,7 @@ function _ding_adgangsplatformen_provider_login(array $user_info) {
       //       adgangsplatformen. But pre-authenticate can't use the card no.
       //       so fallback to CPR if it's given.
       //
-      'name' => is_null($user_info['attributes']['cpr']) ? $user_info['attributes']['userId'] : $user_info['attributes']['cpr'],
+      'name' => empty($user_info['attributes']['cpr']) ? $user_info['attributes']['userId'] : $user_info['attributes']['cpr'],
       //
       // HACK: The pincode used here should be removed later on.
       //       This only exists to get around pre-authentication issues
@@ -464,7 +464,7 @@ function _ding_adgangsplatformen_provider_login(array $user_info) {
       //
       'pass' => isset($user_info['attributes']['pincode']) ? $user_info['attributes']['pincode'] : '',
       'extra' => $user_info,
-      'single_sign_on' => !is_null($user_info['attributes']['cpr']),
+      'single_sign_on' => !empty($user_info['attributes']['cpr']),
     ));
 
     if ($account !== FALSE) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4633

#### Description

Not all Adgangsplatformen clients are configured to return a CPR - 
not even as an attribute with a NULL value. The current state will 
cause such clients to fail because CPR will still be used anyway and 
generate notices because it is not defined.

This PR updates the code accordingly to make such clients work again.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Behat tests fail for whatever reason. I will try rerunning them.