### PR TITLE
Core: Use menu item classes for debts, overdue loans and reservations

### DIFF
--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -606,7 +606,7 @@ function ddbasic_menu_link__menu_tabs_menu($vars) {
           if (!empty($debts)) {
             $notification = array(
               'count' => $debts,
-              'type' => 'debts',
+              'type' => 'warning',
             );
           }
 
@@ -615,7 +615,7 @@ function ddbasic_menu_link__menu_tabs_menu($vars) {
             if (!empty($overdues)) {
               $notification = array(
                 'count' => $overdues,
-                'type' => 'overdue',
+                'type' => 'warning',
               );
             }
           }
@@ -625,13 +625,13 @@ function ddbasic_menu_link__menu_tabs_menu($vars) {
             if (!empty($ready)) {
               $notification = array(
                 'count' => $ready,
-                'type' => 'ready',
+                'type' => 'success',
               );
             }
           }
 
           if (!empty($notification)) {
-            $element['#title'] .= '<div class="notification-count notification-count-type-' . $notification['type'] . '">' . $notification['count'] . '</div>';
+            $element['#title'] .= '<div class="menu-item-count menu-item-count-' . $notification['type'] . '">' . $notification['count'] . '</div>';
           }
         }
       }


### PR DESCRIPTION
#### Description

The notification classes were a part of the P2 project and are no
longer available. Make the user menu title use existing classes which
are also used for menu items.

These do not have types per use case so we switch to the
success/warning variants that we already have.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.