### PR TITLE
1519: Fix ding_campagin_plus_search's query munging

### DIFF
--- a/modules/ding_campaign_plus/modules/ding_campaign_plus_search/ding_campaign_plus_search.module
+++ b/modules/ding_campaign_plus/modules/ding_campaign_plus_search/ding_campaign_plus_search.module
@@ -257,7 +257,7 @@ function _ding_campaign_plus_search_match(TingSearchRequest $searchRequest) {
       $query = $cqlDoctor->string_to_cql();
 
       $searchRequest = $searchRequest;
-      $searchRequest = $searchRequest->withFullTextQuery('"' . $query . '" AND (' . $rule->query . ')');
+      $searchRequest = $searchRequest->withFullTextQuery('(' . $query . ') AND (' . $rule->query . ')');
       $results = $searchRequest->execute();
       if (($results->getNumTotalObjects() / $originalResults->getNumTotalObjects()) * 100 >= $rule->percent) {
         $nids[] = $rule->nid;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1519

#### Description

Spurious query errors show up on sites. Turns out that ding_campagin_plus_search does a search where it takes the existing query and wraps it in double quotes before adding it's own extesnions. But this fails horribly when the query already
contains double quotes. Change to parenthesises.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
