### PR TITLE
4707: Use separate query parameter for campaign click tracking

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -284,11 +284,11 @@ function ding_webtrekk_preprocess_node(&$variables) {
 function ding_webtrekk_process_node(&$variables) {
   $node = $variables['node'];
   if ($node->type == 'ding_campaign_plus') {
-    // Add u_navigatedby URL-parameter to campaign URLs, to be able to track
+    // Add u_navigatedby_kp URL-parameter to campaign URLs, to be able to track
     // page views triggered from campaigns. We use a process for this because
     // campaign plus adds the variable in preprocess.
     $url = drupal_parse_url($variables['campaign_url']);
-    $url['query']['u_navigatedby'] = check_plain($node->title);
+    $url['query']['u_navigatedby_kp'] = check_plain($node->title);
     $variables['campaign_url'] = url($url['path'], [
       'query' => $url['query'],
       'fragment' => $url['fragment'],


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4707

#### Description

Use separate query parameter for campaign click tracking.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
