### PR TITLE
Issue-4928: Changed page heading to level 1 (h1)

### DIFF
--- a/modules/ding_library/ding_library.pages_default.inc
+++ b/modules/ding_library/ding_library.pages_default.inc
@@ -225,7 +225,7 @@ function ding_library_default_page_manager_handlers() {
     $pane->access = array();
     $pane->configuration = array(
       'link' => 0,
-      'markup' => 'h1',
+      'markup' => 'h2',
       'id' => '',
       'class' => '',
       'context' => 'argument_entity_id:node_1',


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4928

#### Description

Changes page heading from level 2 (h2) to level 1 (h1).

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.