### PR TITLE
3585: Allow cookie-agreed-cid to pass through Varnish

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -1028,3 +1028,10 @@ function ding2_update_7087() {
 function ding2_update_7088() {
   ding2_translation_update();
 }
+
+/**
+ * Update translations.
+ */
+function ding2_update_7089() {
+  ding2_set_eu_cookie_compliance_settings();
+}

--- a/ding2.profile
+++ b/ding2.profile
@@ -833,6 +833,7 @@ function ding2_set_eu_cookie_compliance_settings() {
   $eu_cookie_compliance = array_merge($eu_cookie_compliance, [
     'method' => 'opt_in',
     'show_disagree_button' => 1,
+    'popup_enabled' => TRUE,
     'popup_info' => [
       'value' => '<h2>Hjælp os med at forbedre oplevelsen på hjemmesiden ved at acceptere cookies.</h2>',
       'format' => 'ding_wysiwyg',
@@ -853,6 +854,9 @@ function ding2_set_eu_cookie_compliance_settings() {
     'popup_delay' => 1000,
     'exclude_admin_pages' => TRUE,
     'consent_storage_method' => 'provider',
+    // Use the name of the latest ding2 update hook to change the provider
+    // settings to ensure that users have to agree again.
+    'cookie_name' => 'cookie-agreed-7083',
   ]);
   i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3585

#### Description

Without this we cannot transfer consent from any anonymous user to 
a specific authenticated user when logging in as the consent id 
cookie is stripped before reaching Drupal.

As the consent cookie name is configurable we cannot know what the
cookie name will be but the cookie-agreed is the default so we go
with that. An update hook sets the precedence of using the version
as a suffix to the cookie name. To accommodate this practice we have
to make the stripping sufficiently flexible.

Allawing this cookie to be passed through will reduce the efficiency
of the Varnish cache for anonymous users as we accept variance based
on another cookie but it should only create one additional buckets 
for each url: With or without the cookie. The cookie will generally 
always have the same value set.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
