### PR TITLE
4493: Make search help translatable

### DIFF
--- a/modules/ding_ting_frontend/ding_ting_frontend.pages_default.inc
+++ b/modules/ding_ting_frontend/ding_ting_frontend.pages_default.inc
@@ -457,7 +457,6 @@ search/ting
     $pane->uuid = 'e8e6c75b-7dcd-4314-808b-b4a5cd00f3c3';
     $display->content['new-e8e6c75b-7dcd-4314-808b-b4a5cd00f3c3'] = $pane;
     $display->panels['main_content'][4] = 'new-e8e6c75b-7dcd-4314-808b-b4a5cd00f3c3';
-       
     $pane = new stdClass();
     $pane->pid = 'new-7c02f708-c47f-4eb5-8958-d6279de6ade4';
     $pane->panel = 'main_content';
@@ -486,24 +485,22 @@ search/ting
     );
     $pane->css = array();
     $pane->extras = array();
-    $pane->position = 6;
+    $pane->position = 5;
     $pane->locks = '';
     $pane->uuid = '7c02f708-c47f-4eb5-8958-d6279de6ade4';
     $display->content['new-7c02f708-c47f-4eb5-8958-d6279de6ade4'] = $pane;
-    $display->panels['main_content'][6] = 'new-7c02f708-c47f-4eb5-8958-d6279de6ade4';
+    $display->panels['main_content'][5] = 'new-7c02f708-c47f-4eb5-8958-d6279de6ade4';
     $pane = new stdClass();
-    $pane->pid = 'new-d97b9f79-61c3-4f2d-ab06-cad4e3fec910';
+    $pane->pid = 'new-793c5d13-8d76-4299-aed9-fad18bf7d920';
     $pane->panel = 'main_content';
-    $pane->type = 'custom';
-    $pane->subtype = 'custom';
+    $pane->type = 'search_help';
+    $pane->subtype = 'search_help';
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'admin_title' => 'Fandt du',
-      'title' => 'Fandt du ikke hvad du søgte?',
-      'body' => '<p>Spørg os på biblioteket eller få hjælp på <a href="http://biblioteksvagten.dk/" target="_blank">biblioteksvagten.dk</a><br>Du kan også søge videre på <a href="https://bibliotek.dk" target="_blank">bibliotek.dk</a></p>',
-      'format' => 'ding_wysiwyg',
-      'substitute' => 1,
+      'override_title' => 0,
+      'override_title_text' => '',
+      'override_title_heading' => 'h2',
     );
     $pane->cache = array();
     $pane->style = array(
@@ -516,9 +513,9 @@ search/ting
     $pane->extras = array();
     $pane->position = 6;
     $pane->locks = array();
-    $pane->uuid = 'd97b9f79-61c3-4f2d-ab06-cad4e3fec910';
-    $display->content['new-d97b9f79-61c3-4f2d-ab06-cad4e3fec910'] = $pane;
-    $display->panels['main_content'][7] = 'new-d97b9f79-61c3-4f2d-ab06-cad4e3fec910';  
+    $pane->uuid = '793c5d13-8d76-4299-aed9-fad18bf7d920';
+    $display->content['new-793c5d13-8d76-4299-aed9-fad18bf7d920'] = $pane;
+    $display->panels['main_content'][6] = 'new-793c5d13-8d76-4299-aed9-fad18bf7d920';
   $display->hide_title = PANELS_TITLE_NONE;
   $display->title_pane = '0';
   $handler->conf['display'] = $display;

--- a/modules/ting_search/plugins/content_types/search_help.inc
+++ b/modules/ting_search/plugins/content_types/search_help.inc
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @file
+ * The search help pane.
+ */
+
+$plugin = array(
+  'title' => t('Ting search - search help'),
+  'description' => t("Show help for searching."),
+  'single' => TRUE,
+  'content_types' => array('search_help'),
+  'category' => t('Ting'),
+);
+
+/**
+ * Render the ting search results amount block.
+ */
+function ting_search_search_help_content_type_render($subtype, $conf, $panel_args, $context) {
+  $block = new stdClass();
+
+  $block->title = t('Found what you where looking for?');
+  $block->content = t('Ask us at the library or get help at <a href="http://biblioteksvagten.dk">biblioteksvagten.dk</a><br />
+Or you can keep looking at <a href="https://bibliotek.dk">bibliotek.dk</a>');
+
+  return $block;
+}
+
+/**
+ * Enable admin settings page.
+ */
+function ting_search_search_help_content_type_edit_form($form, &$form_state) {
+  return $form;
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4493

#### Description

Replaces custom content with a content type that translates strings.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.
![image](https://user-images.githubusercontent.com/229422/91561331-b3f8f100-e93b-11ea-9a4f-64ca557dbdbe.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
