### PR TITLE
4638: Fix single material overlay

### DIFF
--- a/themes/ddbasic/sass/components/node/paragraphs.scss
+++ b/themes/ddbasic/sass/components/node/paragraphs.scss
@@ -158,6 +158,18 @@
   }
 }
 
+// Make single material overlay go a bit less to the left so it
+// doesn't leave the viewport.
+.no-touch .field-name-field-ding-paragraphs-single-mat {
+  .ting-object {
+    .inner.move-left:hover {
+      .group-text {
+        left: -100%;
+      }
+    }
+  }
+}
+
 // Override existing css from different files.
 .node-ding-page .field-name-field-ding-page-body > .paragraphs-text p:last-child {
   margin-bottom: 30px;

--- a/themes/ddbasic/scripts/ting-object/ting-object.js
+++ b/themes/ddbasic/scripts/ting-object/ting-object.js
@@ -25,7 +25,7 @@
           position_of_hovered = hovered.offset();
 
       // If hovered element is left of window center.
-      if(position_of_hovered.left < (window_width / 2)) {
+      if((position_of_hovered.left + (hovered.width() / 2)) < (window_width / 2)) {
         hovered.addClass('move-right');
       } else {
         hovered.addClass('move-left');


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4638

#### Description

Make it move to the left, and not quite so much, so it should stay in
the viewport.

#### Screenshot of the result

![single-overlay](https://user-images.githubusercontent.com/229422/91403237-96476100-e841-11ea-91cd-47269990fc94.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
