### PR TITLE
4926: DO NOT MERGE Update CSS to see if changes apply on Platform.sh

### DIFF
--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -109,6 +109,7 @@ body > .ding2-site-template {
   text-align: left;
   a {
     @include button(arrow-right);
+    background-color: green;
     &::after {
       color: $charcoal-opacity-dark;
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4926

#### Description

Currently CSS changes do not seem to apply on Platform.sh environments. I have updated the configuration. The purpose of this PR is to verify that the system now works as expected.

If so then more link buttons should be shown with a green background on the Platform.sh environment for this PR.

#### Screenshots of the result

![DDB CMS | 2020-09-22 05-25-42](https://user-images.githubusercontent.com/73966/93841519-238ca280-fc94-11ea-841e-f8f711c9d742.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.