### PR TITLE
4592 update globaleredirect

### DIFF
--- a/project.make
+++ b/project.make
@@ -154,7 +154,7 @@ projects[geophp][subdir] = "contrib"
 projects[geophp][version] = "1.7"
 
 projects[globalredirect][subdir] = "contrib"
-projects[globalredirect][version] = "1.5"
+projects[globalredirect][version] = "1.6"
 projects[globalredirect][patch][] = "http://drupal.org/files/language_redirect_view_node-1399506-2.patch"
 
 projects[google_analytics][subdir] = "contrib"

--- a/project.make
+++ b/project.make
@@ -155,7 +155,6 @@ projects[geophp][version] = "1.7"
 
 projects[globalredirect][subdir] = "contrib"
 projects[globalredirect][version] = "1.6"
-projects[globalredirect][patch][] = "http://drupal.org/files/language_redirect_view_node-1399506-2.patch"
 
 projects[google_analytics][subdir] = "contrib"
 projects[google_analytics][version] = "1.3"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4592

#### Description

Global redirect uses the wrong variable when checking for maintenance mode, which has resulted in an error that was very hard to debug.

Also, if the module checks the wrong variable it will redirect in mainetenance mode which is shouldn't.

Additionally, by updating to latest version, we can remove a patch in make-file since these changes are included in the latest version.

The module contains a new configuration option to redirect comment URL's to their parent node. Since we're not using comments, we will just use the default value which is off.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
