### PR TITLE
4440 by Inlead: Decrease margin and remove border for pop messages.

### DIFF
--- a/themes/ddbasic/sass/components/messages.scss
+++ b/themes/ddbasic/sass/components/messages.scss
@@ -18,7 +18,7 @@
     position: relative;
   }
   .messages {
-    padding: 40px 0 20px;
+    padding: 12px 0;
     border: none;
     background-color: $grey-light;
     > ul {
@@ -68,7 +68,6 @@
         padding: 5px 0;
         margin: 5px 0;
         color: $color-standard-text;
-        border-bottom: 1px solid $grey;
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4440

#### Description

Within the ddbasic system messages we removed the border-bottom and the decreased the margin.

#### Screenshot of the result

![ding-popup](https://user-images.githubusercontent.com/287648/71894607-07b98e80-314f-11ea-974e-155e18ec9aeb.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.