### PR TITLE
4739: Add noindex, nofollow robots metatag on /user/* pages

### DIFF
--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -39,6 +39,18 @@ function ding_user_preprocess_html(&$variables) {
       drupal_add_http_header('Cache-Control', 'no-store, must-revalidate');
       drupal_add_http_header('Pragma', 'no-cache');
     }
+
+    // Ensure that search engines doesn't index pages under /user/*. We also add
+    // nofollow since the login page contains links to other pages under /user
+    // that are disallowed in robots.txt.
+    $robots_noindex = array(
+      '#tag' => 'meta',
+      '#attributes' => array(
+        'name' =>  'robots',
+        'content' => 'noindex, nofollow',
+      ),
+    );
+    drupal_add_html_head($robots_noindex, 'ding_user_noindex');
   }
 }
 

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -46,7 +46,7 @@ function ding_user_preprocess_html(&$variables) {
     $robots_noindex = array(
       '#tag' => 'meta',
       '#attributes' => array(
-        'name' =>  'robots',
+        'name' => 'robots',
         'content' => 'noindex, nofollow',
       ),
     );


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4739

#### Description

Ensure that search engines doesn't index pages under /user/*. We
also add nofollow since the login page contains links to other
pages under /user that are disallowed in robots.txt.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
