### PR TITLE
4756: Use Adgangsplatformen authentication client when logging out

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.install
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.install
@@ -14,3 +14,12 @@ function ding_adgangsplatformen_install() {
     ->condition('name', 'ding_adgangsplatformen', '=')
     ->execute();
 }
+
+/**
+ * Set default revoke end-point url.
+ */
+function ding_adgangsplatformen_update_7001() {
+  $config = ding_adgangsplatformen_get_configuration();
+  $config['revoke'] = 'https://login.bib.dk/oauth/revoke';
+  variable_set('ding_adgangsplatformen_settings', $config);
+}

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -197,6 +197,7 @@ function ding_adgangsplatformen_get_configuration() {
     'singleLogout' => TRUE,
     'automaticallyAgency' => TRUE,
     'singleLogoutOrigin' => 'https://login.bib.dk/',
+    'revoke' => 'https://login.bib.dk/oauth/revoke',
   ];
 
   $config = variable_get('ding_adgangsplatformen_settings', $defaults);
@@ -559,8 +560,12 @@ function ding_adgangsplatformen_has_token_client() {
  *   Whether revoking the token succeeded or not.
  */
 function ding_adgangsplatformen_revoke_token(GenericProvider $provider, $access_token) {
-  $request = $provider->getAuthenticatedRequest('DELETE',
-    'https://login.bib.dk/oauth/revoke', $access_token);
+  $config = ding_adgangsplatformen_get_configuration();
+  $request = $provider->getAuthenticatedRequest(
+    'DELETE',
+    $config['revoke'],
+    $access_token
+  );
   $response = $provider->getResponse($request);
   $success = $response->getStatusCode() == 200;
   if (!$success) {

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -275,20 +275,50 @@ function ding_adgangsplatformen_login() {
 function ding_adgangsplatformen_logout($regen_session = FALSE) {
   global $base_url;
 
+  // Build base options for logging out.
   $config = ding_adgangsplatformen_get_configuration();
   $singleLogout = $config['singleLogout'] ? 'true' : 'false';
   $token = ding_adgangsplatformen_openplatform_token_get();
+
+  $logout_options = [
+    'singlelogout' => $singleLogout,
+    'redirect_uri' => $base_url,
+    'token' => $token,
+  ];
+
+  if (ding_adgangsplatformen_has_token_client()) {
+    // Revoke our current token. It has been retrieved by the token provider using
+    // password grants and will not be revoked by Adgangsplatformen itself during
+    // logout.
+    ding_adgangsplatformen_revoke_token(
+      ding_adgangsplatformen_get_provider(),
+      $token
+    );
+
+    try {
+      // Retrieve a new anonymous token and use that for the logout procedure. By
+      // using the authentication provider we ensure that Adgangsplatformen will
+      // redirect to the right site.
+      $auth_provider = ding_adgangsplatformen_get_provider(TRUE);
+      $token = $auth_provider->getAccessToken('password', [
+        // Using @ as username and password works as an anonymous user.
+        'username' => '@',
+        'password' => '@',
+      ]);
+
+      $logout_options['token'] = $token->getToken();
+    }
+    catch (IdentityProviderException $e) {
+      watchdog('ding_adgangsplatformen', 'Unable to retrieve anonymous token to perform single logout: %message', $e->getMessage(), WATCHDOG_ERROR);
+    }
+  }
 
   // Generate logout request for the authorization service and send the request.
   $logout_url = url(
     $config['urlLogout'],
     array(
       'external' => TRUE,
-      'query' => array(
-        'singlelogout' => $singleLogout,
-        'access_token' => $token,
-        'redirect_uri' => $base_url,
-      ),
+      'query' => $logout_options,
     ));
 
   if (!$regen_session) {
@@ -415,11 +445,7 @@ function ding_adgangsplatformen_callback() {
       // This only exists to get around pre-authentication issues currently in
       // FBS.
       //
-      $request = $provider->getAuthenticatedRequest('DELETE', 'https://login.bib.dk/oauth/revoke', $access_token);
-      $response = $provider->getResponse($request);
-      if ($response->getStatusCode() != 200) {
-        watchdog('ding_adgangsplatformen', "https://login.bib.dk/oauth/revoke returned status code: %code", array('%code' => $response->getStatusCode()), WATCHDOG_CRITICAL);
-      }
+      ding_adgangsplatformen_revoke_token($provider, $access_token->getToken());
       unset($_SESSION['oauth2token']);
 
       if (module_exists('ding_registration') && ding_registration_is_registration_request()) {
@@ -519,6 +545,34 @@ function ding_adgangsplatformen_has_token_client() {
   $clientSecret = variable_get('ding_adgangsplatformen_token_client_secret', NULL);
 
   return $clientId && $clientSecret;
+}
+
+/**
+ * Revoke an OAuth2 access token using a provider.
+ *
+ * @param \League\OAuth2\Client\Provider\GenericProvider $provider
+ *   The OAuth2 provider to use when revoking the token.
+ * @param string $access_token
+ *   The access token to revoke.
+ *
+ * @return bool
+ *   Whether revoking the token succeeded or not.
+ */
+function ding_adgangsplatformen_revoke_token(GenericProvider $provider, $access_token) {
+  $request = $provider->getAuthenticatedRequest('DELETE',
+    'https://login.bib.dk/oauth/revoke', $access_token);
+  $response = $provider->getResponse($request);
+  $success = $response->getStatusCode() == 200;
+  if (!$success) {
+    watchdog('ding_adgangsplatformen',
+      "Unable to revoke token: %code %reason",
+      [
+        '%code' => $response->getStatusCode(),
+        '%reason' => $response->getReasonPhrase(),
+      ],
+      WATCHDOG_CRITICAL);
+  }
+  return $success;
 }
 
 /**

--- a/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
+++ b/modules/ding_adgangsplatformen/includes/ding_adgangsplatformen.admin.inc
@@ -71,6 +71,13 @@ function ding_adgangsplatformen_admin_settings_form($form, &$form_state) {
     '#default_value' => $default['urlLogout'],
   );
 
+  $form['ding_adgangsplatformen_settings']['revoke'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Revoke service'),
+    '#description' => t('The end-point to use for revoking an access token.'),
+    '#default_value' => $default['revoke'],
+  );
+
   $form['ding_adgangsplatformen_settings']['singleLogout'] = array(
     '#type' => 'checkbox',
     '#title' => t('Enable single logout'),


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4756

#### Description

We currently use a separate secondary Adgangsplaformen client for
retrieving tokens without access to sensitive information. These 
tokens are suitable for use in client side applications.

However the secondary client is potentially shareable between 
installations and thus cannot be configured with a single valid 
logout url. This means that Adgangsplatform cannot redirect to the
correct site.

To address this we instead revoke the access token manually and then
generare a unique access token for an anonymous user using the
primary client.

We can then pass this token to Adgangsplatformen when logging out and
it will allow redirect to the corresponding site.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.