### PR TITLE
4614: Periodical holdings - Follow up

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -944,3 +944,10 @@ function ding2_update_7080() {
 function ding2_update_7081() {
   ding2_translation_update();
 }
+
+/**
+ * Update translations.
+ */
+function ding2_update_7082() {
+  ding2_translation_update();
+}

--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -413,6 +413,9 @@ function _ding_availability_text(&$item) {
 function theme_ding_holdings_periodical($variables) {
   $items = array();
 
+  // Remember if this periodical was reservable in any of the issues.
+  $reservable = FALSE;
+
   foreach ($variables['issues'] as $volume => $issues) {
     $iss = array();
     $i = 0;
@@ -428,6 +431,7 @@ function theme_ding_holdings_periodical($variables) {
 
       // Check if the volume is reservable and add reservation button.
       if (!empty($issue_id) && ding_availability_periodical_is_reservable($issues[$key])) {
+        $reservable = TRUE;
         $item_id = array($issue_id, $volume, $key);
         $item_id = array_map('base64_encode', $item_id);
 
@@ -499,7 +503,11 @@ function theme_ding_holdings_periodical($variables) {
   // TODO: We could include info about reservation status here like with normal
   // holdings.
   $prefix = '<h3>' . t('Issues') . '</h3>';
-  $prefix .= '<p>' . t('To make a reservation you need to find an issue below and click a reservation button') . '</p>';
+
+  // If any issues was reservable; insert a helpful text.
+  if ($reservable) {
+    $prefix .= '<p>' . t('To make a reservation you need to find an issue below and click a reservation button.') . '</p>';
+  }
 
   return $prefix . theme('item_list', array('items' => $items, 'attributes' => array('class' => 'ding-periodical-issues')));
 }

--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -198,6 +198,11 @@ function ding_availability_holdings(array $provider_ids) {
       'ordered_count' => 0,
     );
 
+    if (empty($item['holdings'])) {
+      $item['html'] = '<p>' . t('We have 0 copies.') . '</p>';
+      continue;
+    }
+
     if (empty($item['is_periodical'])) {
       // Marks internet resources as available.
       if (!empty($item['is_internet'])) {

--- a/translations/da.po
+++ b/translations/da.po
@@ -67751,3 +67751,15 @@ msgstr "Nulstil migreringsstatus"
 #: /system/ajax
 msgid "Enable debug logging"
 msgstr "Aktivér logging af debugging"
+
+#: /ding_availability/holdings/05627591
+msgid "We have 0 copies."
+msgstr "Vi har ingen eksemplarer af dette materiale."
+
+#: /ding_availability/holdings/06373674
+msgid "To make a reservation you need to find an issue below and click a reservation button."
+msgstr "For at reservere skal du finde et eksemplar i nedenstående med en reserverknap."
+
+#: /ding_availability/holdings/45654265,26838525
+msgid "Cannot be reserved."
+msgstr "Kan ikke reserveres."


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4614

#### Description

A follow up to #1603.

- Do not attempt to render holdings row or show any other availability information if provider didn't return any holdings. Instead we show an alternate empty text that can be translated. (see screenshot below).
- Only show reserved text if there was any reservable.
- Add translations and update.

#### Screenshot of the result

![4614-no-holdings-library-material](https://user-images.githubusercontent.com/5011234/81709655-52874200-9472-11ea-8fd6-37b8e80814d4.png)

Instead of:

![image](https://user-images.githubusercontent.com/5011234/81710265-e822d180-9472-11ea-8dd7-004b0a43d088.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
