### PR TITLE
3290: add more specific empty messages on loan status

### DIFF
--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -26,7 +26,6 @@ function ding_loan_loans_content_type_render($subtype, $conf, $panel_args, $cont
   $block->module = 'ding_loan';
   $block->delta = 'loans';
   $block->title = t('Loan list');
-  $block->content = t('You do not currently have any loans.');
 
   // Get loans from the provider.
   $account = isset($context->data) ? $context->data : NULL;
@@ -71,6 +70,17 @@ function ding_loan_loans_content_type_render($subtype, $conf, $panel_args, $cont
   // Set block content, with loans form if any loans exists.
   if (!empty($loans)) {
     $block->content = ding_provider_get_form('ding_loan_loans_form', $account, $loans);
+  }
+  // If we only show either regular or overdue loans, override the standard
+  // empty message with a more specific one.
+  elseif ($conf['overdue'] && !$conf['regular'])  {
+    $block->content = t('You do not currently have any overdue loans.');
+  }
+  elseif ($conf['regular'] && !$conf['overdue'])  {
+    $block->content = t('You do not currently have any regular loans.');
+  }
+  else {
+    $block->content = t('You do not currently have any loans.');
   }
 
   return $block;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3290

#### Description

Some loaners are getting confused by the "You currently have no loans"-message that can be shown on both regular and overdue loans status. Even though one of them is not empty the message can still be show on the other status page, leading some loaners to wrongfully conclude, that they have no loans.

In this PR we provide separate and more specific translatable empty messages for regular and overdue loans.

#### Screenshot of the result

![3290-overdue-loans-translation](https://user-images.githubusercontent.com/5011234/73657929-8e508580-4693-11ea-9d54-8eee994dd587.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
