### PR TITLE
4799: Authenticate react users via token availability - not SSO login

### DIFF
--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -315,12 +315,13 @@ function ding_react_user_js() {
   drupal_add_http_header('Content-Type', 'application/javascript');
   echo "window.ddbReact = window.ddbReact || {};\n";
 
-  $authenticated = ding_user_is_logged_in_with_sso() ? 'true' : 'false';
-  echo sprintf("window.ddbReact.userAuthenticated = %s;\n", $authenticated);
-
   $token = ding_provider_invoke('openplatform_token', 'get');
+
   if ($token) {
+    echo sprintf("window.ddbReact.userAuthenticated = true;\n");
     echo sprintf("window.ddbReact.setToken('%s');\n", $token);
+  } else {
+    echo sprintf("window.ddbReact.userAuthenticated = false;\n");
   }
 
   drupal_exit();


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4799

#### Description

We currently have two ways of authenticating users from
Adgangsplatformen against FBS:

1. SSO login. This occurs for most users
2. Certain users without CPR. These get the user id and password
from Adgangsplatformen and perform a normal authentication.

Both approaches will result in a user getting a valid token to use
With React components. However for the second type of users
ding_user_is_logged_in_with_sso() will return false.

This results in an inconsistent state where
window.ddbReact.userAuthenticated is false while
window.ddbReact.setToken() is called with a valid token.

To address this situation and make React components work for both
types of users we base both userAuthenticated and setToken() solely
on the existence of a token.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
