### PR TITLE
4752: Ensure AJAX responder is loaded when using Adgangsplatformen

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -24,7 +24,7 @@ use League\OAuth2\Client\Provider\GenericProvider;
  * We don't known which pages this will happen on, so we add the script to every
  * page.
  */
-function ding_page_build() {
+function ding_adgangsplatformen_page_build() {
   if (user_is_anonymous()) {
     ctools_add_js('ajax-responder');
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4752?next_issue_id=4748&prev_issue_id=4753#note-23

#### Description

We rely on redirect responses which will pass the user along to
Adgangsplatformen if she tries to perform an action while not logged
in.

If the CTools AJAX responder is not loaded then the responder will be
returned and loaded as a part of the response. 

![Materiale | Harry Potter | - Mozilla Firefox (Private Browsing) 2020-02-26 15-58-03](https://user-images.githubusercontent.com/73966/75356976-efddcb80-58b0-11ea-9886-a0ba766d28b6.png)

This has two problems:

1. The user is not redirected to Adgangsplatformen immediately but
must try to perform the action again.
2. The user is not redirected to the correct path e.g. when trying to
make a reservation.

Being aware of this we originally intended to include the AJAX
responder with every anonymous response but a refactor broke the
hook name which should ensure this.

Rename the function `ding_page_build()` to 
`ding_adgangsplatformen_page_build()` to implement the hook properly.

Since the current code is already running in production I assume we 
have been saved by another part of the project including the file
which has subsequently been disabled/removed. Probably in the P2
modulespace.

#### Additional comments

Scrutinizer fails but because of an existing issue. I would prefer not to change the code at this point in time.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
