### PR TITLE
4772: Fix action links triggering login form for anonymous users

### DIFF
--- a/modules/ding_user_form/js/ding_user_form.js
+++ b/modules/ding_user_form/js/ding_user_form.js
@@ -24,19 +24,7 @@
         }
       }
 
-      /**
-       * Attach open login events.
-       */
-      Drupal.behaviors.open_login = {
-        attach: function(context, settings) {
-          $('a.open-login', context).bind('click', function (evt) {
-            evt.preventDefault();
-            openLogin();
-          });
-        }
-      };
-
-      $('a.js-topbar-link-user', context).on('click', function(evt) {
+      $('a.js-topbar-link-user,a.open-login', context).on('click', function(evt) {
         evt.preventDefault();
         openLogin();
       });


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4772

#### Description

For some reason the current version uses nested behaviors: `open_login`
is defined within `ding_user_form()`. This means that `open_login` is
only attached after `open_login` has been attached.

This is unnecessary and we might just as well expand the selector 
from `open_login` to the current selector in `ding_user_form`.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.