### PR TITLE
4622: Fix carousel material display

### DIFF
--- a/modules/ding_ting_frontend/ding_ting_frontend.field_group.inc
+++ b/modules/ding_ting_frontend/ding_ting_frontend.field_group.inc
@@ -246,9 +246,9 @@ function ding_ting_frontend_field_group_info() {
     'label' => 'Text',
     'weight' => '2',
     'children' => array(
-      0 => 'ting_abstract',
-      1 => 'group_inner',
       0 => 'ding_entity_buttons',
+      1 => 'ting_abstract',
+      2 => 'group_inner',
     ),
     'format_type' => 'div',
     'format_settings' => array(
@@ -280,9 +280,9 @@ function ding_ting_frontend_field_group_info() {
     'label' => 'Text',
     'weight' => '2',
     'children' => array(
-      0 => 'ting_abstract',
-      1 => 'group_inner',
       0 => 'ding_entity_buttons',
+      1 => 'ting_abstract',
+      2 => 'group_inner',
     ),
     'format_type' => 'div',
     'format_settings' => array(
@@ -724,7 +724,6 @@ function ding_ting_frontend_field_group_info() {
   t('Image');
   t('Info');
   t('Inner');
-  t('Issues');
   t('Left column');
   t('On this site');
   t('Right column');

--- a/modules/ting/ting.module
+++ b/modules/ting/ting.module
@@ -414,11 +414,11 @@ function ting_ding_entity_buttons($type, $entity, $view_mode, $widget = 'default
       ];
     }
 
-    // Loading collection (specially on empty cache is expensive). So only load
-    // the collection when it's need and here only when this button is required
-    // in the design. Before using context it was load but not used in the
-    // design.
-    if (strpos($view_mode, 'teaser') === FALSE) {
+    // Loading collection (specially on empty cache is expensive). So only show
+    // "Other formats" buttons where it's needed on the main page of the
+    // material.
+    $entity_path = entity_uri('ting_object', $entity)['path'];
+    if (current_path() == $entity_path) {
       $collection = ting_collection_load($entity->id);
       if (is_a($collection, 'TingCollection') && count($collection->types) > 1) {
         $buttons[] = [

--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -48,6 +48,12 @@ function ting_search_carousel_carousel_content_type_render($subtype, $conf, $pan
       );
     }
 
+    // Since we don't load any materials on initial page request, we have to
+    // ensure the check reservability script is present. Ding carousel uses
+    // custom attach logic in frontend, which does not handle any scripts added
+    // during the AJAX-request.
+    drupal_add_js(drupal_get_path('module', 'ding_reservation') . '/js/ding_reservation_reservability.js');
+
     $block->content = array(
       '#type' => 'ding_tabbed_carousel',
       '#tabs' => $carousels,

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -159,8 +159,8 @@
           opacity: 1;
         }
       }
-      // Hide ding list add entity button in teaser view modes.
-      .ding-list-add-button {
+      // Hide ding react add to list button in teaser views.
+      [data-ddb-app="add-to-checklist"] {
         display: none;
       }
 
@@ -335,7 +335,8 @@
           width: 42%;
         }
       }
-      .ding-list-add-button {
+      // Hide ding react add to list button in reference teaser views.
+      [data-ddb-app="add-to-checklist"] {
         display: none;
       }
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4622

Also see: https://platform.dandigbib.org/issues/4562

#### Description

- Fix error in field group export.
- Fix missing reservation buttons in carousels.
- Only show "Other formats" button on entity path (explanation in commit message).
- Hide add to list button from in teaser views.

Since `hook_ding_entity_buttons()` shows all buttons, it's up to the implementer to ensure it's displayed correctly in the different view modes in frontend. Otherwise it will have to be removed in theming, like the approach in this PR.

#### Screenshot of the result

![4622-result](https://user-images.githubusercontent.com/5011234/83712212-80047d00-a625-11ea-854d-7a0d9d09dc02.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
