### PR TITLE
3659: GDPR contact form

### DIFF
--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -54,12 +54,14 @@ function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
   );
   $form['#submit'][] = 'ding_contact_contact_form_submit';
 
-  // Add a notice about not inserting personal data in the contact form. It's
-  // hardcoded and untranslated on purpose, since it should not be possible to
-  // change the text.
+  // Add a notice about not inserting personal data in the contact form. We make
+  // it translatable so that administrators are able to change the link to the
+  // privacy policy page.
+  $notice = '<p><strong>BEMÆRK</strong>: Indsæt ALDRIG persondata (fx CPR-nr. eller PIN-kode) i formularen.</p>';
+  $notice .= '<p>Læs hvordan dine persondata behandles i <a href="/persondata">bibliotekets persondata politik</a>.</p>';
   $form['privacy_notice'] = [
     '#type' => 'item',
-    '#markup' => '<p><strong>BEMÆRK</strong>: indsæt ALDRIG persondata (som f.eks. CPR-nummer) eller din pinkode i formularen.</p>',
+    '#markup' => t($notice),
   ];
 }
 

--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -50,11 +50,10 @@ function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
   // Add a notice about not inserting personal data in the contact form. We make
   // it translatable so that administrators are able to change the link to the
   // privacy policy page.
-  $notice = '<strong>BEMÆRK</strong>: Indsæt ALDRIG persondata (fx CPR-nr. eller PIN-kode) i formularen. ';
-  $notice .= 'Læs hvordan dine persondata behandles i <a href="/persondata">bibliotekets persondata politik</a>.';
+  $privacy_notice = t('<strong>NOTICE</strong>: NEVER insert personal data of any kind in the formular. Read more in our <a href="/persondata">privacy policy</a>.');
   $form['privacy_notice'] = [
     '#type' => 'item',
-    '#markup' => '<p>' . t($notice) . '</p>',
+    '#markup' => '<p>' . $privacy_notice . '</p>',
   ];
 }
 

--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -52,7 +52,7 @@ function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
       array('Cache-Control', 'no-cache, no-store, must-revalidate')
     ),
   );
-  $form['#submit'][] = 'ding_contact_contact_form_stop_redirect';
+  $form['#submit'][] = 'ding_contact_contact_form_submit';
 
   // Add a notice about not inserting personal data in the contact form. It's
   // hardcoded and untranslated on purpose, since it should not be possible to
@@ -64,13 +64,21 @@ function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
 }
 
 /**
- * Prevent default redirect to frontpage ( @see contact.pages.inc::contact_personal_form_submit() )
+ * Ding contact form submission handler for contact_site_form()
  *
  * @param $form
  * @param $form_state
  */
