### PR TITLE
4800: Fix eresource tags styling

### DIFF
--- a/themes/ddbasic/sass/components/node/eresource.scss
+++ b/themes/ddbasic/sass/components/node/eresource.scss
@@ -204,5 +204,20 @@
         margin-right: 20px;
       }
     }
+    .field-name-field-ding-eresource-tags {
+      padding: 10px 0;
+      border-top: 1px solid $grey-medium;
+      border-bottom: 1px solid $grey-medium;
+      margin-bottom: 30px;
+
+      .field-items .field-item {
+        display: inline;
+        margin-right: 15px;
+      }
+      .field-label {
+        @include font('base-bold');
+      }
+
+    }
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4800

#### Description

Styles the tags on eresources.

#### Screenshot of the result

Before: 
![image](https://user-images.githubusercontent.com/229422/90776199-16c60900-e2fa-11ea-95cd-af3fb8901716.png)

After:
![image](https://user-images.githubusercontent.com/229422/90776139-057cfc80-e2fa-11ea-894b-4b524b0036f9.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
