### PR TITLE
4033: Make comment module optional and disable

### DIFF
--- a/modules/ding_content/ding_content.info
+++ b/modules/ding_content/ding_content.info
@@ -4,7 +4,6 @@ core = 7.x
 package = Ding!
 project = ding_content
 dependencies[] = clone
-dependencies[] = comment
 dependencies[] = ctools
 dependencies[] = ctools_custom_content
 dependencies[] = ding_page

--- a/modules/ding_content/ding_content.install
+++ b/modules/ding_content/ding_content.install
@@ -187,3 +187,10 @@ function ding_content_update_7000() {
 function ding_content_update_7001() {
   ding_content_insert_html5_video_presets();
 }
+
+/**
+ * Disable comment module.
+ */
+function ding_content_update_7002() {
+  module_disable(['comment']);
+}

--- a/modules/ding_frontend/ding_frontend.info
+++ b/modules/ding_frontend/ding_frontend.info
@@ -5,7 +5,6 @@ package = Ding!
 project = ding_frontend
 dependencies[] = block
 dependencies[] = block_access
-dependencies[] = comment
 dependencies[] = conditional_styles
 dependencies[] = ctools
 dependencies[] = ding_page

--- a/modules/ding_library/ding_library.info
+++ b/modules/ding_library/ding_library.info
@@ -5,7 +5,6 @@ package = Ding!
 project = ding_library
 dependencies[] = addressfield
 dependencies[] = cache_actions
-dependencies[] = comment
 dependencies[] = cs_adaptive_image
 dependencies[] = ctools
 dependencies[] = ding_base


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4033

#### Description

DDB CMS has very limited comment integration and the styling is currently all over the place (see screenshot below). To use it properly would require adjustments that webmasters are not able to make. It therefore makes sense to disable it as standard.

Another is issue that it's very easy to turn on comments by accident as described in the case.

The easiest approach is to make the comment module optional by removing dependencies and just disable it.

DDB CMS has some comment integration in ding_user and comment related strongarmed variables. We'll keep these, since they do not cause any issue with the comment module disabled, and if any library was actually using comments, they can just enable it again and everything will work as usual. 

#### Screenshot of the result

![4033-ddbasic-comment-styling](https://user-images.githubusercontent.com/5011234/83642082-a89d6000-a5ae-11ea-964e-7b4e41eb418e.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
