### PR TITLE
4659: Do not publish news to app by default

### DIFF
--- a/modules/ding_news/ding_news.info
+++ b/modules/ding_news/ding_news.info
@@ -80,7 +80,6 @@ features[variable][] = comment_form_location_ding_news
 features[variable][] = comment_preview_ding_news
 features[variable][] = comment_subject_field_ding_news
 features[variable][] = field_bundle_settings_node__ding_news
-features[variable][] = flag_mobile_app_default_ding_news
 features[variable][] = flag_push_to_mongo_default_ding_news
 features[variable][] = language_content_type_ding_news
 features[variable][] = menu_options_ding_news

--- a/modules/ding_news/ding_news.install
+++ b/modules/ding_news/ding_news.install
@@ -141,3 +141,10 @@ function ding_news_update_7006() {
 function ding_news_update_7007(&$sandbox) {
   ding_paragraphs_migrate_content_body_field('field_ding_news_body', 'field_ding_paragraphs_text', 'field_ding_news_paragraphs', 'ding_paragraphs_text', 'ding_news', $sandbox);
 }
+
+/**
+ * Unset flag to publish news to mobile app by default.
+ */
+function ding_news_update_7008(&$sandbox) {
+  variable_del('flag_mobile_app_default_ding_news');
+}

--- a/modules/ding_news/ding_news.strongarm.inc
+++ b/modules/ding_news/ding_news.strongarm.inc
@@ -161,13 +161,6 @@ function ding_news_strongarm() {
   $strongarm = new stdClass();
   $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
   $strongarm->api_version = 1;
-  $strongarm->name = 'flag_mobile_app_default_ding_news';
-  $strongarm->value = 1;
-  $export['flag_mobile_app_default_ding_news'] = $strongarm;
-
-  $strongarm = new stdClass();
-  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
-  $strongarm->api_version = 1;
   $strongarm->name = 'flag_push_to_mongo_default_ding_news';
   $strongarm->value = 1;
   $export['flag_push_to_mongo_default_ding_news'] = $strongarm;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4659

#### Description

We currently have a variable set which marks news for publication in
app by default.

The current default is that content is not published by default.
Unset this variable to make news follow this default. Also clean up
after Features which managed this variable previously.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Behat tests involving searches currently fail. See #1628.