### PR TITLE
4720: Fix ting object view error when unpublishing/deleting related nodes

### DIFF
--- a/modules/ting_reference/ting_reference.module
+++ b/modules/ting_reference/ting_reference.module
@@ -386,9 +386,15 @@ function ting_reference_field_formatter_view($entity_type, $entity, $field, $ins
           // loaded. Trying to get anything from the entity before this will
           // result in NULL.
           $host = $entity->hostEntity();
-          $entity_type = $entity->hostEntityType();
-          $host_wrapper = entity_metadata_wrapper($entity->hostEntityType(), $host);
-          $entities = entity_load($entity->hostEntityType(), array($host_wrapper->getIdentifier()), $conditions);
+          // Ensure the host entity was loaded and is published.
+          if ($host && $host->status == NODE_PUBLISHED) {
+            $entity_type = $entity->hostEntityType();
+            $host_wrapper = entity_metadata_wrapper($entity->hostEntityType(), $host);
+            $entities = entity_load($entity->hostEntityType(), array($host_wrapper->getIdentifier()), $conditions);
+          }
+          else {
+            $entities = array();
+          }
         }
 
         if (!empty($entities)) {

--- a/modules/ting_reference/ting_reference.module
+++ b/modules/ting_reference/ting_reference.module
@@ -386,11 +386,10 @@ function ting_reference_field_formatter_view($entity_type, $entity, $field, $ins
           // loaded. Trying to get anything from the entity before this will
           // result in NULL.
           $host = $entity->hostEntity();
-          // Ensure the host entity was loaded and is published.
+          // Ensure the host entity could be loaded and is published.
           if ($host && $host->status == NODE_PUBLISHED) {
+            $entities = array($host);
             $entity_type = $entity->hostEntityType();
-            $host_wrapper = entity_metadata_wrapper($entity->hostEntityType(), $host);
-            $entities = entity_load($entity->hostEntityType(), array($host_wrapper->getIdentifier()), $conditions);
           }
           else {
             $entities = array();


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4720

#### Description

Fixes issues when nodes hosting material list paragraphs items are unpublished/deleted.

If they are deleted we will get a fatal error trying to use non-existing host entity. As described in the case, this could also happen when unpublishing nodes, but I've not been able to reproduce this. As far as I can see, the `ParagraphsItemEntity::hostEntity` uses `entity_load` without any `$conditions`, so they should be loaded regardless of `$node->status` value. Anyway if it's possible somehow, this fix protects against that too.

Also discovered that the entity was loaded twice, and we can just use the host entity loaded by `ParagraphsItemEntity::hostEntity`. The `$condition` array we passed to the manual `entity_load` call before, had no effect since [it was empty in case of entity of type `paragraphs_item`](https://github.com/ding2/ding2/blob/7.x-5.0.1/modules/ting_reference/ting_reference.module#L373)

Now we just check the status directly on the already loaded host node.

#### Error on deleted published node

![4720-error-deleted-node](https://user-images.githubusercontent.com/5011234/74936248-19e34980-53ea-11ea-9391-93d5b919f78a.png)

#### Unpulished node is shown as relation resulting in broken link

![4720-no-error-node-unpublished](https://user-images.githubusercontent.com/5011234/74936323-38e1db80-53ea-11ea-9e95-1ce24fa00d90.png)

![4720-error-when-clicking-node-unpublished](https://user-images.githubusercontent.com/5011234/74936335-3bdccc00-53ea-11ea-8c32-41285216e118.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
