### PR TITLE
4761: Never cache ding_react/user.js in Varnish

### DIFF
--- a/ding2.vcl
+++ b/ding2.vcl
@@ -53,6 +53,7 @@ sub vcl_recv {
     req.url ~ "^.*/ajax/.*$" ||
     req.url ~ "^.*/ahah/.*$" ||
     req.url ~ "^.*/edit.*$" ||
+    req.url ~ "^.*/ding_react/user.js" ||
     req.url ~ "^.*/ding_availability.*$") {
     return (pass);
   }

--- a/ding2_v4.vcl
+++ b/ding2_v4.vcl
@@ -57,6 +57,7 @@ sub vcl_recv {
     req.url ~ "^.*/ajax/.*$" ||
     req.url ~ "^.*/ahah/.*$" ||
     req.url ~ "^.*/edit.*$" ||
+    req.url ~ "^.*/ding_react/user.js" ||
     req.url ~ "^.*/ding_availability.*$") {
     return (pass);
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4761

#### Description

Never cache `ding_react/user.js` in Varnish.

This file contains a unique per user specific token and should not
be cached. However [our current Varnish configuration treats all files
ending in .js](http://github.com/ding2/ding2/blob/master/ding2.vcl#L74-L74) as a static file and strips cookies [no matter what
headers we send](http://github.com/ding2/ding2/blob/master/modules/ding_react/ding_react.module#L277-L277).
 
This results in the file always returning as if accessed by the
anonymous user.

To fix this we update the Varnish configuration to bypass caching of
this file.

This PR is alternative take on that is also proposed in #1593.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.