### PR TITLE
4362: Small fixes to ting_smart_search

### DIFF
--- a/modules/ting_smart_search/extras/parse_auto_data.php
+++ b/modules/ting_smart_search/extras/parse_auto_data.php
@@ -16,8 +16,7 @@ try {
   $data = array();
   while (($line = fgetcsv($file, 1000, ";")) !== FALSE) {
     if (!(strpos($line[1], 'ereolen') !== false)) {
-      // Needs to be done. The incoming file is not UTF-8.
-      $search = mb_convert_encoding($line[0], 'UTF-8', 'ISO-8859-15');;
+      $search = $line[0];
       $clicked_page = $line[1];
       $hits = $line[2];
       
@@ -41,8 +40,14 @@ try {
   foreach ($data as $search => $objects) {
     arsort($objects);
     reset($objects);
-    $output[$search] = array_slice($objects, 0, 5);
+    $slice = array_slice($objects, 0, 5);
+    foreach ($slice as $faust => $hits) {
+      if ($hits >= 2) {
+        $output[$search][$faust] = $hits;
+      }
+    }
   }
+
   $serialized_output = serialize($output);
   file_put_contents($output_file, $serialized_output);
 

--- a/modules/ting_smart_search/includes/ting_smart_search.admin.inc
+++ b/modules/ting_smart_search/includes/ting_smart_search.admin.inc
@@ -69,6 +69,12 @@ function ting_smart_search_admin_form($form, &$form_state) {
     '#type' => 'submit',
     '#submit' => array('ting_smart_search_export_form_submit'),
   );
+  $form['export_smartsearch']['help_text'] = array(
+    '#markup' => '<p>' . t('Filter on active in order to see your changes') . '</p>',
+    '#type' => 'markup',
+
+  );
+  
   $form['import_smartsearch'] = array(
     '#type' => 'fieldset',
     '#title' => t('Import Smart Search records'),

--- a/modules/ting_smart_search/includes/ting_smart_search.admin.inc
+++ b/modules/ting_smart_search/includes/ting_smart_search.admin.inc
@@ -72,9 +72,7 @@ function ting_smart_search_admin_form($form, &$form_state) {
   $form['export_smartsearch']['help_text'] = array(
     '#markup' => '<p>' . t('Filter on active in order to see your changes') . '</p>',
     '#type' => 'markup',
-
-  );
-  
+  );  
   $form['import_smartsearch'] = array(
     '#type' => 'fieldset',
     '#title' => t('Import Smart Search records'),

--- a/modules/ting_smart_search/ting_smart_search.module
+++ b/modules/ting_smart_search/ting_smart_search.module
@@ -194,7 +194,7 @@ function ting_smart_search_auto(array $smart_search_userdefined_boosts, $query) 
   if (isset($record) && isset($record->materialids)) {
     // We set a huge boost value. Necassery in order to ensure we get the order
     // of materials we want.
-    $weight = 10000;
+    $weight = 100000;
     $first_fausts_for_query = explode(',', $record->materialids);
     foreach ($first_fausts_for_query as $faust) {
       $smart_search_userdefined_boosts[] = array(
@@ -202,7 +202,7 @@ function ting_smart_search_auto(array $smart_search_userdefined_boosts, $query) 
         'fieldValue' => urldecode($faust),
         'weight' => $weight,
       );
-      $weight = $weight - 1000;
+      $weight = (int) $weight / 2;
     }
   }
   return $smart_search_userdefined_boosts;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4362

#### Description

Three small fixes. A lower limit on the number off clicks we use in automatic boosting. A bug fix off sometimes wrong order off automatically boosted materials and a help text under the view local smart search records in the admin page.

