### PR TITLE
4625: Reset paragraphs items cache in BPI workflow

### DIFF
--- a/modules/ding_paragraphs/ding_paragraphs.module
+++ b/modules/ding_paragraphs/ding_paragraphs.module
@@ -75,7 +75,10 @@ function ding_paragraphs_bpi_convert_to_bpi_alter(&$bpi_content, $entity, array 
         $field = $entity->$paragraphs_field_name;
         if (isset($field[$lang]) && is_array($field[$lang])) {
           $ids = paragraphs_field_item_to_ids($field[$lang]);
-          $paragraphs_items = paragraphs_item_load_multiple($ids);
+          // When running this code from the BPI workflow, the paragraph
+          // objects are not fully loaded.
+          // Resetting the entity cache here seems to fix the issue.
+          $paragraphs_items = paragraphs_item_load_multiple($ids, NULL, TRUE);
           if (is_array($paragraphs_items)) {
             foreach ($paragraphs_items as $paragraphs_item) {
               $fields = field_info_instances($paragraphs_item->entityType(), $paragraphs_item->bundle());


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4625#note-20

#### Description

When running this code from the BPI workflow, the paragraph objects are not fully loaded. Resetting the entity cache here seems to fix the issue.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