-function ding_contact_contact_form_stop_redirect($form, &$form_state) {
+function ding_contact_contact_form_submit($form, &$form_state) {
+  // Prevent default redirect to frontpage.
+  // See: contact.pages.inc::contact_personal_form_submit()
   unset($form_state['redirect']);
+
+  // Ensure the cookies set by the contact module with the user's name and mail
+  // are removed.
+  // See: contact.pages.inc::contact_personal_form_submit()
+  user_cookie_delete('name');
+  user_cookie_delete('mail');
 }
 
 /**

--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -42,11 +42,11 @@ function ding_contact_flooded_form($form, $form_state, $message) {
 }
 
 /**
- * Implements hook_form_FORM_ID_alter (contact_site_form)
- * Alter the contact form: make sure no cached page is delivered, and stop redirect
- * Why ? - to make sure no cached page is delivered
+ * Implements hook_form_FORM_ID_alter().
  */
 function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
+  // Alter the contact form: make sure no cached page is delivered, and stop
+  // redirect. Why ? - to make sure no cached page is delivered
   $form['actions']['submit']['#attached'] = array(
     'drupal_add_http_header' => array(
       array('Cache-Control', 'no-cache, no-store, must-revalidate')

--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -57,11 +57,11 @@ function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
   // Add a notice about not inserting personal data in the contact form. We make
   // it translatable so that administrators are able to change the link to the
   // privacy policy page.
-  $notice = '<p><strong>BEMÆRK</strong>: Indsæt ALDRIG persondata (fx CPR-nr. eller PIN-kode) i formularen.</p>';
-  $notice .= '<p>Læs hvordan dine persondata behandles i <a href="/persondata">bibliotekets persondata politik</a>.</p>';
+  $notice = '<strong>BEMÆRK</strong>: Indsæt ALDRIG persondata (fx CPR-nr. eller PIN-kode) i formularen. ';
+  $notice .= 'Læs hvordan dine persondata behandles i <a href="/persondata">bibliotekets persondata politik</a>.';
   $form['privacy_notice'] = [
     '#type' => 'item',
-    '#markup' => t($notice),
+    '#markup' => '<p>' . t($notice) . '</p>',
   ];
 }
 

--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -7,13 +7,13 @@
 include_once 'ding_contact.features.inc';
 
 /**
- * Implements hook_block_view_alter
+ * Implements hook_block_view_alter().
  *
  * Contact form is taken over by page_manager - @see ctools/plugins/tasks/contact_site.inc, and
  * expects a form to render - the contact module [drupal]/modules/contact returns message as a string if eg.
  * flooding is violated, and thus page_manager fails to render jthe message.
  *
- * check if content on contact site  is a form. If not make it so
+ * Check if content on contact site  is a form. If not make it so.
  * */
 function ding_contact_block_view_alter(&$data, $block) {
   if ($block->delta == 'contact_site') {
@@ -24,14 +24,7 @@ function ding_contact_block_view_alter(&$data, $block) {
 }
 
 /**
- * A simple form that displays a message
- *
- * @param $form
- * @param $form_state
- * @param $message
- *  The message to disply
- * @return array
- *  Very simple form
+ * A simple form that displays a message.
  */
 function ding_contact_flooded_form($form, $form_state, $message) {
   $form = array();
@@ -46,10 +39,10 @@ function ding_contact_flooded_form($form, $form_state, $message) {
  */
 function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
   // Alter the contact form: make sure no cached page is delivered, and stop
-  // redirect. Why ? - to make sure no cached page is delivered
+  // redirect. Why ? - to make sure no cached page is delivered.
   $form['actions']['submit']['#attached'] = array(
     'drupal_add_http_header' => array(
-      array('Cache-Control', 'no-cache, no-store, must-revalidate')
+      array('Cache-Control', 'no-cache, no-store, must-revalidate'),
     ),
   );
   $form['#submit'][] = 'ding_contact_contact_form_submit';
@@ -66,19 +59,16 @@ function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
 }
 
 /**
- * Ding contact form submission handler for contact_site_form()
- *
- * @param $form
- * @param $form_state
+ * Ding contact form submission handler for contact_site_form().
  */
 function ding_contact_contact_form_submit($form, &$form_state) {
   // Prevent default redirect to frontpage.
-  // See: contact.pages.inc::contact_personal_form_submit()
+  // See: contact.pages.inc::contact_personal_form_submit().
   unset($form_state['redirect']);
 
   // Ensure the cookies set by the contact module with the user's name and mail
   // are removed.
-  // See: contact.pages.inc::contact_personal_form_submit()
+  // See: contact.pages.inc::contact_personal_form_submit().
   user_cookie_delete('name');
   user_cookie_delete('mail');
 }

--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -53,6 +53,14 @@ function ding_contact_form_contact_site_form_alter(&$form, &$form_state) {
     ),
   );
   $form['#submit'][] = 'ding_contact_contact_form_stop_redirect';
+
+  // Add a notice about not inserting personal data in the contact form. It's
+  // hardcoded and untranslated on purpose, since it should not be possible to
+  // change the text.
+  $form['privacy_notice'] = [
+    '#type' => 'item',
+    '#markup' => '<p><strong>BEMÆRK</strong>: indsæt ALDRIG persondata (som f.eks. CPR-nummer) eller din pinkode i formularen.</p>',
+  ];
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3659

#### Description

1. Inserts a hardcoded privacy notice on contact form advicing users not the insert personal data.
2. Remove user cookies set by contact module (se commit message for details).

We can not prevent users from entering personal data, pin etc. and this getting send out unencrypted to various mail servers, but this should make them think twice before hitting that submit button :)

#### Screenshot of the result

![3659-contact-form-privacy-notice](https://user-images.githubusercontent.com/5011234/80506518-fe5e6700-8975-11ea-9167-13d2651b0087.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
