### PR TITLE
4764: Related materials

### DIFF
--- a/modules/ding_provider/connie_openplatform_token/connie_openplatform_token.module
+++ b/modules/ding_provider/connie_openplatform_token/connie_openplatform_token.module
@@ -57,8 +57,8 @@ function connie_openplatform_token_login_url($options = []) {
 function connie_openplatform_token_for_agency() {
   $token = FALSE;
 
-  if (!empty($_SESSION['connie_openplatform_for_agency'])) {
-    $token = $_SESSION['connie_openplatform_for_agency'];
+  if (!empty($_SESSION['connie_openplatform_token_for_agency'])) {
+    $token = $_SESSION['connie_openplatform_token_for_agency'];
   }
 
   return $token;

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -20,9 +20,10 @@ function ding_react_libraries_info() {
   return [
     'ddb-react' => [
       'name' => 'DDB React',
-      'vendor url' => 'https://github.com/reload/ddb-react',
-      'download url' => 'https://github.com/reload/ddb-react/releases/download/latest/dist.zip',
-      'version' => '1.0.0',
+      'vendor url' => 'https://github.com/danskernesdigitalebibliotek/ddb-react',
+      'download url' => 'https://github.com/danskernesdigitalebibliotek/ddb-react/releases/download/latest/dist.zip',
+      // We have to set the version to something for Library API to work.
+      'version' => 'latest',
       'files' => [
         'js' => [
           'runtime.js' => ['scope' => 'footer', 'group' => JS_LIBRARY],

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -315,13 +315,14 @@ function ding_react_user_js() {
   drupal_add_http_header('Content-Type', 'application/javascript');
   echo "window.ddbReact = window.ddbReact || {};\n";
 
-  $token = ding_provider_invoke('openplatform_token', 'for_user');
+  $tokens = [
+    'user' => ding_provider_invoke('openplatform_token', 'for_user'),
+    'library' => ding_provider_invoke('openplatform_token', 'for_agency'),
+  ];
+  $tokens = array_filter($tokens);
 
-  if ($token) {
-    echo sprintf("window.ddbReact.userAuthenticated = true;\n");
-    echo sprintf("window.ddbReact.setToken('%s');\n", $token);
-  } else {
-    echo sprintf("window.ddbReact.userAuthenticated = false;\n");
+  foreach ($tokens as $type => $token) {
+    echo sprintf("window.ddbReact.setToken('%s', '%s');\n", $type, $token);
   }
 
   drupal_exit();

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -23,7 +23,7 @@ function ding_react_libraries_info() {
       'vendor url' => 'https://github.com/danskernesdigitalebibliotek/ddb-react',
       'download url' => 'https://github.com/danskernesdigitalebibliotek/ddb-react/releases/download/latest/dist.zip',
       // We have to set the version to something for Library API to work.
-      'version' => 'latest',
+      'version callback' => 'ding_react_get_version',
       'files' => [
         'js' => [
           'runtime.js' => ['scope' => 'footer', 'group' => JS_LIBRARY],
@@ -35,6 +35,27 @@ function ding_react_libraries_info() {
       ],
     ],
   ];
+}
+
+/**
+ * Libraries info version callback.
+ */
+function ding_react_get_version($library) {
+  // We do not care about any options given to the callback. Our version is
+  // always defined within a JSON file which is easy to parse.
+  $version_file = DRUPAL_ROOT . '/' . $library['library path'] . '/version.json';
+  $version_file_data = file_get_contents($version_file);
+  if ($version_file_data) {
+    $version_data = json_decode($version_file_data, TRUE);
+    if ($version_data && !empty($version_data['version'])) {
+      // The version number will be relative to the latest tag in the format
+      // provided by git describe. Libraries API uses strings for versions so
+      // we can so just return it as is.
+      return $version_data['version'];
+    }
+  }
+
+  watchdog('ding_react', 'Unable to read library version from %path', ['%path' => $version_file], WATCHDOG_ERROR);
 }
 
 /**

--- a/modules/ding_react/plugins/content_types/related_materials.inc
+++ b/modules/ding_react/plugins/content_types/related_materials.inc
@@ -38,6 +38,7 @@ function ding_react_related_materials_content_type_render($subtype, $conf, $pane
       return $data->getTingObject();
     }
   }, $contexts_with_data);
+  // Contexts are in prioritized order so get the first which yielded an object.
   $object = array_shift($ting_objects);
 
   if ($object) {
@@ -45,6 +46,8 @@ function ding_react_related_materials_content_type_render($subtype, $conf, $pane
     // list is not sufficient. NB: There is currently no admin UI for setting
     // this.
     $sources = variable_get('ding_react_related_materials_sources', implode(',', [
+      // These are sources containing well-known materials which are also
+      // likely to have cover images. This makes the list more appealing.
       'bibliotekskatalog',
       'ereolen',
       'ereolen global',

--- a/modules/ding_react/plugins/content_types/related_materials.inc
+++ b/modules/ding_react/plugins/content_types/related_materials.inc
@@ -1,0 +1,106 @@
+<?php
+
+/**
+ * @file
+ * Add the checklist app content type.
+ */
+
+$plugin = [
+  'title' => t('Related materials app'),
+  'single' => TRUE,
+  'description' => t('Display related materials for an object.'),
+  'category' => t('DDB React'),
+  'required context' => [
+    new ctools_context_optional(t('Ting object'), 'ting_object'),
+    new ctools_context_optional(t('Ting collection'), 'ting_collection'),
+  ],
+];
+
+/**
+ * Return pane content.
+ */
+function ding_react_related_materials_content_type_render($subtype, $conf, $panel_args, $contexts) {
+  $block = new stdClass();
+
+  // We support multiple contexts which can result in a Ting object.
+  // Find the ones available and extract an object accordingly.
+  $contexts_with_data = array_filter($contexts,
+    function (ctools_context $context) {
+      return !empty($context->data);
+    }
+  );
+  $ting_objects = array_map(function (ctools_context $context) {
+    $data = $context->data;
+    if ($data instanceof TingCollection) {
+      return $data->getPrimary_object()->getTingObject();
+    }
+    elseif ($data instanceof TingEntity) {
+      return $data->getTingObject();
+    }
+  }, $contexts_with_data);
+  $object = array_shift($ting_objects);
+
+  if ($object) {
+    // Support setting allowed sources through a variable in case our hard-coded
+    // list is not sufficient. NB: There is currently no admin UI for setting
+    // this.
+    $sources = variable_get('ding_react_related_materials_sources', implode(',', [
+      'bibliotekskatalog',
+      'ereolen',
+      'ereolen global',
+      'comics plus',
+      'ebook central',
+      'rbdigital magazines',
+    ]));
+    $sources = explode(',', $sources);
+
+    $data = [
+      'subjects' => ding_react_related_materials_format_strings($object->getSubjects()),
+      'categories' => ding_react_related_materials_format_strings($object->getAudience()),
+      'sources' => ding_react_related_materials_format_strings($sources),
+      'exclude-title' => ding_react_related_materials_format_string($object->getTitle()),
+      // We cannot use url() here as it will encode the colon in the placeholder.
+      'search-url' => '/search/ting/:query?sort=:sort',
+      'material-url' => '/ting/object/:pid',
+      'cover-service-url' => 'https://cover.dandigbib.org/api',
+      'title-text' => t('Related materials'),
+      'search-text' => t('Show search result for related materials'),
+    ];
+    $block->content = ding_react_app('related-materials', $data);
+  }
+
+  return $block;
+}
+
+/**
+ * Format a set of string values to a format suitable for React app data.
+ *
+ * @param string[] $strings
+ *   The string values.
+ *
+ * @return string
+ *   A single formatted string containing all the values.
+ */
+function ding_react_related_materials_format_strings(array $strings) {
+  $formatted_strings = array_map('ding_react_related_materials_format_string', $strings);
+  return implode(" ", $formatted_strings);
+}
+
+/**
+ * Format a single string to a format suitable for React app data.
+ *
+ * @param string $string
+ *   The string value.
+ *
+ * @return string
+ *   The formatted string value.
+ */
+function ding_react_related_materials_format_string($string) {
+  // Remove , from strings. OpenPlatform currently fails with the error
+  // "q is not of a type(s) string" if we do not do this. This means that we
+  // will probably not get a match on this exact string but that is preferable
+  // to failing with 0 results.
+  $string = str_replace(',', '', $string);
+  // Handle multiple words as a phrase.
+  return (strpos($string, ' ') !== FALSE) ? "'$string'" : $string;
+}

--- a/modules/ding_ting_frontend/ding_ting_frontend.pages_default.inc
+++ b/modules/ding_ting_frontend/ding_ting_frontend.pages_default.inc
@@ -815,6 +815,25 @@ search/ting
     $pane->uuid = '0ff7e4a6-1810-4de9-84d4-fda87404376a';
     $display->content['new-0ff7e4a6-1810-4de9-84d4-fda87404376a'] = $pane;
     $display->panels['attachment_1_1'][3] = 'new-0ff7e4a6-1810-4de9-84d4-fda87404376a';
+    $pane = new stdClass();
+    $pane->pid = 'new-1fdbaeae-5265-41a0-b80f-5cbb249f0ba7';
+    $pane->panel = 'attachment_1_1';
+    $pane->type = 'related_materials';
+    $pane->subtype = 'related_materials';
+    $pane->shown = TRUE;
+    $pane->access = array();
+    $pane->configuration = array();
+    $pane->cache = array();
+    $pane->style = array(
+      'settings' => NULL,
+    );
+    $pane->css = array();
+    $pane->extras = array();
+    $pane->position = 4;
+    $pane->locks = array();
+    $pane->uuid = '1fdbaeae-5265-41a0-b80f-5cbb249f0ba7';
+    $display->content['new-1fdbaeae-5265-41a0-b80f-5cbb249f0ba7'] = $pane;
+    $display->panels['attachment_1_1'][4] = 'new-1fdbaeae-5265-41a0-b80f-5cbb249f0ba7';
   $display->hide_title = PANELS_TITLE_FIXED;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;

--- a/modules/ting/src/TingObjectInterface.php
+++ b/modules/ting/src/TingObjectInterface.php
@@ -103,8 +103,8 @@ interface TingObjectInterface {
    *
    * Eg. "børnematerialer"
    *
-   * @return string|FALSE
-   *   The target group, or FALSE if it could not be determined.
+   * @return string|string[]|FALSE
+   *   The target group(s), or FALSE if it could not be determined.
    */
   public function getAudience();
 

--- a/themes/ddbasic/sass/components/ding-react.scss
+++ b/themes/ddbasic/sass/components/ding-react.scss
@@ -93,3 +93,63 @@
     font-size: 18px;
   }
 }
+
+// Related materials
+.ddb-related-materials {
+  padding: 0;
+  background-color: transparent;
+
+  &__title {
+    // Make the application title look like a panel title.
+    // @see .pane-content .pane-title
+    @include font('display-large');
+    color: $color-text;
+    margin: 0 0 20px;
+
+    @include media($mobile) {
+      margin-bottom: 10px;
+    }
+  }
+
+  &__search {
+    display: block;
+    margin: 16px 0 0;
+    color: $color-text-link;
+  }
+
+  &__list {
+    justify-content: space-between;
+  }
+}
+
+.ddb-related-material {
+  margin: 16px 0 0;
+
+  // Sizing covers where we do not have a guaranteed height or width is tricky.
+  // Lock in some sensible values at known breakpoints.
+  $image_height_width_ratio: 1.5;
+  // Widths suitable for a 5x2 display.
+  $width: 212px;
+  $notebook_width: 171px;
+  $tablet_width: 125px;
+  // Mobile display is 2x5.
+  $mobile_width: 160px;
+
+  width: $width;
+  height: $width * $image_height_width_ratio;
+
+  @include media($notebook) {
+    width: $notebook_width;
+    height: $notebook_width * $image_height_width_ratio;
+  }
+
+  @include media($tablet) {
+    width: $tablet_width;
+    height: $tablet_width * $image_height_width_ratio;
+  }
+
+  @include media($mobile) {
+    width: $mobile_width;
+    height: $mobile_width * $image_height_width_ratio;
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4764

#### Description

This PR adds a new React app displaying related materials for an object on the object page.

#### Screenshot of the result

![Ting object | Harry Potter og fangen fra Azkaban | Ding2 2020-05-25 00-03-23](https://user-images.githubusercontent.com/73966/82765915-2c22b880-9e1b-11ea-935b-e70e5a61cd6f.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

To make this work for anonymous users were we need to access OpenPlatform without a token for an authenticated user we pull in support for agency tokens for #1617. Note that if that PR is updated and merged this will likely result in conflicts for us as well.

Scrutinizer comments are either "imported" through 6f1f54b or contradictory.