### PR TITLE
4638: Limit width of single material

### DIFF
--- a/themes/ddbasic/sass/components/node/paragraphs.scss
+++ b/themes/ddbasic/sass/components/node/paragraphs.scss
@@ -158,6 +158,10 @@
   }
 }
 
+.field-name-field-ding-paragraphs-single-mat .ting-object {
+  max-width: 50%;
+}
+
 // Override existing css from different files.
 .node-ding-page .field-name-field-ding-page-body > .paragraphs-text p:last-child {
   margin-bottom: 30px;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4638

#### Description

To ensure that the overlay stays in viewport.

#### Screenshot of the result

![single-overlay2](https://user-images.githubusercontent.com/229422/91407803-14583780-e843-11ea-87fd-e1a468a4472c.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
