### PR TITLE
4896: Remove JS hover class

### DIFF
--- a/modules/ding_nodelist/css/ding_nodelist.css
+++ b/modules/ding_nodelist/css/ding_nodelist.css
@@ -1355,7 +1355,7 @@
   transition: opacity 300ms 400ms cubic-bezier(0.165, 0.84, 0.44, 1);
   opacity: 1;
 }
-.ding_nodelist-node_blocks .nb-item.is-hovered {
+.ding_nodelist-node_blocks .nb-item:hover {
   z-index: 2;
 }
 .ding_nodelist-node_blocks .more-links {

--- a/modules/ding_nodelist/js/node_blocks.js
+++ b/modules/ding_nodelist/js/node_blocks.js
@@ -22,7 +22,7 @@
           // Adjust height of all elements in row.
           for (i = 0; i < $row.length; i++) {
             var article = $row[i],
-            row = $(article).find('.inner').outerHeight();
+                row = $(article).find('.inner').outerHeight();
             if (height - row !== 0) {
               var padding = $(article).find('.text').css('padding-top');
               $(article).find('.text').css('padding-top', parseInt(padding) + height - row);
@@ -46,13 +46,11 @@
         // Set timeout to make sure element is still above while it animates
         // out.
         hovered = $(this);
-        hovered.toggleClass('is-hovered', true);
         hovered.find('.field-type-text-long').toggleClass('element-hidden', false);
       });
 
       $pane.find('article').mouseleave(function() {
         $(this).find('.title-and-lead').css('min-height', '');
-        $(this).toggleClass('is-hovered', false);
         $(this).find('.field-type-text-long').toggleClass('element-hidden', true);
       });
     }

--- a/modules/ding_nodelist/sass/ding_nodelist.scss
+++ b/modules/ding_nodelist/sass/ding_nodelist.scss
@@ -1168,7 +1168,7 @@ $label-bg: url('../images/p.png');
       }
     }
 
-    &.is-hovered {
+    &:hover {
       z-index: 2;
     }
   }

--- a/themes/ddbasic/sass/components/node/event.scss
+++ b/themes/ddbasic/sass/components/node/event.scss
@@ -16,9 +16,6 @@
     position: relative;
     float: left;
     width: 100%;
-    &.is-hovered {
-      z-index: 2;
-    }
     a {
       position: absolute;
       width: 100%;
@@ -157,8 +154,8 @@
     }
     // Hover for non touch devices
     .no-touch & {
-      &.is-hovered,
       &:hover {
+        z-index: 2;
         .background {
           @include transition(
             width $speed $hover-delay $ease,

--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -86,9 +86,6 @@
           }
         }
       }
-      &.is-hovered {
-        z-index: 2;
-      }
       &.move-right {
         .group-text {
           left: 100%;
@@ -167,6 +164,7 @@
       // Hover for non touch devices
       &:hover {
         .no-touch & {
+          z-index: 2;
           .ting-cover::after {
             @include transition(opacity $speed $hover-delay $ease);
             opacity: 0;

--- a/themes/ddbasic/scripts/node/event.js
+++ b/themes/ddbasic/scripts/node/event.js
@@ -58,14 +58,6 @@
       // Set height for title and lead text.
       var title_and_lead_height = $(teaser).find('.title').outerHeight(true) + $(teaser).find('.field-name-field-ding-event-lead .field-items').outerHeight(true) + 20;
       $(teaser).find('.title-and-lead').css('min-height', title_and_lead_height);
-
-      // Set timeout to make shure element is still above while it animates
-      // out.
-      var hovered = $(teaser);
-      setTimeout(function(){
-        $('.node-ding-event.node-teaser').removeClass('is-hovered');
-        hovered.addClass('is-hovered');
-      }, 300);
     },
 
     deactivateTeaser: function(teaser) {

--- a/themes/ddbasic/scripts/node/news.js
+++ b/themes/ddbasic/scripts/node/news.js
@@ -6,7 +6,7 @@
     // Set height for news teasers.
     $(window).bind('resize.ding_news_teaser', function (evt) {
       var ding_news_teaser_height = 0;
-  
+
       $('.node-ding-news.node-teaser').each(function (delta, view) {
         ding_news_teaser_height = $(this).find('.inner').outerHeight();
         $(this).height(ding_news_teaser_height);
@@ -21,7 +21,7 @@
       });
     }
   };
-    
+
   /**
    * Hover first item in view ding news with class "first-child-large"
    */
@@ -52,17 +52,9 @@
         title_and_lead_height = $(this).find('.title').outerHeight(true) + $(this).find('.field-name-field-ding-news-lead').outerHeight(true) + 50;
 
         $(this).find('.title-and-lead').css('min-height', title_and_lead_height);
-
-        // Set timeout to make shure element is still above while it animates
-        // out.
-        hovered = $(this);
-        setTimeout(function(){
-          $('.node-ding-news.node-teaser').removeClass('is-hovered');
-          hovered.addClass('is-hovered');
-        }, 300);
       });
       $('.node-ding-news.node-teaser').mouseleave(function() {
-         $(this).find('.title-and-lead').css('min-height', '');
+        $(this).find('.title-and-lead').css('min-height', '');
       });
     }
   };

--- a/themes/ddbasic/scripts/ting-object/ting-object.js
+++ b/themes/ddbasic/scripts/ting-object/ting-object.js
@@ -30,12 +30,6 @@
       } else {
         hovered.addClass('move-left');
       }
-
-      // Set timeout to make shure element is still above while it animates out.
-      setTimeout(function(){
-        $('.ting-object > .is-hovered').removeClass('is-hovered');
-        hovered.addClass('is-hovered');
-      }, 300);
     });
     element_to_hover.mouseleave(function() {
       $(this).removeClass('move-left');


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4896

#### Description

The combination of CSS hover effects and JS driven hover effects
causes odd behaviour.

Remove the JS hover effect, the CSS one is just fine.

#### Screenshot of the result

![new-event-overlay-2020-08-26](https://user-images.githubusercontent.com/229422/91274718-6a63a700-e77f-11ea-9573-fd26b86183ce.gif)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

