### PR TITLE
4627: Allow agency filtering

### DIFF
--- a/modules/opensearch/opensearch.module
+++ b/modules/opensearch/opensearch.module
@@ -159,6 +159,7 @@ function opensearch_boost_field_element_process($element, $form_state) {
       'term.identifier' => t('ISBN number'),
       'term.subject' => t('Subject'),
       'facet.dk5' => t('Classification'),
+      'dkcclterm.ln' => t('Agency'),
     ),
     '#default_value' => (isset($element['#value']['field_name'])) ? $element['#value']['field_name'] : NULL,
     '#attributes' => array('class' => array('field-name')),


### PR DESCRIPTION
DDBCMS-46

#### Link to issue

https://platform.dandigbib.org/issues/4627

#### Description

I forbindelse med Inter-Library Loans modulet ("bestil-knappen"), fjernes filtrering på agency, hvorved mængden af poster i søgeresultatet øges markant. Dette gør det endnu sværere at lave en hensigtsmæssig rankering.

Derfor tilføjer vi en mulighed for at booste på agency.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
