### PR TITLE
Ensure that 'user_my_library' page is removed

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -944,3 +944,14 @@ function ding2_update_7080() {
 function ding2_update_7081() {
   ding2_translation_update();
 }
+
+/**
+ * Ensure that 'user_my_library' page manager page is removed from db.
+ */
+function ding2_update_7082() {
+  module_load_include('inc', 'page_manager', 'plugins/tasks/page');
+  $page = page_manager_page_load('user_my_library');
+  if (isset($page)) {
+    page_manager_page_delete($page);
+  }
+}


### PR DESCRIPTION
#### Link to issue

None (yet).

Mentioned on Facebook (requires membership at DDB CMS group):
https://www.facebook.com/groups/ddbcms/permalink/1160992500742404/ 

An we're experiencing the issue on vejlebib.dk

#### Description

Appearently the 'user_my_library' custom page manager page can get stuck in the DB after removal of P2-modules.

This adds an update function which ensure it's removed if present.

#### Screenshot of the result

![user-my-library-stuck](https://user-images.githubusercontent.com/5011234/79688297-bb054980-824d-11ea-9acb-593960981c03.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
