### PR TITLE
4193 headlines

### DIFF
--- a/modules/ding_frontend/ding_frontend.pages_default.inc
+++ b/modules/ding_frontend/ding_frontend.pages_default.inc
@@ -74,7 +74,7 @@ function ding_frontend_default_page_manager_handlers() {
     $pane->configuration = array(
       'links' => 1,
       'no_extras' => 0,
-      'override_title' => 0,
+      'override_title' => 1,
       'override_title_text' => '',
       'identifier' => '',
       'link' => 0,

--- a/modules/ding_library/ding_library.features.field_instance.inc
+++ b/modules/ding_library/ding_library.features.field_instance.inc
@@ -68,6 +68,12 @@ function ding_library_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'teaser_no_overlay' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
     ),
     'entity_type' => 'node',
     'field_name' => 'field_ding_library_addresse',
@@ -134,6 +140,12 @@ function ding_library_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'teaser_no_overlay' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
     ),
     'entity_type' => 'node',
     'field_name' => 'field_ding_library_body',
@@ -188,6 +200,12 @@ function ding_library_field_default_field_instances() {
         'weight' => 4,
       ),
       'teaser_highlight' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser_no_overlay' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -248,6 +266,12 @@ function ding_library_field_default_field_instances() {
         'weight' => 4,
       ),
       'teaser_highlight' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser_no_overlay' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -319,6 +343,12 @@ function ding_library_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'teaser_no_overlay' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
     ),
     'entity_type' => 'node',
     'field_name' => 'field_ding_library_lead',
@@ -373,6 +403,12 @@ function ding_library_field_default_field_instances() {
         'weight' => 6,
       ),
       'teaser_highlight' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser_no_overlay' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -453,6 +489,12 @@ function ding_library_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'teaser_no_overlay' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
     ),
     'entity_type' => 'node',
     'field_name' => 'field_ding_library_mail',
@@ -512,6 +554,12 @@ function ding_library_field_default_field_instances() {
         'type' => 'hidden',
         'weight' => 0,
       ),
+      'teaser_no_overlay' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
     ),
     'entity_type' => 'node',
     'field_name' => 'field_ding_library_phone_number',
@@ -565,6 +613,12 @@ function ding_library_field_default_field_instances() {
         'weight' => 5,
       ),
       'teaser_highlight' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser_no_overlay' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -637,6 +691,12 @@ function ding_library_field_default_field_instances() {
         'weight' => 3,
       ),
       'teaser_highlight' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser_no_overlay' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',
@@ -741,6 +801,12 @@ function ding_library_field_default_field_instances() {
         'weight' => 7,
       ),
       'teaser_highlight' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 0,
+      ),
+      'teaser_no_overlay' => array(
         'label' => 'above',
         'settings' => array(),
         'type' => 'hidden',

--- a/modules/ding_library/ding_library.pages_default.inc
+++ b/modules/ding_library/ding_library.pages_default.inc
@@ -225,13 +225,13 @@ function ding_library_default_page_manager_handlers() {
     $pane->access = array();
     $pane->configuration = array(
       'link' => 0,
-      'markup' => 'h2',
+      'markup' => 'h1',
       'id' => '',
       'class' => '',
       'context' => 'argument_entity_id:node_1',
       'override_title' => 1,
       'override_title_text' => '',
-      'override_title_heading' => 'h2',
+      'override_title_heading' => 'h1',
     );
     $pane->cache = array();
     $pane->style = array(

--- a/themes/ddbasic/sass/components/node/eresource.scss
+++ b/themes/ddbasic/sass/components/node/eresource.scss
@@ -178,11 +178,6 @@
         }
       }
     }
-    h1 {
-      @include font('display');
-      margin-bottom: 0;
-      color: $charcoal;
-    }
     .field-name-field-ding-eresource-access {
       padding: 10px 0;
       border-top: 1px solid $grey-medium;

--- a/themes/ddbasic/templates/node/node--webform.tpl.php
+++ b/themes/ddbasic/templates/node/node--webform.tpl.php
@@ -87,6 +87,7 @@
   hide($content['links']);
 ?>
 <div class="<?php print $classes; ?>">
+  <h1 class="page-title"><?php print $title; ?></h1>
   <div class="content"<?php print $content_attributes; ?>>
     <?php print render($content); ?>
   </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4193

#### Description

Fixes the main header on libraries, webforms and e-resources to be a H1 and properly styled.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/90508574-489f6a00-e158-11ea-90eb-8c05cbc76f84.png)
![image](https://user-images.githubusercontent.com/229422/90508594-5228d200-e158-11ea-9ca6-47ad52ffac70.png)
![image](https://user-images.githubusercontent.com/229422/90508625-5ce36700-e158-11ea-92d3-4557a1f8bd19.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
