### PR TITLE
4783: update CKEditor to 4.14.0

### DIFF
--- a/project.make
+++ b/project.make
@@ -500,7 +500,7 @@ libraries[bpi-client][download][branch] = "master"
 
 ; For wysiwyg.
 libraries[ckeditor][download][type] = "get"
-libraries[ckeditor][download][url] = https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.9.2/ckeditor_4.9.2_standard.zip
+libraries[ckeditor][download][url] = https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.14.0/ckeditor_4.14.0_standard.zip
 libraries[ckeditor][directory_name] = "ckeditor"
 libraries[ckeditor][destination] = "libraries"
 


### PR DESCRIPTION
https://platform.dandigbib.org/issues/4783

Update CKEeditor JavaScript libraries to v4.14.0

The problem existed in CKEditor module for Drupal, not in JavaScript libraries with the same names, so it's not critical.

- [x ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
