### PR TITLE
4936: Prevent auto fill on password confirm elements

### DIFF
--- a/modules/ding_user/plugins/content_types/profile2/profile2_form.inc
+++ b/modules/ding_user/plugins/content_types/profile2/profile2_form.inc
@@ -53,6 +53,16 @@ function ding_user_profile2_form_content_type_render($subtype, $conf, $panel_arg
       $form = entity_ui_get_form('profile2', $profile);
     }
 
+    // Attempt to prevent browser from auto filling the password update fields
+    // as this can cause unecesarry issues with form validation. This should be
+    // the standard way of doing it, but some browsers may still ignore it. We
+    // add it here since attributes are not passed along from password_confirm
+    // element to the password fields.
+    // See: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion
+    // See: https://stackoverflow.com/questions/2530/how-do-you-disable-browser-autocomplete-on-web-form-field-input-tag
+    $form['pass']['pincode']['pass1']['#attributes']['autocomplete'] = 'new-password';
+    $form['pass']['pincode']['pass2']['#attributes']['autocomplete'] = 'new-password';
+
     // Set block delta and title.
     $block->title = $profile_type->profile_type->label;
     $block->delta = $form['#form_id'];


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4936

#### Description

Attempt to prevent browser from auto filling the password update fields  as this can cause unnecessary issues with form validation, which might confuse users.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
