### PR TITLE
4811: Re-add missing holdings suffix configuration

### DIFF
--- a/modules/fbs/fbs.module
+++ b/modules/fbs/fbs.module
@@ -276,6 +276,31 @@ function fbs_settings_form() {
     '#default_value' => variable_get('fbs_holdings_branches_blacklist', array()),
   );
 
+  $form['holdings_suffix'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Holdings suffix'),
+    '#description' => t('Select which type of suffix to use for holdings'),
+    '#collapsible' => TRUE,
+    '#collapsed' => TRUE,
+  );
+
+  $form['holdings_suffix']['fbs_show_material_group'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Show material group description'),
+    '#default_value' => variable_get('fbs_show_material_group', 0),
+  );
+
+  $form['holdings_suffix']['fbs_holdings_suffix_type'] = array(
+    '#type' => 'radios',
+    '#title' => t('Holdings suffix'),
+    '#description' => t('Simple shows a mix between DK5 and inverted creator, while Shelf mark simulates the shelf mark from ALMA using marc-data from the well.'),
+    '#default_value' => variable_get('fbs_holdings_suffix_type', 'shelf_mark'),
+    '#options' => array(
+      'simple' => t('Simple'),
+      'shelf_mark' => t('Shelf mark'),
+    ),
+  );
+
   return system_settings_form($form);
 }
 
@@ -681,34 +706,6 @@ function fbs_form_ding_reservation_reservations_form_alter(&$form, &$form_state)
       }
     }
   }
-}
-
-/**
- * Implements hook_form_FORM_ID_alter().
- *
- * Access options for the attributes in the holdings field.
- */
-function fbs_form_ding_availability_admin_holdings_settings_alter(&$form, &$form_state, $form_id) {
-  $form['holdings'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Holdings levels display'),
-    '#description' => t('Configure holdings display modes.'),
-  );
-  $form['holdings']['fbs_show_material_group'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Show material group description'),
-    '#default_value' => variable_get('fbs_show_material_group', 0),
-  );
-  $form['holdings']['fbs_holdings_suffix_type'] = array(
-    '#type' => 'radios',
-    '#title' => t('Holdings suffix'),
-    '#description' => t('Select which type of suffix to use for holdings. Simple shows a mix between DK5 and inverted creator, while Shelf mark simulates the shelf mark from ALMA using marc-data from the well.'),
-    '#default_value' => variable_get('fbs_holdings_suffix_type', 'shelf_mark'),
-    '#options' => array(
-      'simple' => t('Simple'),
-      'shelf_mark' => t('Shelf mark'),
-    ),
-  );
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4811

#### Description

PR #1603 has rendered this missing, since it was added to the now
removed provider holdings form.

We re-add it to the FBS provider form, where it's perhaps better
placed, since the configuration is specific to this provider.

#### Screenshot of the result

![4811-holdings-suffix-config](https://user-images.githubusercontent.com/5011234/81694961-48f5de00-9462-11ea-8296-9f50c348f5da.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
