### PR TITLE
4864: Updated TUI color picker directory name in makefile

### DIFF
--- a/project.make
+++ b/project.make
@@ -648,7 +648,7 @@ libraries[ddb-cover-service-upload-client][destination] = "libraries"
 ; Libraries used by CoverService upload.
 libraries[tui-color-picker][download][type] = "get"
 libraries[tui-color-picker][download][url] = https://github.com/nhn/tui.color-picker/archive/v2.2.6.tar.gz
-libraries[tui-color-picker][directory_name] = "ui-color-picker"
+libraries[tui-color-picker][directory_name] = "tui-color-picker"
 libraries[tui-color-picker][destination] = "libraries"
 
 ; Libraries used by CoverService upload.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4864

#### Description

There was an missing `t` in the directory name for the TUI color picker in the `project.make` file. So the library is never load and the image editor fails loading doing to the new missing dependency.

#### Screenshot of the result

<img width="1622" alt="Screenshot 2020-06-19 at 09 23 15" src="https://user-images.githubusercontent.com/111397/85107612-8c382f00-b20e-11ea-9af4-1e1a9dd7d33f.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments