### PR TITLE
4579: PHP 5.6 compatability

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ jobs:
           - drupal/profiles/ding2/themes/ddbasic/sass_css
           - drupal/profiles/ding2/themes/ddbasic/scripts/min
 
-  php_lint:
+  php_lint_70:
     docker:
     - image: circleci/php:7.0-cli
     steps:
@@ -75,6 +75,21 @@ jobs:
     - run:
         name: Lint PHP files
         command: parallel-lint -e php,inc,module,theme,install,profile .
+
+  php_lint_56:
+    docker:
+      - image: circleci/php:5.6-cli
+    steps:
+      - checkout
+      - run:
+          name: Install PHP linter
+          command: |
+            echo 'export PATH=~/.composer/vendor/bin:$PATH'  >> $BASH_ENV
+            source $BASH_ENV
+            composer global require jakub-onderka/php-parallel-lint:^1 --no-interaction
+      - run:
+          name: Lint PHP files
+          command: parallel-lint -e php,inc,module,theme,install,profile .
 
   site_install:
     docker:
@@ -329,12 +344,14 @@ workflows:
     jobs:
     - drush_make
     - gulp
-    - php_lint
+    - php_lint_56
+    - php_lint_70
     - site_install:
         requires:
           - drush_make
           - gulp
-          - php_lint
+          - php_lint_56
+          - php_lint_70
     - unit_tests:
         requires:
           - site_install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
         command: |
           echo 'export PATH=~/.composer/vendor/bin:$PATH'  >> $BASH_ENV
           source $BASH_ENV
-          composer global require jakub-onderka/php-parallel-lint:^1 --no-interaction
+          composer global require php-parallel-lint/php-parallel-lint:^1 --no-interaction
     - run:
         name: Lint PHP files
         command: parallel-lint -e php,inc,module,theme,install,profile .
@@ -86,7 +86,7 @@ jobs:
           command: |
             echo 'export PATH=~/.composer/vendor/bin:$PATH'  >> $BASH_ENV
             source $BASH_ENV
-            composer global require jakub-onderka/php-parallel-lint:^1 --no-interaction
+            composer global require php-parallel-lint/php-parallel-lint:^1 --no-interaction
       - run:
           name: Lint PHP files
           command: parallel-lint -e php,inc,module,theme,install,profile .

--- a/modules/ding_user/ding_user.module
+++ b/modules/ding_user/ding_user.module
@@ -163,7 +163,7 @@ function ding_user_authenticate(array $user_info) {
 
   try {
     // Check if more info is provide from the user login form or SSO provider and default to empty array.
-    $extra = $user_info['extra'] ?? [];
+    $extra = (isset($user_info['extra'])) ? $user_info['extra'] : [];
 
     if (array_key_exists('single_sign_on', $user_info) && $user_info['single_sign_on'] == TRUE) {
       // No password provided by the authentication request (not even the empty


### PR DESCRIPTION
#### Link to issue

Please add a link to the issue being addressed by this change.

#### Description

We run the site using PHP 7.0 but the sites are deployed using Aegir
running PHP 5.6. Code which is incompatible with PHP 5.6 causes
deployments to fail.

To raise awareness of this we add a separat step to our CI pipeline
which lints files using PHP 5.6.

With the update [we can identify the error](https://circleci.com/gh/reload/ding2/5612)
and provide a fix.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

With this change I also seized the opportunity to update the package we use for linting. [The previous version was abandoned](https://packagist.org/packages/jakub-onderka/php-parallel-lint).