### PR TITLE
4780: Fallback to default category when no instances

### DIFF
--- a/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/ding_ddbasic_opening_hours.theme.inc
+++ b/modules/ding_ddbasic/modules/ding_ddbasic_opening_hours/ding_ddbasic_opening_hours.theme.inc
@@ -42,6 +42,12 @@ function template_preprocess_ding_ddbasic_opening_hours_week(&$variables) {
     return $instance->category_tid;
   }, $instances));
 
+  // If there are no instances we have no knowledge of what categories are in
+  // use, and we will fallback to the default category only.
+  if (empty($instances)) {
+    $category_tids = [NULL];
+  }
+
   // Add closed days.
   for ($day = $timespan[0]; $day <= $timespan[1]; $day += DING_DDBASIC_OPENING_HOURS_ONE_DAY) {
     $date = date('Y-m-d', $day);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4780

#### Description

A follow up to the solution from #1560.

It's good that we now place the "Closed" text based on the categories in use on the instances of the current week. But if there are no instances, we have no categories, and it will result in empty display (see screenshot below).

It's pretty hard to make any assumptions about the way the categories are used on the site. We could look at all instances, but that would be pretty extensive and what if some categories are only used in some weeks.

I therefore think that the best solution is to check for empty instances in the current week and fallback to the "NULL-category" only. See screenshot below for result.

#### Screenshot of the result

![4780-no-instances](https://user-images.githubusercontent.com/5011234/76881260-2f2c8600-6879-11ea-9762-ad39ffbc4fbb.png)

![4780-closed-all-days](https://user-images.githubusercontent.com/5011234/76881272-33f13a00-6879-11ea-96ed-0692a01d2012.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
