### PR TITLE
4116: Remove padding from "on the site"

### DIFF
--- a/themes/ddbasic/sass/components/field.scss
+++ b/themes/ddbasic/sass/components/field.scss
@@ -287,6 +287,7 @@ div.search-field-in-content--message {
   .search-results {
     ul {
       margin: 0;
+      padding: 0;
       li.search-result {
         width: 100%;
         float: left;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4116#change-49550

#### Description

Add `padding: 0` to the `ul` element. The default styling adds some padding for the bullets we don't use.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.
![image](https://user-images.githubusercontent.com/229422/91271659-d2fc5500-e77a-11ea-8530-29c0a89e5e37.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
