### PR TITLE
4765: Use jQuery.attr() instead of data() in reservability checks

### DIFF
--- a/modules/ding_reservation/js/ding_reservation_reservability.js
+++ b/modules/ding_reservation/js/ding_reservation_reservability.js
@@ -11,7 +11,7 @@
       var localIds = [];
       var selector = '.js-check-reservability';
       $(selector, context).once('js-check-reservability', function() {
-        localIds.push($(this).data("local-id"));
+        localIds.push($(this).attr("data-local-id"));
       });
 
       if (localIds.length) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4765

#### Description

jQuery.data() will try to process the data value to an appropriate
type and this “00123” becomes 123.

That is not desirable for us and thus we fall back to using the
simpler jQuery.attr() function.

“Every attempt is made to convert the attribute's string value 
to a JavaScript value (this includes booleans, numbers, objects, 
arrays, and null) […] To retrieve a data-* attribute value as an unconverted string, use the attr() method.”
https://api.jquery.com/data/#data-html5

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
