### PR TITLE
4913 fix notices

### DIFF
--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1684,8 +1684,12 @@ function _ding_nodelist_striptags($nodes) {
   foreach ($nodes as $n => $node) {
     if (!is_array($node)) {
       $body_field = 'field_' . $node->type . '_body';
-      foreach ($node->{$body_field} as $lng => $body) {
-        $nodes[$n]->{$body_field}[$lng][0]['value'] = strip_tags($body[0]['value']);
+
+      // Not all node types has a body field, so check first.
+      if (isset($node->{$body_field})) {
+        foreach ($node->{$body_field} as $lng => $body) {
+          $nodes[$n]->{$body_field}[$lng][0]['value'] = strip_tags($body[0]['value']);
+        }
       }
     }
     else {

--- a/modules/ding_nodelist/ding_nodelist.module
+++ b/modules/ding_nodelist/ding_nodelist.module
@@ -1449,7 +1449,7 @@ function _ding_nodelist_get_event_date($date) {
 
   $now = new DateObject();
   $now = $now->getTimestamp();
-  if ($start <= $now && $now <= $end) {
+  if ($start->getTimestamp() <= $now && $now <= $end->getTimestamp()) {
     $result = $now;
   }
 

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -32,6 +32,7 @@ function ding_webtrekk_menu() {
  * Implements hook_page_alter().
  */
 function ding_webtrekk_page_alter(&$page) {
+  global $user;
   $domain = variable_get('webtrekk_ti_domain', '');
   $id = variable_get('webtrekk_ti_id', '');
 
@@ -87,7 +88,7 @@ function ding_webtrekk_page_alter(&$page) {
     }
     // Fallback to cpr+pin if none the modules we know about was used to log in.
     else {
-      if (ding_user_is_provider_user()) {
+      if (ding_user_is_provider_user($user)) {
         $params['p_isloggedin'] = 'cpr+pinkode';
       }
       else {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4913

#### Description

Fix sloppy code, comparing DateObject to timestap, and missing parameters to `ding_user_is_provider_user()`, which all causes notices.
#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
