### PR TITLE
4638: Fix single material overlay

### DIFF
--- a/modules/ding_paragraphs/ding_paragraphs.features.field_instance.inc
+++ b/modules/ding_paragraphs/ding_paragraphs.features.field_instance.inc
@@ -481,7 +481,7 @@ The recommended minimum width of this image is 900px to ensure images are not up
     'description' => '',
     'display' => array(
       'default' => array(
-        'label' => 'above',
+        'label' => 'hidden',
         'module' => 'ting_reference',
         'settings' => array(
           'view_mode' => 'teaser',

--- a/themes/ddbasic/sass/components/node/paragraphs.scss
+++ b/themes/ddbasic/sass/components/node/paragraphs.scss
@@ -158,6 +158,32 @@
   }
 }
 
+// Make single material overlay go a bit less to the left so it
+// doesn't leave the viewport.
+.no-touch .paragraphs-block--full-width {
+  .ting-object {
+    .inner.move-left:hover {
+      .group-text {
+        width: 100%;
+        left: -100%;
+      }
+    }
+  }
+}
+
+// Hide the abstract on half width materials, there's really no room
+// for it.
+.no-touch .paragraphs-block--half-left,
+.no-touch .paragraphs-block--half-right {
+  .ting-object {
+    .inner.move-left:hover {
+      .field-type-ting-abstract {
+        display: none;
+      }
+    }
+  }
+}
+
 // Override existing css from different files.
 .node-ding-page .field-name-field-ding-page-body > .paragraphs-text p:last-child {
   margin-bottom: 30px;

--- a/themes/ddbasic/scripts/ting-object/ting-object.js
+++ b/themes/ddbasic/scripts/ting-object/ting-object.js
@@ -25,7 +25,7 @@
           position_of_hovered = hovered.offset();
 
       // If hovered element is left of window center.
-      if(position_of_hovered.left < (window_width / 2)) {
+      if((position_of_hovered.left + (hovered.width() / 2)) < (window_width / 2)) {
         hovered.addClass('move-right');
       } else {
         hovered.addClass('move-left');


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4638

#### Description

Make the material overlay for full width materials move to the left, and not quite so much, so it should stay in
the viewport.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/91553182-4645c880-e92d-11ea-9dfa-96a9b63d9ed3.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
