### PR TITLE
4764: Strip certain characters from keys before performing DB search

### DIFF
--- a/modules/ting_search/plugins/content_types/search_backends.inc
+++ b/modules/ting_search/plugins/content_types/search_backends.inc
@@ -147,4 +147,3 @@ function ting_search_backend_engines_form($form, &$form_state, $options, $defaul
 function ting_search_backend_engines_content_type_edit_form($form, &$form_state) {
   return $form;
 }
-

--- a/modules/ting_search/plugins/content_types/search_backends.inc
+++ b/modules/ting_search/plugins/content_types/search_backends.inc
@@ -72,11 +72,14 @@ function ting_search_backend_engines_content_type_render($subtype, $conf, $panel
         break;
 
       case 'node':
+        // Strip characters which may work for Ting search queries but trips
+        // up content search.
+        $db_keys = str_replace('\'', '', $keys);
         // Load view which is rendered on node search and getting the total
         // amount of rows returned.
         $view = views_get_view('ding_multiple_search');
         $view->set_display('panel_pane_1');
-        $view->set_arguments(array($keys));
+        $view->set_arguments(array($db_keys));
         $view->execute();
         $count = $view->total_rows;
         $title = $title . ' <span class="count">(' . $count . ')</span>';


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4764#note-26

#### Description

Some characters may be valid CQL and thus work when searching for
materials but cause problems when used for CMS content search. One
example of such a character is ‘. When included in the search keys
a database error will occur such as:

```
SQLSTATE[42000]: Syntax error or access violation: 1064 You have an
error in your SQL syntax; check the manual that corresponds to your
MySQL server version for the right syntax to use near '%' AS w0,
t.word LIKE '%potter'%' AS w1 FROM
search_api_db_default_multiple_ind' at line 1
```

Tracing this error goes deep into the Drupal database layer and
without a proper fix.

The simplest way to address this seems to be to just strip the
characters.

#### Screenshot of the result

Before the change the following error was shown:

![Søg | 'Harry Potter' | AarhusBibliotekerne 2020-07-06 01-20-36](https://user-images.githubusercontent.com/73966/86544412-e7fcfa80-bf26-11ea-938f-fa8423080944.png)

https://www.aakb.dk/search/ting/%27Harry%20Potter%27?

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
