### PR TITLE
4915: Do not use samesite for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,7 @@ jobs:
           drush vset -y opensearch_recommendation_url 'http://openadhl.addi.dk/1.1/'
           drush vset -y ting_infomedia_url 'http://useraccessinfomedia.addi.dk/1.4/'
           drush vset -y opensearch_search_autocomplete_suggestion_url 'https://ortograf.dbc.dk/ortograf/suggest'
+          drush eval "variable_set('samesite_cookie_attribute_value', '');"
           sudo chown -R 33:33 /var/www/html/sites/default/files
     - run:
         name: Install Behat


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4915

#### Description

These do not use HTTPS so we cannot use “SameSite=None”.

Setting an empty variable is tricky with drush so we have to use
eval instead.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
