### PR TITLE
4814: Fixed loan list cache

### DIFF
--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -63,7 +63,7 @@ function ding_loan_loans_content_type_render($subtype, $conf, $panel_args, $cont
 
     // Store the loans into ding session cache.
     if (module_exists('ding_session_cache')) {
-      ding_session_cache_set('ding_loan', 'list', $cache_key);
+      ding_session_cache_set('ding_loan', $cache_key, $loans);
     }
   }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4814

#### Description

The loan list should be cached in session cache, but currently the cache key is stored under a not used key.

This actually stores the list in cache.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.