### PR TITLE
4731 by Inlead: Nodelist improvements.

### DIFF
--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1824,7 +1824,7 @@ function ding_nodelist_preprocess(&$variables, $hook) {
 
       $links = array();
       foreach ($variables['links'] as $link) {
-        $links[] = l(t('@text', array('@text' => $link['text'])), $link['links']);
+        $links[] = l(t($link['text']), $link['links']);
       }
       $variables['links'] = $links;
       $variables['items'] = $items;

--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -957,7 +957,7 @@ function _ding_nodelist_get_templates($include_hidden = TRUE, $content_type = NU
   // Fetch templates declared by this and other modules hook_theme function.
   // @todo: menu_block is known to cause issues on this call in PHP 5.3.x.
   foreach (module_invoke_all('theme', array(), NULL, NULL, NULL) as $template_name => $template) {
-    if (strpos($template_name, 'ding_nodelist') === 0) {
+    if (strpos($template_name, 'ding_nodelist.') === 0) {
       $templates[$template_name] = array(
         'filename' => $template_name,
       );

--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1816,7 +1816,7 @@ function ding_nodelist_preprocess(&$variables, $hook) {
 
         $fee_field = field_get_items('node', $item, 'field_ding_event_price');
         $items[$key]->price = t('Free');
-        if (is_array($fee_field)) {
+        if (is_array($fee_field) && !empty($fee_field[0]['value'])) {
           $fee = current($fee_field);
           $items[$key]->price = $fee['value'] . ' ' . variable_get('ding_event_currency_type', 'Kr');
         }

--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1449,7 +1449,7 @@ function _ding_nodelist_get_event_date($date) {
 
   $now = new DateObject();
   $now = $now->getTimestamp();
-  if ($start <= $now && $now <= $end) {
+  if ($start->getTimestamp() <= $now && $now <= $end->getTimestamp()) {
     $result = $now;
   }
 

--- a/modules/ding_nodelist/js/node_blocks.js
+++ b/modules/ding_nodelist/js/node_blocks.js
@@ -55,6 +55,14 @@
         $(this).toggleClass('is-hovered', false);
         $(this).find('.field-type-text-long').toggleClass('element-hidden', true);
       });
+
+      $('.node-ding-news.nb-item', context).mouseenter(function() {
+        var title_and_lead_height;
+        // Set height for title and lead text.
+        title_and_lead_height = $(this).find('.title').outerHeight(true) + $(this).find('.field-name-field-ding-news-lead').outerHeight(true) + 50;
+
+        $(this).find('.title-and-lead').css('min-height', title_and_lead_height);
+      });
     }
   };
 })(jQuery);

--- a/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
+++ b/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
@@ -767,7 +767,7 @@ function _ding_nodelist_plugin_content_section(&$form, &$form_state, $node_type,
 
     // Set default field value.
     $first_field = array_shift(array_keys($allowed_fields));
-    $filter = $field_settings[$first_field];
+    $filter = isset($field_settings[$first_field]) ? $field_settings[$first_field] : [];
 
     $form['ding_nodelist_wrapper']['nodelist_content']['nodelist_content_wrapper']['ding_nodelist_dynamic']['taxonomy_filters'][$key]
       = _ding_nodelist_taxonomy_filter($allowed_fields, $filter, $key);

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -906,6 +906,12 @@ $label-bg: url('../images/p.png');
   width: 100%;
   overflow: visible;
 
+  .element-hidden {
+    opacity: 0;
+    display: block;
+    height: 0;
+  }
+
   .nb-item {
     margin: 0 2% 2% 0;
     height: 100%;
@@ -1169,7 +1175,7 @@ $label-bg: url('../images/p.png');
         @include transition(
                         min-height $speed $hover-delay $ease
         );
-        min-height: 118px;
+        min-height: 100px;
 
         @include media($mobile) {
           min-height: 100%;

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -144,6 +144,10 @@ $label-bg: url('../images/p.png');
   height: 391px;
   overflow: inherit;
 
+  .slick-slider .slick-list {
+    padding-bottom: 10px;
+  }
+
   .label-wrapper a,
   .field-name-field-ding-event-category {
     margin-left: 10px;

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -181,6 +181,13 @@ $label-bg: url('../images/p.png');
       .item-price {
         color: $white;
       }
+
+      .library,
+      .field-type-entityreference,
+      .library .field-items,
+      .library .field-item {
+        display: inline-block;
+      }
     }
 
     .item-date {
@@ -299,6 +306,11 @@ $label-bg: url('../images/p.png');
     position: absolute;
     top: 0;
     left: 0;
+    right: 0;
+    bottom: 0;
+    background-repeat: no-repeat;
+    background-size: cover;
+    background-position: center center;
     width: 100%;
     height: 100%;
 

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -1132,7 +1132,7 @@ $label-bg: url('../images/p.png');
       .date {
         display: block;
         @include transition(
-                        opacity $speed $hover-delay $ease
+          opacity $speed $hover-delay $ease
         )
       }
 
@@ -1142,14 +1142,14 @@ $label-bg: url('../images/p.png');
         position: relative;
         padding-bottom: 10px;
         @include transition(
-                        opacity $speed $hover-delay $ease
+          opacity $speed $hover-delay $ease
         )
       }
       .background {
         @include transition(
-                        width $speed $hover-delay $ease,
-                        background-color $speed $ease,
-                        box-shadow $speed $ease
+          width $speed $hover-delay $ease,
+          background-color $speed $ease,
+          box-shadow $speed $ease
         );
         width: 115%;
         background-color: $white;
@@ -1170,15 +1170,15 @@ $label-bg: url('../images/p.png');
 
       .button {
         @include transition(
-                        opacity $speed $hover-delay $ease,
-                        background-color $speed $ease,
-                        color $speed $ease
+          opacity $speed $hover-delay $ease,
+          background-color $speed $ease,
+          color $speed $ease
         );
         opacity: 1;
       }
       .title-and-lead {
         @include transition(
-                        min-height $speed $hover-delay $ease
+          min-height $speed $hover-delay $ease
         );
         min-height: 100px;
 
@@ -1189,7 +1189,7 @@ $label-bg: url('../images/p.png');
       }
       .field-name-field-ding-event-lead {
         @include transition(
-                        opacity $speed $hover-delay $ease
+          opacity $speed $hover-delay $ease
         );
         opacity: 1;
       }
@@ -1265,7 +1265,7 @@ $label-bg: url('../images/p.png');
         .field-name-field-ding-event-lead,
         .field-name-field-ding-page-lead {
           @include transition(
-                          opacity $speed $hover-delay $ease
+            opacity $speed $hover-delay $ease
           );
           opacity: 1;
           color: #fff;

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -1143,7 +1143,10 @@ $label-bg: url('../images/p.png');
         padding-bottom: 10px;
         @include transition(
           opacity $speed $hover-delay $ease
-        )
+        );
+        @include media($mobile) {
+          display: none;
+        }      
       }
       .background {
         @include transition(
@@ -1192,6 +1195,10 @@ $label-bg: url('../images/p.png');
           opacity $speed $hover-delay $ease
         );
         opacity: 1;
+
+        @include media($mobile) {
+          display: none;
+        }
       }
     }
 
@@ -1212,10 +1219,13 @@ $label-bg: url('../images/p.png');
   .ding_nodelist-items {
     display: inline-block;
     width: 100%;
+
     .nodelist-item {
       position: relative;
       @include span-columns(3.95 of 12);
-      margin: 0 10px 10px 10px;
+      margin: 0 5px 10px 5px;
+      padding: 0 10px 10px 0;
+
       :last-child {
         margin-right: -10px;
       }

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -910,6 +910,11 @@ $label-bg: url('../images/p.png');
     opacity: 0;
     display: block;
     height: 0;
+
+    .field-item {
+      height:0;
+      display:none;
+    }
   }
 
   .nb-item {

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.carousel.tpl.php
@@ -12,7 +12,7 @@ if (!empty($item->image)) {
   $image = '<div class="article_image" style="background-image:url(' . $item->image . ');"></div>';
 }
 ?>
-<div class="item">
+<div class="item"<?php print $attributes; ?>>
   <?php print $image; ?>
   <div class="article-info">
     <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
@@ -10,7 +10,7 @@
 
 ?>
 <article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>"
-         class="node node-ding-eresource node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>">
+         class="node node-ding-eresource node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>"<?php print $attributes; ?>>
   <a href="<?php print '/node/' . $item->nid; ?>">
     <div class="inner">
       <div class="background">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.carousel.tpl.php
@@ -12,7 +12,7 @@ if (!empty($item->image)) {
   $image = '<div class="event-image" style="background-image:url(' . $item->image . ');"></div>';
 }
 ?>
-<div class="item">
+<div class="item"<?php print $attributes; ?>>
   <?php print $image; ?>
   <div class="event-time">
     <div class="event-day"><?php print format_date($item->timestamp, 'custom', 'D', $item->timezone); ?></div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.node_blocks.tpl.php
@@ -7,7 +7,7 @@
 ?>
 
 <article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>"
-         class="node node-ding-event node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>">
+         class="node node-ding-event node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>"<?php print $attributes; ?>>
   <a href="<?php print '/node/' . $item->nid; ?>">
     <?php if (!empty($item->image)): ?>
       <div class="event-list-image nb-image" style="background-image:url(<?php print $item->image; ?>);"></div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_event.promoted_nodes.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_event.promoted_nodes.tpl.php
@@ -17,6 +17,7 @@ $classes = implode(" ", $classes);
   <?php if (!empty($item->image) && $position): ?>
     style="background-image: url(<?php print $item->image; ?>);"
   <?php endif; ?>
+  <?php print $attributes; ?>
 >
   <?php if (isset($item->video)): ?>
     <div class="media-container">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_news.carousel.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_news.carousel.tpl.php
@@ -12,7 +12,7 @@ if (!empty($item->image)) {
   $image = '<div class="article_image" style="background-image:url(' . $item->image . ');"></div>';
 }
 ?>
-<div class="item">
+<div class="item"<?php print $attributes; ?>>
   <?php print $image; ?>
   <div class="article-info">
     <div class="label-wrapper"><?php print drupal_render($item->category_link); ?></div>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_news.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_news.node_blocks.tpl.php
@@ -28,7 +28,7 @@ if (!empty($item->image)) {
           <h3 class="title"><?php print $item->title; ?></h3>
           <div class="date"><?php print $item->date; ?></div>
           <div
-                  class="field field-name-field-ding-news-lead field-type-text-long field-label-hidden">
+                  class="field field-name-field-ding-news-lead field-type-text-long field-label-hidden element-hidden">
             <div class="field-items">
               <div class="field-item">
                 <?php print $item->teaser_lead; ?>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_news.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_news.node_blocks.tpl.php
@@ -14,7 +14,7 @@ if (!empty($item->image)) {
 }
 ?>
 <article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>"
-         class="node node-ding-news node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>">
+         class="node node-ding-news node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>"<?php print $attributes; ?>>
   <a href="<?php print '/node/' . $item->nid; ?>">
     <div class="inner">
       <div class="background">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_page.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_page.node_blocks.tpl.php
@@ -15,7 +15,7 @@
       <div class="text page-text">
         <div class="title-and-lead">
           <h3 class="title"><?php print $item->title; ?></h3>
-          <div class="field-name-field-ding-page-lead">
+          <div class="field-name-field-ding-page-lead field-type-text-long element-hidden">
             <div class="field-items">
               <div class="field-item">
                 <?php print $item->teaser_lead; ?>

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_page.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_page.node_blocks.tpl.php
@@ -6,7 +6,7 @@
  */
 ?>
 
-<article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>" class="node node-ding-page node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>">
+<article data-row="<?php print $row; ?>" data-column="<?php print $column; ?>" class="node node-ding-page node-promoted nb-item <?php print $item->image ? 'has-image' : ''; ?>"<?php print $attributes; ?>>
   <a href="<?php print '/node/' . $item->nid; ?>">
     <div class="inner">
       <div class="background">

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_page.rolltab.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_page.rolltab.tpl.php
@@ -20,7 +20,7 @@ if (!empty($body) && substr($body, 0, 2) === '<p') {
 }
 
 ?>
-<div class="ding-tabroll">
+<div class="ding-tabroll"<?php print $attributes; ?>>
   <div class="ui-tabs-panel">
     <div class="image">
       <?php if (!$item->image): ?>

--- a/themes/ddbasic/scripts/ddbasic.common.js
+++ b/themes/ddbasic/scripts/ddbasic.common.js
@@ -105,21 +105,26 @@
   // Nodelist "Promoted Nodes".
   Drupal.behaviors.ding_nodelist_promoted_nodes = {
     attach: function (context, settings) {
-      // "Promoted nodes" items classes list.
-      var classes = ['first-left-block', 'first-right-block', 'last-left-block', 'last-right-block'];
-      classes.forEach(function (value) {
-        // Attach mouseover/click handler to every item wrapper.
-        var itemWrapper = $('.' + value);
-        itemWrapper.on('mouseover click', function (event) {
-          // Always display pointer cursor.
-          itemWrapper.css('cursor', 'pointer');
-          // If click event; use data-href value on current item wrapper as link
-          // to new page.
-          if (event.type === 'click') {
-            window.location.href = $(this).data('href');
-          }
+      var pnNodelistPanes = $('.pane-ding-nodelist .ding_nodelist', context);
+      if (pnNodelistPanes.length > 0) {
+        $(pnNodelistPanes).each(function (i, block) {
+          // "Promoted nodes" items classes list.
+          var classes = ['first-left-block', 'first-right-block', 'last-left-block', 'last-right-block'];
+          classes.forEach(function (value) {
+            // Attach mouseover/click handler to every item wrapper.
+            var itemWrapper = $('.' + value);
+            itemWrapper.on('mouseover click', function (event) {
+              // Always display pointer cursor.
+              itemWrapper.css('cursor', 'pointer');
+              // If click event; use data-href value on current item wrapper as link
+              // to new page.
+              if (event.type === 'click') {
+                window.location.href = $(this).data('href');
+              }
+            });
+          });
         });
-      });
+      }
     }
   };
 

--- a/themes/ddbasic/scripts/node/event.js
+++ b/themes/ddbasic/scripts/node/event.js
@@ -15,9 +15,11 @@
   // Call resize function when images are loaded.
   Drupal.behaviors.ding_event_teaser_loaded = {
     attach: function(context, settings) {
-      $('.view-ding-event .view-elements, .view-ding-related-content .view-content').imagesLoaded( function() {
-        $(window).triggerHandler('resize.ding_event_teaser');
-      });
+      if ($.isFunction($.fn.imagesLoaded)) {
+        $('.view-ding-event .view-elements, .view-ding-related-content .view-content').imagesLoaded( function() {
+          $(window).triggerHandler('resize.ding_event_teaser');
+        });
+      }
     }
   };
 

--- a/themes/ddbasic/scripts/node/news.js
+++ b/themes/ddbasic/scripts/node/news.js
@@ -16,29 +16,11 @@
   // Call resize function when images are loaded.
   Drupal.behaviors.ding_news_teaser_loaded = {
     attach: function(context, settings) {
-      $('.view-ding-news .view-elements').imagesLoaded( function() {
-        $(window).triggerHandler('resize.ding_news_teaser');
-      });
-    }
-  };
-    
-  /**
-   * Hover first item in view ding news with class "first-child-large"
-   */
-  Drupal.behaviors.hover_view_ding_news_first_child_large = {
-    attach: function(context, settings) {
-      var text_element_height;
-      $('.view-ding-news.first-child-large .views-row:first-child', context).mouseenter(function() {
-        if(!ddbasic.breakpoint.is('mobile')) {
-          text_element_height = $(this).find('.inner').outerHeight() - $(this).find('.news-text').outerHeight();
-          $(this).find('.field-name-field-ding-news-lead').height(text_element_height);
-        }
-      });
-      $('.view-ding-news.first-child-large .views-row:first-child', context).mouseleave(function() {
-        if(!ddbasic.breakpoint.is('mobile')) {
-          $(this).find('.field-name-field-ding-news-lead').height(0);
-        }
-      });
+      if ($.isFunction($.fn.imagesLoaded)) {
+        $('.view-ding-news .view-elements').imagesLoaded( function() {
+          $(window).triggerHandler('resize.ding_news_teaser');
+        });
+      }    
     }
   };
 

--- a/themes/ddbasic/scripts/view.js
+++ b/themes/ddbasic/scripts/view.js
@@ -225,9 +225,11 @@
   // Call resize when images are loaded.
   Drupal.behaviors.ding_event_grouping = {
     attach: function (context, settings) {
-      $('.view-ding-event.max-two-rows .view-elements .view-elements-inner', context).imagesLoaded(function () {
-        $(window).triggerHandler('resize.ding_event_grouping');
-      });
+      if (jQuery.isFunction($.fn.imagesLoaded)) {
+        $('.view-ding-event.max-two-rows .view-elements .view-elements-inner', context).imagesLoaded(function () {
+          $(window).triggerHandler('resize.ding_event_grouping');
+        });
+      }
     }
   };
 
@@ -267,10 +269,12 @@
 
   // Call masonry resize when images are loaded.
   Drupal.behaviors.ding_event_teaser_masonry = {
-    attach: function (context, settings) {
-      $('.js-masonry-view', context).imagesLoaded(function () {
-        handle_ding_event_masonry(true);
-      });
+    if (jQuery.isFunction($.fn.imagesLoaded)) {
+      attach: function (context, settings) {
+        $('.js-masonry-view', context).imagesLoaded(function () {
+          handle_ding_event_masonry(true);
+        });
+      }
     }
   };
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4731

#### Description

This issues adresses a lot of things:
- Prevent loading unrelated templates.
- Ensure variables are properly parsed.
- Display 0 price events as Free in Nodelist.
- Support i18n for 'More link' in Nodelist panes.
- Added dynamic height for news teaser.
- Use PHP 5.6 syntax for nodelist filter.
- Fix display of More link.
- Add fix style for image.
- Fix display on hover for teaser.
- Fixed hover on Nodeblock display.
- Fix wrong indention.
- Fix display grid image and nodeblock.
- Allow attributes to be set.
- Nodelist Promoted node looks to wrong wrapper.
- Consider not used functions.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
