### PR TITLE
4720: Fix error on deleted relation nodes

### DIFF
--- a/modules/ting_reference/ting_reference.module
+++ b/modules/ting_reference/ting_reference.module
@@ -250,6 +250,14 @@ function ting_reference_field_delete($entity_type, $entity, $field, $instance, $
 
   foreach ($relations as $rid => $relation) {
     relation_delete($rid);
+
+    // Try to get the entity ID of the ting_object and clear it's field cache.
+    // This is not handled automatically and it would otherwise only be cleared
+    // on next cache flush.
+    if (!empty($relation->endpoints[$langcode])) {
+      $entity_id = $relation->endpoints[$langcode][1]['entity_id'];
+      cache_clear_all("field:ting_object:$entity_id", 'cache_field');
+    }
   }
 }
 

--- a/modules/ting_reference/ting_reference.module
+++ b/modules/ting_reference/ting_reference.module
@@ -378,7 +378,7 @@ function ting_reference_field_formatter_view($entity_type, $entity, $field, $ins
 
         // Handle ting_reference in paragraphs, which will link back to the
         // paragraph (giving a reference loop) and not the host node.
-        if ($entity_type === 'paragraphs_item') {
+        if ($entity_type === 'paragraphs_item' && !empty($entities)) {
           // It should only be possible to link back to one entity per item.
           $entity = reset($entities);
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4720

#### Description

Fix error when viewing materials that has been attached to deleted nodes in paragraphs material lists.

It's only the node's field cache that is cleared when a ting_reference field is deleted. The ting_object's field_cache data will keep pointing back to paragraph/node until next cache flush, which will give error. 

It could take long before next cache flush, so in this PR we also attempt to clear the related ting_object's field cache, when ting_reference field is deleted.

To be safe we will still keep the empty-checks in the field formatter, to ensure we could load the referenced entity.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
