### PR TITLE
4737: Added UTF8 safe functions to add_ellipsis

### DIFF
--- a/themes/ddbasic/utils.inc
+++ b/themes/ddbasic/utils.inc
@@ -131,9 +131,9 @@ function ddbasic_account_count_reservation_not_ready($account = NULL) {
  * Function to truncate strings
  */
 function add_ellipsis($string, $length = 200, $end = '...') {
-  if (strlen($string) > $length) {
-    $length -= strlen($end);
-    $string  = substr($string, 0, $length);
+  if (drupal_strlen($string) > $length) {
+    $length -= drupal_strlen($end);
+    $string  = mb_substr($string, 0, $length);
     $string .= '<span class="truncation">' . $end . '</span>';
   }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4737

#### Description

When triming the title this is done without UTF8 safe functions, which results in json_encode returning FALSE and a empty result.

#### Screenshot of the result

See ticket,

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
