### PR TITLE
4762 mobilesearch null tags

### DIFF
--- a/modules/ding_mobilesearch/ding_mobilesearch.module
+++ b/modules/ding_mobilesearch/ding_mobilesearch.module
@@ -176,27 +176,29 @@ function ding_mobilesearch_ding_mobilesearch_node_export_mapping($node) {
           'value' => array(),
           'attr' => array(),
         );
-        foreach ($items as $item) {
-          if (preg_match_all('/(\[\[\{.*\}\]\])/', $item['value'], $matches, PREG_SET_ORDER)) {
-            if (!empty($matches[0])) {
-              foreach ($matches[0] as $key => $value) {
-                $json = drupal_json_decode($value);
-                if (is_array($json) && !empty($json[0][0]['fid'])) {
-                  $fid = $json[0][0]['fid'];
-                  $file = file_load($fid);
-                  if (is_object($file) && $file->type == 'image') {
-                    $base64 = base64_encode(file_get_contents($file->uri));
-                    $render = "<img src=\"data:{$file->filemime};base64,{$base64}\" alt=\"\" />";
-                    $item['value'] = str_replace($value, $render, $item['value']);
-                  }
-                  else {
-                    $item['value'] = str_replace($value, '', $item['value']);
+        if (!empty($items)) {
+          foreach ($items as $item) {
+            if (preg_match_all('/(\[\[\{.*\}\]\])/', $item['value'], $matches, PREG_SET_ORDER)) {
+              if (!empty($matches[0])) {
+                foreach ($matches[0] as $key => $value) {
+                  $json = drupal_json_decode($value);
+                  if (is_array($json) && !empty($json[0][0]['fid'])) {
+                    $fid = $json[0][0]['fid'];
+                    $file = file_load($fid);
+                    if (is_object($file) && $file->type == 'image') {
+                      $base64 = base64_encode(file_get_contents($file->uri));
+                      $render = "<img src=\"data:{$file->filemime};base64,{$base64}\" alt=\"\" />";
+                      $item['value'] = str_replace($value, $render, $item['value']);
+                    }
+                    else {
+                      $item['value'] = str_replace($value, '', $item['value']);
+                    }
                   }
                 }
               }
             }
+            $mapping['fields'][$machine_name]['value'][] = $item['value'];
           }
-          $mapping['fields'][$machine_name]['value'][] = $item['value'];
         }
         if (count($mapping['fields'][$machine_name]['value']) == 1) {
           $mapping['fields'][$machine_name]['value'] = reset($mapping['fields'][$machine_name]['value']);
@@ -287,15 +289,17 @@ function ding_mobilesearch_ding_mobilesearch_node_export_mapping($node) {
             'attr' => array(),
           );
 
-          foreach ($items as $item) {
-            $entity = entity_load_single($target, $item['target_id']);
-            if ($entity) {
-              if ($target == 'node') {
-                $value = $entity->title;
-              }
+          if (!empty($items)) {
+            foreach ($items as $item) {
+              $entity = entity_load_single($target, $item['target_id']);
+              if ($entity) {
+                if ($target == 'node') {
+                  $value = $entity->title;
+                }
 
-              if (!empty($value)) {
-                $mapping['fields'][$machine_name]['value'][] = $value;
+                if (!empty($value)) {
+                  $mapping['fields'][$machine_name]['value'][] = $value;
+                }
               }
             }
           }
@@ -310,8 +314,10 @@ function ding_mobilesearch_ding_mobilesearch_node_export_mapping($node) {
           'attr' => array(),
         );
 
-        foreach ($items as $item) {
-          $mapping['fields'][$machine_name]['value']['materials'] = $item;
+        if (!empty($items)) {
+          foreach ($items as $item) {
+            $mapping['fields'][$machine_name]['value']['materials'] = $item;
+          }
         }
 
         $relations = ting_reference_get_relations($field['entity_type'], $node);

--- a/modules/ding_mobilesearch/ding_mobilesearch.module
+++ b/modules/ding_mobilesearch/ding_mobilesearch.module
@@ -421,7 +421,9 @@ function ding_mobilesearch_ding_mobilesearch_node_export_mapping($node) {
         'attr' => array(),
       );
       foreach ($items as $item) {
-        $mapping['fields'][$tag_field]['value'][] = $item['name'];
+        if ($term = taxonomy_term_load($item['tid'])) {
+          $mapping['fields'][$tag_field]['value'][] = $term->name;
+        }
       }
     }
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4762

#### Description

Fix tags with NULL value in mobilesearch export.

When using `field_get_items()` it will only return the term ID. To get the name of the term we need to load the full term object with `taxonomy_term_load()`. See the changes here: https://github.com/ding2/ding2/pull/1665/commits/952f82cf45cd66ba279dd00efe58a48026f7a28b

Also fixes some potential `Invalid argument supplied for foreach` Warnings in the export code.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
