### PR TITLE
4562 async carousels

### DIFF
--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -33,23 +33,18 @@ function ting_search_carousel_carousel_content_type_render($subtype, $conf, $pan
         'available' => '',
       );
       $query = new TingSearchCarouselQuery($search['query'], $search['sort'], $search['available']);
-      $chunk = ting_search_carousel_get_entities($query, 0, TING_SEARCH_CAROUSEL_CHUNK_SIZE);
-      $items = array();
-      foreach ($chunk['entities'] as $entity) {
-        $items[] = ting_object_view($entity, 'teaser');
-      }
 
-      $placeholders = count($items) ? count($items) : TING_SEARCH_CAROUSEL_CHUNK_SIZE;
-      $placeholders = $chunk['next_offset'] > -1 ? ($placeholders) + 1 : 0;
       $carousels[] = array(
         '#type' => 'ding_carousel',
         '#title' => $search['title'],
         '#path' => ting_search_carousel_ajax_path($query),
-        '#items' => $items,
-        '#offset' => $chunk['next_offset'],
-        // Add a single placeholder to fetch more content later if there is more
-        // content.
-        '#placeholders' => $placeholders,
+        // Start without any covers, but load them all via AJAX. This eliminates
+        // rendering covers and hitting the availability service, which slows
+        // down page rendering.
+        '#items' => [],
+        '#offset' => 0,
+        // Add placeholders instead.
+        '#placeholders' => TING_SEARCH_CAROUSEL_CHUNK_SIZE,
       );
     }
 

--- a/themes/ddbasic/utils.inc
+++ b/themes/ddbasic/utils.inc
@@ -131,9 +131,9 @@ function ddbasic_account_count_reservation_not_ready($account = NULL) {
  * Function to truncate strings
  */
 function add_ellipsis($string, $length = 200, $end = '...') {
-  if (strlen($string) > $length) {
-    $length -= strlen($end);
-    $string  = substr($string, 0, $length);
+  if (mb_strlen($string) > $length) {
+    $length -= mb_strlen($end);
+    $string  = mb_substr($string, 0, $length);
     $string .= '<span class="truncation">' . $end . '</span>';
   }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4562

#### Description

##### Make add_ellipsis handle UTF properly

Stop it from accidentally cutting up multi-byte characters, resulting
in invalid UTF sequences, which the browsers might ignore (haven't
checked) but json_encode certainly chokes on.

##### Only load carousels over AJAX

Pre-populating the first page from server-side means doing the
rendering (not too bad) and hitting the availability service to check
if the material is available (can be pretty bad for pages with many
carousels).

#### Checklist

- [X] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [X] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [X] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
