### PR TITLE
Bypass Varnish cookie stripping for React user token javascript

### DIFF
--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -47,7 +47,8 @@ function ding_react_menu() {
     'access arguments' => array('administer site configuration'),
     'type' => MENU_NORMAL_ITEM,
   );
-  $items['ding_react/user.js'] = [
+  // Use - instead of . to bypass ding2.vcl cookie stripping rules.
+  $items['ding_react/user-js'] = [
     'title' => 'Retrieve access token',
     'page callback' => 'ding_react_user_js',
     'access callback' => TRUE,
@@ -235,7 +236,7 @@ function ding_react_app($name, array $data = []) {
       libraries_get_path('ddb-react') . '/' . $name . '.js' => ['scope' => 'footer', 'group' => JS_LIBRARY, 'weight' => 1],
       // Use our menu callback to mimic an external file which allows us to set
       // per-user data which bypasses Varnish caching.
-      url('ding_react/user.js', ['absolute' => TRUE]) => ['scope' => 'footer', 'type' => 'external'],
+      url('ding_react/user-js', ['absolute' => TRUE]) => ['scope' => 'footer', 'type' => 'external'],
       drupal_get_path('module', 'ding_react') . '/js/ding-react.js' => ['scope' => 'footer'],
     ],
   ];


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

Our [current configuration in `ding2.vcl` will strip cookies from as
requests ending in `.js`](https://github.com/ding2/ding2/blob/master/ding2.vcl#L73-L76) assuming they are static files which should
always be cacheable. 

Our user token callback currently is `user.js` and is consequently also
affected by this. This results in the session cookie being stripped
and thus the callback will always reply as if the user is not logged
in.

Rename the file path of callback from `user.js` to `user-js` as that 
means the response will not be treated as a static file.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Alternatively we could add `ding_react/user.js` to [our list of uncacheable paths](https://github.com/ding2/ding2/blob/master/ding2.vcl#L47-L58).