### PR TITLE
4764: Do not show related materials for objects without subjects

### DIFF
--- a/modules/ding_react/plugins/content_types/related_materials.inc
+++ b/modules/ding_react/plugins/content_types/related_materials.inc
@@ -5,6 +5,8 @@
  * Add the checklist app content type.
  */
 
+use Ting\TingObjectInterface;
+
 $plugin = [
   'title' => t('Related materials app'),
   'single' => TRUE,
@@ -41,7 +43,9 @@ function ding_react_related_materials_content_type_render($subtype, $conf, $pane
   // Contexts are in prioritized order so get the first which yielded an object.
   $object = array_shift($ting_objects);
 
-  if ($object) {
+  // Only show related materials if the object has subjects. If not then there
+  // is not enough data to display meaningful results.
+  if ($object instanceof TingObjectInterface && !empty($object->getSubjects())) {
     // Support setting allowed sources through a variable in case our hard-coded
     // list is not sufficient. NB: There is currently no admin UI for setting
     // this.

--- a/themes/ddbasic/sass/components/ding-react.scss
+++ b/themes/ddbasic/sass/components/ding-react.scss
@@ -118,12 +118,28 @@
   }
 
   &__list {
-    justify-content: space-between;
+    justify-content: flex-start;
+
+    li {
+      margin: 16px 16px 0 0;
+
+      // Default is a 5x2 display.
+      &:nth-child(5n) {
+        margin-right: 0;
+      }
+
+      // Mobile is a 5x2 display.
+      @include media($mobile) {
+        &:nth-child(even) {
+          margin-right: 0;
+        }
+      }
+    }
   }
 }
 
 .ddb-related-material {
-  margin: 16px 0 0;
+  margin: 0;
 
   // Sizing covers where we do not have a guaranteed height or width is tricky.
   // Lock in some sensible values at known breakpoints.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4764#note-33

#### Description

If there are no subjects then we have very little data to work with
when trying to retrieve relevant materials. Consequently the
suggested materials will not seem very relevant.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
