### PR TITLE
4975: Wait up to 5 seconds when checking for object covers.

### DIFF
--- a/tests/behat/features/bootstrap/Page/ObjectPage.php
+++ b/tests/behat/features/bootstrap/Page/ObjectPage.php
@@ -104,7 +104,9 @@ class ObjectPage extends PageBase
      */
     public function hasCoverPage()
     {
-        $coverimg = $this->find('xpath', '//div[contains(@class,"ting-cover")]/img');
+        $coverimg = $this->waitFor(5, function ($element) {
+          return $element->find('css', '.ting-cover img');
+        });
         $txt_cover = "";
         if ($coverimg) {
             $txt_cover = $coverimg->getAttribute('src');


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4975

#### Description

We see multiple failures where a cover cannot be found even though
the subsequent screenshot shows the cover as expected. However Covers
may be loaded asynchronously and may not yet be ready when the test
is conducted.

Consequently we wait a bit. This is the same approach taken on the
search page.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Note that even if this test passed there is no guarantee that it actually fixes the issue. Not all tests are affected by the problem.