### PR TITLE
3585: Fix migration of cookie consent when logging in

### DIFF
--- a/.platform/routes.yaml
+++ b/.platform/routes.yaml
@@ -7,9 +7,7 @@
   type: upstream
   upstream: "app:http"
   cache:
-    enabled: true
-    # Base the cache on the session cookie. Ignore all other cookies.
-    cookies: ['/^SS?ESS/']
+    enabled: false
 
 "https://www.{default}/":
   type: redirect

--- a/ding2.install
+++ b/ding2.install
@@ -1035,3 +1035,10 @@ function ding2_update_7088() {
 function ding2_update_7089() {
   ding2_translation_update();
 }
+
+/**
+ * Update cookie compliance settings.
+ */
+function ding2_update_7090() {
+  ding2_set_eu_cookie_compliance_settings();
+}

--- a/ding2.profile
+++ b/ding2.profile
@@ -833,11 +833,19 @@ function ding2_set_eu_cookie_compliance_settings() {
   $eu_cookie_compliance = array_merge($eu_cookie_compliance, [
     'method' => 'opt_in',
     'show_disagree_button' => 1,
+    'popup_enabled' => TRUE,
     'popup_info' => [
       'value' => '<h2>Hjælp os med at forbedre oplevelsen på hjemmesiden ved at acceptere cookies.</h2>',
       'format' => 'ding_wysiwyg',
     ],
+    'popup_agreed' => array(
+      // We do not use the module in a mode where text is displayed after the
+      // user agrees but the module expects a value so set an empty string.
+      'value' => '',
+      'format' => 'ding_wysiwyg',
+    ),
     'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',
+    'popup_agreed_enabled' => FALSE,
     'popup_disagree_button_message' => 'Mere info',
     'disagree_button_label' => 'Afvis',
     'withdraw_enabled' => 1,
@@ -847,12 +855,19 @@ function ding2_set_eu_cookie_compliance_settings() {
     ],
     'withdraw_tab_button_label' => 'Privatlivsindstillinger',
     'withdraw_action_button_label' => 'Tilbagekald samtykke',
+    // This will make the popup use the bottom position.
+    'popup_position' => FALSE,
     'popup_link' => 'cookies',
     'popup_bg_hex' => '0D0D26',
     'popup_text_hex' => 'FFFFFF',
+    'popup_height' => '',
+    'popup_width' => '100%',
     'popup_delay' => 1000,
     'exclude_admin_pages' => TRUE,
     'consent_storage_method' => 'provider',
+    // Use the name of the latest ding2 update hook to change the provider
+    // settings to ensure that users have to agree again.
+    'cookie_name' => 'cookie-agreed-7083',
   ]);
   i18n_variable_set('eu_cookie_compliance', $eu_cookie_compliance, 'da');
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3585

#### Description

When users are logging in their consent should be migrated from the 
anonymous user to the current user.

Currently this does not seem to occur in testing environments due to 
configuration problems related to the cookie compliance module. 
The values we set in the default configuration must include all values
expected when reading the configuration again. The module will not
provide any sane defaults. This may result in warnings as well as
errors.

If the cookie_name variable is not set then we will not be able to
migrate cookie consent from an anonymous user to the authenticated
user on login.

To test this on Platform.sh we have to disable the HTTP cache as it will
strip cookies - even for the POST requests that are used during login.

This prevents the cookie compliance consent cookies from being 
detected and passed to the user by the storage provider during login.

We should not have to touch the Varnish configuration as it is already
configured to pass POST requests directly through instead of processing
them which at the moment includes stripping of most cookies.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
