### PR TITLE
4789: Nodelist promoted nodes link issue

### DIFF
--- a/themes/ddbasic/scripts/ddbasic.common.js
+++ b/themes/ddbasic/scripts/ddbasic.common.js
@@ -108,16 +108,15 @@
       // "Promoted nodes" items classes list.
       var classes = ['first-left-block', 'first-right-block', 'last-left-block', 'last-right-block'];
       classes.forEach(function (value) {
-        // Getting item wrapper.
+        // Attach mouseover/click handler to every item wrapper.
         var itemWrapper = $('.' + value);
-        // Extracting item's url from wrapper.
-        var href = itemWrapper.data('href');
         itemWrapper.on('mouseover click', function (event) {
           // Always display pointer cursor.
           itemWrapper.css('cursor', 'pointer');
-          // Act as a click on link when "click" event is executed.
+          // If click event; use data-href value on current item wrapper as link
+          // to new page.
           if (event.type === 'click') {
-            window.location.href = href;
+            window.location.href = $(this).data('href');
           }
         });
       });


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4789

#### Description

The click handler was getting the data-href from it's outer scope, resulting in it always using the value from the first matches. In case of multiple nodelist promoted nodes on one page, this would make them all point to items in the first one.

To solve this we get the data-href directly from the clicked itemwrapper in the click handler.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
