### PR TITLE
1519 translatable errors

### DIFF
--- a/modules/ding_campaign_plus/modules/ding_campaign_plus_search/ding_campaign_plus_search.module
+++ b/modules/ding_campaign_plus/modules/ding_campaign_plus_search/ding_campaign_plus_search.module
@@ -257,7 +257,7 @@ function _ding_campaign_plus_search_match(TingSearchRequest $searchRequest) {
       $query = $cqlDoctor->string_to_cql();
 
       $searchRequest = $searchRequest;
-      $searchRequest = $searchRequest->withFullTextQuery('"' . $query . '" AND (' . $rule->query . ')');
+      $searchRequest = $searchRequest->withFullTextQuery('(' . $query . ') AND (' . $rule->query . ')');
       $results = $searchRequest->execute();
       if (($results->getNumTotalObjects() / $originalResults->getNumTotalObjects()) * 100 >= $rule->percent) {
         $nids[] = $rule->nid;

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -540,10 +540,19 @@ function opensearch_execute(TingClientRequest $request) {
     return $response;
   }
   catch (TingClientException $e) {
-    if (isset($e->user_message)) {
-      drupal_set_message($e->user_message, 'warning');
+    if ($e->getType() === TingClientException::TYPE_SYNTAX_ERROR) {
+      drupal_set_message(t('Syntax error in search query'), 'warning', FALSE);
     }
-    watchdog('ting client', 'Error performing request: ' . $e->getMessage(), NULL, WATCHDOG_ERROR, 'http://' . $_SERVER["HTTP_HOST"] . request_uri());
+    elseif ($e->getType() === TingClientException::TYPE_INTERNAL_ERROR) {
+      drupal_set_message(t('Internal server error, please try again later'), 'warning', FALSE);
+    }
+    watchdog(
+      'ting client',
+      'Error performing request: @message',
+      array('@message' => $e->getMessage()),
+      WATCHDOG_ERROR,
+      'http://' . $_SERVER["HTTP_HOST"] . request_uri()
+    );
     return FALSE;
   }
   finally {

--- a/modules/opensearch/opensearch.client.inc
+++ b/modules/opensearch/opensearch.client.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * Wrapper functions for Opensearch client.
@@ -145,7 +146,7 @@ function opensearch_get_objects(array $ids, $local = FALSE) {
  * @throws \TingClientException
  *   This may throw this exception if the search request fails.
  */
-function opensearch_do_search($query, $page = 1, $results_per_page = 10, $options = array()) {
+function opensearch_do_search($query, $page = 1, $results_per_page = 10, array $options = array()) {
   $request = opensearch_get_request_factory()->getSearchRequest();
 
   $request->setQuery($query);
@@ -408,14 +409,14 @@ function opensearch_execute(TingClientRequest $request) {
 
     // Build maps of singular requests for objects by id or local id.
     $object_ids = array_combine($object_ids, $object_ids);
-    $object_id_requests = array_map(function($id) use ($request) {
+    $object_id_requests = array_map(function ($id) use ($request) {
       $object_request = clone $request;
       $object_request->setObjectId($id);
       return $object_request;
     }, $object_ids);
 
     $local_ids = array_combine($local_ids, $local_ids);
-    $local_id_requests = array_map(function($id) use ($request) {
+    $local_id_requests = array_map(function ($id) use ($request) {
       $object_request = clone $request;
       $object_request->setLocalId($id);
       return $object_request;
@@ -661,10 +662,10 @@ function _opensearch_predict_cache(array $collections, TingClientRequest $reques
  *
  * @param TingClientRequest $request
  *   The search request for which to set/retrieve a cached response.
- * @param \TingClientSearchResult|\TingClientObjectCollection|\TingClientObject[]|NULL $response
+ * @param \TingClientSearchResult|\TingClientObjectCollection|\TingClientObject[]|null $response
  *   The response to cache. NULL to reset the cache entry for the request.
  *
- * @return \TingClientSearchResult|\TingClientObjectCollection|\TingClientObject[]|NULL
+ * @return \TingClientSearchResult|\TingClientObjectCollection|\TingClientObject[]|null
  *   The cached response. NULL if no cached entry exists.
  */
 function _opensearch_cache(TingClientRequest $request, $response = NULL) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1519

#### Description

Makes user visible errors from opensearch translatable. Goes together with https://github.com/ding2/ting-client/pull/33

Different errors are categorized by ting-client into syntax or internal errors depending on error message. This PR adds generic translatable error messages for these types. Also, it only shows each error message once.

And a bit of code style cleanup.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/90733733-44e12400-e2cd-11ea-9668-c87534d36b4f.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
