### PR TITLE
4743: Webform GDPR

### DIFF
--- a/modules/ding_base/ding_base.info
+++ b/modules/ding_base/ding_base.info
@@ -15,6 +15,7 @@ dependencies[] = pathauto
 dependencies[] = strongarm
 dependencies[] = token
 dependencies[] = transliteration
+dependencies[] = webform
 configure = admin/config/ding
 features[ctools][] = page_manager:pages_default:1
 features[ctools][] = strongarm:strongarm:1

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -934,7 +934,10 @@ function ding_base_mail_alter(&$message) {
     }
 
     $count = 0;
-    $email['message'] = str_replace('[submission:values]', '[submission:url]', $email['message'], $count);
+    // We can also have more specific submission values tokens of the form
+    // [submission:values:?] that reference a specific component on the form,
+    // so we use a regular expression.
+    $email['message'] = preg_replace('/\[submission:values.*\]/', '[submission:url]',  $email['message'], -1, $count);
 
     // Replace tokens in the message (again) if any replacements was performed.
     if ($count > 0) {

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -891,3 +891,43 @@ function ding_base_taxonomy_autocomplete($vid, $tag) {
     drupal_json_output($items);
   }
 }
+
+/**
+ * Implements hook_mail_alter().
+ */
+function ding_base_mail_alter(&$message) {
+  // To protect against personal data from webform submissions getting send
+  // unencrypted in mail to various mail servers, we alter every webform
+  // submission mail and replace any [submission:values] tokens with
+  // [submission:url] token. Administrators must then visit the submission
+  // URL to see/download the data, and the mail will only serve as a
+  // notification of a new submission and not as a method of data transfer.
+  if ($message['id'] == 'webform_submission') {
+    $params = $message['params'];
+    $email = $params['email'];
+    $node = $params['node'];
+    $submission = $params['submission'];
+
+    // Get the original mail template without replaced tokens.
+    // Copied from: webform_submission_send_mail().
+    if ($email['template'] == 'default') {
+      $email['message'] = theme(array('webform_mail_' . $node->nid, 'webform_mail', 'webform_mail_message'), array('node' => $node, 'submission' => $submission, 'email' => $email));
+    }
+    else {
+      $email['message'] = $email['template'];
+    }
+
+    $count = 0;
+    $email['message'] = str_replace('[submission:values]', '[submission:url]', $email['message'], $count);
+
+    // Replace tokens in the message (again) if any replacements was performed.
+    if ($count > 0) {
+      // Copied from: webform_submission_send_mail().
+      $email['message'] = webform_replace_tokens($email['message'], $node, $submission, $email, (boolean)$email['html']);
+
+      // Insert new message in body replacing the old completely.
+      $message['body'] = [];
+      $message['body'][] = $email['message'];
+    }
+  }
+}

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -824,6 +824,19 @@ function ding_base_form_alter(&$form, &$form_state, $form_id) {
       ];
     }
   }
+  elseif (strpos($form_id, 'webform_client_form') === 0) {
+    // Add a notice about not inserting personal on every webform. The link is
+    // hardcoded since we currently don't have any central place for setting
+    // up a privacy poplicy page, and we use translation here primarly for
+    // administrators to be able to change the link.
+    $privacy_notice = t('<strong>NOTICE</strong>: NEVER insert personal data of any kind in the formular. Read more in our <a href="/persondata">privacy policy</a>.');
+    $form['submitted']['privacy_notice'] = [
+      '#type' => 'item',
+      '#markup' => '<p>' . $privacy_notice . '</p>',
+      // Ensure notice is placed at the bottom just above submit button.
+      '#weight' => 50,
+    ];
+  }
 }
 
 /**

--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -924,7 +924,10 @@ function ding_base_mail_alter(&$message) {
     // Get the original mail template without replaced tokens.
     // Copied from: webform_submission_send_mail().
     if ($email['template'] == 'default') {
-      $email['message'] = theme(array('webform_mail_' . $node->nid, 'webform_mail', 'webform_mail_message'), array('node' => $node, 'submission' => $submission, 'email' => $email));
+      $email['message'] = theme(
+        ['webform_mail_' . $node->nid, 'webform_mail', 'webform_mail_message'],
+        ['node' => $node, 'submission' => $submission, 'email' => $email]
+      );
     }
     else {
       $email['message'] = $email['template'];
@@ -936,7 +939,7 @@ function ding_base_mail_alter(&$message) {
     // Replace tokens in the message (again) if any replacements was performed.
     if ($count > 0) {
       // Copied from: webform_submission_send_mail().
-      $email['message'] = webform_replace_tokens($email['message'], $node, $submission, $email, (boolean)$email['html']);
+      $email['message'] = webform_replace_tokens($email['message'], $node, $submission, $email, (boolean) $email['html']);
 
       // Insert new message in body replacing the old completely.
       $message['body'] = [];

--- a/modules/ding_content/ding_content.module
+++ b/modules/ding_content/ding_content.module
@@ -22,7 +22,7 @@ function ding_content_menu() {
     'type' => MENU_CALLBACK,
     'file' => 'ding_content.admin.inc',
   );
-  
+
 
   return $items;
 }

--- a/translations/da.po
+++ b/translations/da.po
@@ -67754,4 +67754,4 @@ msgstr "Aktivér logging af debugging"
 
 #: /node/34
 msgid "<strong>NOTICE</strong>: NEVER insert personal data of any kind in the formular. Read more in our <a href="/persondata">privacy policy</a>."
-msgstr "<strong>BEMÆRK</strong>: Indsæt ALDRIG persondata (fx CPR-nr. eller PIN-kode) i formularen. Læs hvordan dine persondata behandles i <a href="/persondata">bibliotekets persondata politik</a>."
+msgstr "<strong>BEMÆRK</strong>: Indsæt ALDRIG persondata (fx CPR-nr. eller PIN-kode) i formularen. Læs hvordan dine persondata behandles i <a href="/persondata">bibliotekets persondatapolitik</a>."

--- a/translations/da.po
+++ b/translations/da.po
@@ -67751,3 +67751,7 @@ msgstr "Nulstil migreringsstatus"
 #: /system/ajax
 msgid "Enable debug logging"
 msgstr "Aktivér logging af debugging"
+
+#: /node/34
+msgid "<strong>NOTICE</strong>: NEVER insert personal data of any kind in the formular. Read more in our <a href="/persondata">privacy policy</a>."
+msgstr "<strong>BEMÆRK</strong>: Indsæt ALDRIG persondata (fx CPR-nr. eller PIN-kode) i formularen. Læs hvordan dine persondata behandles i <a href="/persondata">bibliotekets persondata politik</a>."


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4743

#### Description

1. Prevent webform from sending user submitted data unencrypted in emails. We replace the submission values token with the submission URL token in `hook_mail_alter()` if it's present. The mail is then just a notification that a webform was submitted, and the administrator must visit submission URL to download/inspect the data.
2. Insert a translatable privacy notice on the bottom of every webform (see screenshot).

#### Screenshot of the result

![4743-webform-privacy-notice](https://user-images.githubusercontent.com/5011234/81997636-acddf980-9650-11ea-9e7b-cdf78bc4bbae.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
