### PR TITLE
4854: Clean up opening hours for deleted nodes

### DIFF
--- a/project.make
+++ b/project.make
@@ -317,6 +317,9 @@ projects[opening_hours][patch][] = "https://www.drupal.org/files/issues/opening_
 ; Add "hide if empty" option to field settings.
 ; https://www.drupal.org/node/2820005
 projects[opening_hours][patch][] = "https://www.drupal.org/files/issues/opening-hours-2820005-hide-field-if-empty.patch"
+; Delete opening hours when node is deleted.
+; https://www.drupal.org/project/opening_hours/issues/3007293
+projects[opening_hours][patch][] = "https://www.drupal.org/files/issues/2018-10-17/3007293-2.patch"
 
 projects[override_node_options][subdir] = "contrib"
 projects[override_node_options][version] = "1.13"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4854

#### Description

Add patch to make opening_hours clean up opening hours when nodes are deleted. Has an update hook that cleans out orphaned opening hours.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
