### PR TITLE
4826: Fix behat tests and some cleanup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,8 @@ jobs:
           install_configure_form.update_status_module='array(FALSE,FALSE)' \
           ding2_module_selection_form.providers_selection=connie \
           opensearch_admin_settings.opensearch_url=https://oss-services.dbc.dk/opensearch/5.2/ \
+          opensearch_admin_settings.ting_agency=100200 \
+          opensearch_admin_settings.opensearch_search_profile=test \
           ting_covers_addi_admin_settings_form.ting_covers_addi_wsdl_url=http://moreinfo.addi.dk/2.11 \
           ting_covers_addi_admin_settings_form.ting_covers_addi_username=username \
           ting_covers_addi_admin_settings_form.ting_covers_addi_group=group \
@@ -231,9 +233,6 @@ jobs:
           drush cgen
           drush en -y connie connie_openplatform_token ting_covers_placeholder
           drush dis -y ting_covers_addi
-          drush vset -y ting_agency 100200
-          drush vset -y opensearch_url 'https://oss-services.dbc.dk/opensearch/5.2/'
-          drush vset -y opensearch_search_profile test
           drush vset -y opensearch_recommendation_url 'http://openadhl.addi.dk/1.1/'
           drush vset -y ting_infomedia_url 'http://useraccessinfomedia.addi.dk/1.4/'
           drush vset -y opensearch_search_autocomplete_suggestion_url 'https://ortograf.dbc.dk/ortograf/suggest'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ jobs:
           --site-name=Ding2 --account-name=admin --account-pass=admin \
           install_configure_form.update_status_module='array(FALSE,FALSE)' \
           ding2_module_selection_form.providers_selection=connie \
-          opensearch_admin_settings.opensearch_url=https://opensearch.addi.dk/b3.5_5.2/ \
+          opensearch_admin_settings.opensearch_url=https://oss-services.dbc.dk/opensearch/5.2/ \
           ting_covers_addi_admin_settings_form.ting_covers_addi_wsdl_url=http://moreinfo.addi.dk/2.11 \
           ting_covers_addi_admin_settings_form.ting_covers_addi_username=username \
           ting_covers_addi_admin_settings_form.ting_covers_addi_group=group \
@@ -232,7 +232,7 @@ jobs:
           drush en -y connie connie_openplatform_token ting_covers_placeholder
           drush dis -y ting_covers_addi
           drush vset -y ting_agency 100200
-          drush vset -y opensearch_url 'https://oss-services.dbc.dk/opensearch/5.0/'
+          drush vset -y opensearch_url 'https://oss-services.dbc.dk/opensearch/5.2/'
           drush vset -y opensearch_search_profile test
           drush vset -y opensearch_recommendation_url 'http://openadhl.addi.dk/1.1/'
           drush vset -y ting_infomedia_url 'http://useraccessinfomedia.addi.dk/1.3/'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ jobs:
           opensearch_admin_settings.opensearch_url=https://oss-services.dbc.dk/opensearch/5.2/ \
           opensearch_admin_settings.ting_agency=100200 \
           opensearch_admin_settings.opensearch_search_profile=test \
-          ting_covers_addi_admin_settings_form.ting_covers_addi_wsdl_url=http://moreinfo.addi.dk/2.11 \
+          ting_covers_addi_admin_settings_form.ting_covers_addi_wsdl_url=https://cover.dandigbib.org/api \
           ting_covers_addi_admin_settings_form.ting_covers_addi_username=username \
           ting_covers_addi_admin_settings_form.ting_covers_addi_group=group \
           ting_covers_addi_admin_settings_form.ting_covers_addi_password=password

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,14 +237,6 @@ jobs:
           drush vset -y opensearch_recommendation_url 'http://openadhl.addi.dk/1.1/'
           drush vset -y ting_infomedia_url 'http://useraccessinfomedia.addi.dk/1.4/'
           drush vset -y opensearch_search_autocomplete_suggestion_url 'https://ortograf.dbc.dk/ortograf/suggest'
-          drush vset -y ting_openlist_prefix test
-          drush vset -y ting_openlist_wsdl 'https://test.openlist.ddbcms.dk/?wsdl'
-          drush vset -y ting_library_code 100200
-          drush vset -y user_consent_activate true
-          drush vset -y loan_history_store_title ''
-          drush vset -y loan_history_store_title_first_time ''
-          drush php-eval 'variable_set("loan_history_store_description_first_time", array("value" => ""));'
-          drush php-eval 'variable_set("loan_history_store_description", array("value" => ""));'
           sudo chown -R 33:33 /var/www/html/sites/default/files
     - run:
         name: Install Behat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ jobs:
           drush vset -y opensearch_url 'https://oss-services.dbc.dk/opensearch/5.2/'
           drush vset -y opensearch_search_profile test
           drush vset -y opensearch_recommendation_url 'http://openadhl.addi.dk/1.1/'
-          drush vset -y ting_infomedia_url 'http://useraccessinfomedia.addi.dk/1.3/'
+          drush vset -y ting_infomedia_url 'http://useraccessinfomedia.addi.dk/1.4/'
           drush vset -y opensearch_search_autocomplete_suggestion_url 'https://ortograf.dbc.dk/ortograf/suggest'
           drush vset -y ting_openlist_prefix test
           drush vset -y ting_openlist_wsdl 'https://test.openlist.ddbcms.dk/?wsdl'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -236,8 +236,7 @@ jobs:
           drush vset -y opensearch_search_profile test
           drush vset -y opensearch_recommendation_url 'http://openadhl.addi.dk/1.1/'
           drush vset -y ting_infomedia_url 'http://useraccessinfomedia.addi.dk/1.3/'
-          drush vset -y opensearch_search_autocomplete_suggestion_url 'http://opensuggestion.addi.dk/b3.5_2.0/'
-          drush vset -y opensearch_search_autocomplete_method 'facets'
+          drush vset -y opensearch_search_autocomplete_suggestion_url 'https://ortograf.dbc.dk/ortograf/suggest'
           drush vset -y ting_openlist_prefix test
           drush vset -y ting_openlist_wsdl 'https://test.openlist.ddbcms.dk/?wsdl'
           drush vset -y ting_library_code 100200


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4826

#### Description

The behat search tests was failing because it was still using 5.0 of the testsite, which is no longer available. I didn't see this at first because it was set again further down the pipeline, and not only during initial install.

This PR fixes the behat tests and does some additional cleanup:

- Use 5.2 of test site and only set opensearch variables once during initial install.
- Update autocomplete settings used in behat tests.
- Use newest version of infomedia in behat tests.
- Remove setting of p2 variables in behat tests.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
