### PR TITLE
4175: Don't pre-request covers

### DIFF
--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -167,13 +167,6 @@ function ting_search_carousel_carousel_content_type_edit_form_submit(&$form, &$f
   }
   $form_state['conf']['searches'] = $searches;
   $form_state['conf']['settings'] = $form_state['values']['settings'];
-  // Pre-request first set of results so the caching will be done while form
-  // submit and the client will not have to wait until those requests are
-  // happening when page is opened.
-  foreach ($searches as $search) {
-    $query = new TingSearchCarouselQuery($search['query'], $search['sort'], $search['available']);
-    ting_search_carousel_get_entities($query, 0, 8, FALSE);
-  }
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4175

#### Description

As we're loading covers asynchronously anyway, there's no need to seed
the cache, it only slows down submission.

#### Checklist

- [X] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [X] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [X] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
