### PR TITLE
Switch to no cookie tracking

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -38,10 +38,22 @@
     }
   };
 
+  // Enables tracking without cookies. This method uses IP + user agent
+  // fingerprinting instead to keep sessions together. Cross session analysis
+  // will no longer be possible.
+  // TODO: Insert link to documentation when available. As of writing this is
+  // very new stuff.
+  var noCookieTracking = function noCookieTracking() {
+    if (typeof wts !== 'undefined') {
+      wts.push(['setIdentifierOptOut']);
+    }
+  }
+
   // Other modules dealing with client side webtrekk tracking might find these
   // functions useful, so make them available on the global Drupal object.
   Drupal.dingWebtrekkAppendQueryParameter = appendQueryParameter;
   Drupal.dingWebtrekkPushEvent = pushEvent;
+  Drupal.dingWebtrekkNoCookieTracking= noCookieTracking;
 
   Drupal.behaviors.ding_webtrekk = {
     attach: function(context) {
@@ -168,41 +180,15 @@
   };
 
   // EU cookie compliance integration.
-  // Set Webtrekk opt-out cookie. EU cookie compliance module will try to purge
-  // all cookies 5 seconds after refresh, but setting this cookie will
-  // completely prevent Webtrekk from settings any tracking cookie at all,
-  // which is better.
-  var setOptOutCookie = function setOptOutCookie() {
-    var path = Drupal.settings.basePath;
-    var date = new Date();
-    date.setDate(date.getDate() + parseInt(Drupal.settings.eu_cookie_compliance.cookie_lifetime));
-    $.cookie('webtrekkOptOut', 1, { expires: date, path: path });
-  }
-
-  // When using opt-in model ensure that the opt-out cookie is added as default
-  // if user hasn't agreed.
-  if (typeof Drupal.eu_cookie_compliance !== 'undefined' && Drupal.settings.eu_cookie_compliance.method === 'opt_in') {
-    if (!Drupal.eu_cookie_compliance.hasAgreed() && typeof $.cookie('webtrekkOptOut') === 'undefined') {
-      setOptOutCookie();
+  if (typeof Drupal.eu_cookie_compliance !== 'undefined') {
+    var method = Drupal.settings.eu_cookie_compliance.method;
+    // When using opt-in enable no-cookie tracking if user hasn't agreed.
+    // When using opt-out enable no-cookie tracking if user has disagreed. Since
+    // there's no method for that, we check for the value explicitly.
+    if ((method === 'opt_in' && !Drupal.eu_cookie_compliance.hasAgreed())
+        || (method === 'opt_out' && Drupal.eu_cookie_compliance.getCurrentStatus() === 0)) {
+      noCookieTracking();
     }
   }
-
-  // When user rejects/accepts cookies in the pop-up banner this event will be
-  // fired and we act accordingly.
-  $(document).on('eu_cookie_compliance.changeStatus', function(event, status) {
-    // If user has agreed we ensure that webtrekkOptOut is removed.
-    if (Drupal.eu_cookie_compliance.hasAgreed()) {
-      $.removeCookie('webtrekkOptOut');
-    }
-    else {
-      setOptOutCookie();
-      // Track the opt-out events in Webtrekk.
-      var eventData = {
-        linkId: 'event_optout',
-        customClickParameter: {}
-      };
-      pushEvent('click', eventData);
-    }
-  });
 
 })(jQuery);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4912

#### Description

Uses no cookie tracking with Mapp if:

1.  Opt-in model and user hasn't agreed.
2. Opt-out model and user hasn't disagreed.

Ofcourse we have to use opt-in model, but I thought it was good to keep support for opt-out - at least for demonstrative purpose.

Also removes the old method of blocking Mapp tracking with webtrekkOptOut cookie. I have kept the optOut cookie in the ECC whitelist though to keep support for the old method.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
