### PR TITLE
4793: Use Coverservice v2 for React components

### DIFF
--- a/modules/ding_react/ding_react.admin.inc
+++ b/modules/ding_react/ding_react.admin.inc
@@ -32,6 +32,15 @@ function ding_react_admin_settings_form($form, &$form_state) {
     '#element_validate' => [ 'ding_react_element_validate_url' ],
   ];
 
+  $form['services']['ding_react_cover_service_url'] = [
+    '#type' => 'textfield',
+    '#title' => t('Cover Service'),
+    '#description' => t('Url to the Cover Service instance to use.'),
+    '#default_value' => ding_react_cover_service_url(),
+    '#required' => TRUE,
+    '#element_validate' => [ 'ding_react_element_validate_url' ],
+  ];
+
   $form['migration'] = [
     '#type' => 'fieldset',
     '#title' => t('Migration'),

--- a/modules/ding_react/ding_react.admin.inc
+++ b/modules/ding_react/ding_react.admin.inc
@@ -20,7 +20,7 @@ function ding_react_admin_settings_form($form, &$form_state) {
     '#description' => t('Url to the Material List service instance to use.'),
     '#default_value' => ding_react_material_list_url(),
     '#required' => TRUE,
-    '#element_validate' => [ 'ding_react_element_validate_url' ],
+    '#element_validate' => ['ding_react_element_validate_url'],
   ];
 
   $form['services']['ding_react_follow_searches_url'] = [
@@ -29,7 +29,7 @@ function ding_react_admin_settings_form($form, &$form_state) {
     '#description' => t('Url to the Follow Searches service instance to use.'),
     '#default_value' => ding_react_follow_searches_url(),
     '#required' => TRUE,
-    '#element_validate' => [ 'ding_react_element_validate_url' ],
+    '#element_validate' => ['ding_react_element_validate_url'],
   ];
 
   $form['services']['ding_react_cover_service_url'] = [
@@ -38,7 +38,7 @@ function ding_react_admin_settings_form($form, &$form_state) {
     '#description' => t('Url to the Cover Service instance to use.'),
     '#default_value' => ding_react_cover_service_url(),
     '#required' => TRUE,
-    '#element_validate' => [ 'ding_react_element_validate_url' ],
+    '#element_validate' => ['ding_react_element_validate_url'],
   ];
 
   $form['migration'] = [

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -4,6 +4,7 @@ define('DING_REACT_FOLLOW_SEARCHES_PROD_URL', 'https://prod.followsearches.dandi
 define('DING_REACT_FOLLOW_SEARCHES_STAGE_URL', 'https://stage.followsearches.dandigbib.org');
 define('DING_REACT_MATERIAL_LIST_PROD_URL', 'https://prod.materiallist.dandigbib.org');
 define('DING_REACT_MATERIAL_LIST_TEST_URL', 'https://test.materiallist.dandigbib.org');
+define('DING_REACT_COVER_SERVICE_URL', 'https://cover.dandigbib.org/api/v2');
 define('DING_REACT_MIGRATED_UID_PREFIX', 'migrated-');
 
 /**
@@ -380,6 +381,15 @@ function ding_react_material_list_url() {
  */
 function ding_react_follow_searches_url() {
   return variable_get('ding_react_follow_searches_url', DING_REACT_FOLLOW_SEARCHES_STAGE_URL);
+}
+
+/**
+ * Returns the url to the instance of the Cover service to use.
+ *
+ * @return string
+ */
+function ding_react_cover_service_url() {
+  return variable_get('ding_react_cover_service_url', DING_REACT_COVER_SERVICE_URL);
 }
 
 /**

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -369,6 +369,7 @@ function ding_react_login_url() {
  * Returns the url to the instance of the Material List service to use.
  *
  * @return string
+ *   Url to Material List service instance.
  */
 function ding_react_material_list_url() {
   return variable_get('ding_react_material_list_url', DING_REACT_MATERIAL_LIST_TEST_URL);
@@ -378,6 +379,7 @@ function ding_react_material_list_url() {
  * Returns the url to the instance of the Follow Searches service to use.
  *
  * @return string
+ *   Url to Follow Searches service instance.
  */
 function ding_react_follow_searches_url() {
   return variable_get('ding_react_follow_searches_url', DING_REACT_FOLLOW_SEARCHES_STAGE_URL);
@@ -387,6 +389,7 @@ function ding_react_follow_searches_url() {
  * Returns the url to the instance of the Cover service to use.
  *
  * @return string
+ *   Url to Cover service instance.
  */
 function ding_react_cover_service_url() {
   return variable_get('ding_react_cover_service_url', DING_REACT_COVER_SERVICE_URL);

--- a/modules/ding_react/plugins/content_types/checklist.inc
+++ b/modules/ding_react/plugins/content_types/checklist.inc
@@ -22,6 +22,7 @@ function ding_react_checklist_content_type_render($subtype, $conf, $panel_args, 
 
   $data = [
     'material-list-url' => ding_react_material_list_url(),
+    'cover-service-url' => ding_react_cover_service_url(),
     // We cannot use url() here as it will encode the colon in the placeholder.
     'material-url' => '/ting/object/:pid',
     'author-url' => '/search/ting/phrase.creator=":author"',

--- a/modules/ding_react/plugins/content_types/related_materials.inc
+++ b/modules/ding_react/plugins/content_types/related_materials.inc
@@ -65,7 +65,7 @@ function ding_react_related_materials_content_type_render($subtype, $conf, $pane
       // We cannot use url() here as it will encode the colon in the placeholder.
       'search-url' => '/search/ting/:query?sort=:sort',
       'material-url' => '/ting/object/:pid',
-      'cover-service-url' => 'https://cover.dandigbib.org/api',
+      'cover-service-url' => ding_react_cover_service_url(),
       'title-text' => t('Related materials'),
       'search-text' => t('Show search result for related materials'),
     ];


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4793

#### Description

This PR allows the React components to use the new version of the Cover service.

The change in itself has multiple dependencies:

- The React components themselves were updated to support the new Cover Service version with danskernesdigitalebibliotek/ddb-react#97. This change is included in the `latest` version of the package and an upcoming version 2.0 which will be tagged when tagging the next release of this project.
- The new version of the Cover service requires authentication. This has been implemented in danskernesdigitalebibliotek/ddb-react#96 as well as in #1630 were we need it to provide library level authentication against services for unauthenticated users.

The actual changes related to the issue is thus only related to bringing the cover service up to speed in regards to configuration with other services and ensuring that this configuration is used properly.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If #1630 for some reason is not merged then we will have to rework the changes in this PR to include the token-related code.