### PR TITLE
4813: Added image preprocess function

### DIFF
--- a/themes/ddbasic/template.node.php
+++ b/themes/ddbasic/template.node.php
@@ -471,3 +471,12 @@ function ddbasic_preprocess__node__ding_page(&$variables) {
       break;
   }
 }
+
+/**
+ * Implements hook_preprocess_image().
+ */
+function ddbasic_preprocess_image(&$vars) {
+  if (empty($vars['attributes']['alt'])) {
+    $vars['attributes']['alt'] = "";
+  }
+}


### PR DESCRIPTION
#### Link to issue
https://platform.dandigbib.org/issues/4813
https://platform.dandigbib.org/issues/4792
https://platform.dandigbib.org/issues/3047

#### Description
Adds preprocess image function that checks for alt attribute and sets an empty one if none exists. All images go through this function before being rendered so we cover all instances of missing alt image with 5 lines of code.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
