### PR TITLE
4866: Add css to hide coverupload button on carousel

### DIFF
--- a/modules/ddb_cover_upload/css/ddb_cover_upload.css
+++ b/modules/ddb_cover_upload/css/ddb_cover_upload.css
@@ -1,0 +1,4 @@
+/* Hide upload cover butten on carousel items */
+.ding-carousel-item .cover-upload-button {
+  display: none;
+}

--- a/modules/ddb_cover_upload/ddb_cover_upload.module
+++ b/modules/ddb_cover_upload/ddb_cover_upload.module
@@ -15,6 +15,14 @@ define('DDB_COVER_UPLOAD_FILE_PATH', 'ddb_cover_upload_uploaded');
 use CoverServiceUpload\Configuration;
 use GuzzleHttp\Client;
 
+
+/**
+ * Implements hook_init().
+ */
+function ddb_cover_upload_init() {
+  drupal_add_css(drupal_get_path('module', 'ddb_cover_upload') . '/css/ddb_cover_upload.css');
+}
+
 /**
  * Implements hook_menu().
  */
@@ -259,7 +267,7 @@ function ddb_cover_upload_ding_entity_buttons($type, $entity, $view_mode, $widge
           ),
           'attributes' => array(
             'class' => array(
-              'action-button',
+              'action-button cover-upload-button',
             ),
             'data-local-id' => $entity->localId,
           ),


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4866

#### Description

Remove button on frontpage carousel

#### Screenshot of the result

![Screenshot 2020-08-26 at 14 53 22](https://user-images.githubusercontent.com/332915/91307420-3489e700-e7ae-11ea-96a9-43873936dba5.png)

#### Checklist

- [X] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [X] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [X] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions


