### PR TITLE
4917: Update cookie popup agree and disagree buttons text

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -1048,8 +1048,14 @@ function ding2_update_7090() {
  */
 function ding2_update_7091() {
   $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
+
   // Ensure that this is disabled as it will prevent changing the default text
   // of the popup_agree_button_message on ECC settings form.
   $ecc_settings['enable_save_preferences_button'] = FALSE;
+
+  // Change default text on popup agree and disagree buttons.
+  $ecc_settings['popup_agree_button_message'] = 'Acceptér alle';
+  $ecc_settings['disagree_button_label'] = 'Kun nødvendige';
+
   i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
 }

--- a/ding2.install
+++ b/ding2.install
@@ -1042,3 +1042,14 @@ function ding2_update_7089() {
 function ding2_update_7090() {
   ding2_set_eu_cookie_compliance_settings();
 }
+
+/**
+ * Update cookie compliance settings.
+ */
+function ding2_update_7091() {
+  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
+  // Ensure that this is disabled as it will prevent changing the default text
+  // of the popup_agree_button_message on ECC settings form.
+  $ecc_settings['enable_save_preferences_button'] = FALSE;
+  i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
+}

--- a/ding2.profile
+++ b/ding2.profile
@@ -847,10 +847,10 @@ function ding2_set_eu_cookie_compliance_settings() {
     // Ensure that this is disabled as it will prevent changing the default text
     // of the popup_agree_button_message on ECC settings form.
     'enable_save_preferences_button' => FALSE,
-    'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',
+    'popup_agree_button_message' => 'Acceptér alle',
     'popup_agreed_enabled' => FALSE,
     'popup_disagree_button_message' => 'Mere info',
-    'disagree_button_label' => 'Afvis',
+    'disagree_button_label' => 'Kun nødvendige',
     'withdraw_enabled' => TRUE,
     'withdraw_message' => [
       'value' => '<h2>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse</h2><p>Du har givet os samtykke. Tryk her for at tilbagekalde.</p>',

--- a/ding2.profile
+++ b/ding2.profile
@@ -832,7 +832,7 @@ function ding2_set_eu_cookie_compliance_settings() {
 
   $eu_cookie_compliance = array_merge($eu_cookie_compliance, [
     'method' => 'opt_in',
-    'show_disagree_button' => 1,
+    'show_disagree_button' => TRUE,
     'popup_enabled' => TRUE,
     'popup_info' => [
       'value' => '<h2>Hjælp os med at forbedre oplevelsen på hjemmesiden ved at acceptere cookies.</h2>',
@@ -844,11 +844,14 @@ function ding2_set_eu_cookie_compliance_settings() {
       'value' => '',
       'format' => 'ding_wysiwyg',
     ),
+    // Ensure that this is disabled as it will prevent changing the default text
+    // of the popup_agree_button_message on ECC settings form.
+    'enable_save_preferences_button' => FALSE,
     'popup_agree_button_message' => 'Jeg accepterer brugen af cookies',
     'popup_agreed_enabled' => FALSE,
     'popup_disagree_button_message' => 'Mere info',
     'disagree_button_label' => 'Afvis',
-    'withdraw_enabled' => 1,
+    'withdraw_enabled' => TRUE,
     'withdraw_message' => [
       'value' => '<h2>Vi bruger cookies på hjemmesiden for at forbedre din oplevelse</h2><p>Du har givet os samtykke. Tryk her for at tilbagekalde.</p>',
       'format' => 'ding_wysiwyg',


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4917

#### Description

- Ensure popup agree button message can be changed.
- Update default text on popup agree and disagree buttons.

#### Screenshot of the result

![4917-popup-agree-button-label-visbible](https://user-images.githubusercontent.com/5011234/95999392-24999580-0e36-11eb-990f-a97087b4b773.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
