### PR TITLE
4559: Update mail headers contact from

### DIFF
--- a/modules/ding_contact/ding_contact.module
+++ b/modules/ding_contact/ding_contact.module
@@ -79,18 +79,16 @@ function ding_contact_mail_alter(&$message) {
   switch ($message['id']) {
     case 'contact_page_mail':
     case 'contact_page_copy':
-      $subject = $message['subject'];
-      $sitename = variable_get('site_name', 'DDB CMS');
-      $default_from = variable_get('site_mail', ini_get('sendmail_from'));
-      $from_value = t('"!subject via !site_name" <!site_mail>', array(
-        '!subject' => $subject,
-        '!site_name' => $sitename,
-        '!site_mail' => $default_from,
-      ));
+      $site_name = variable_get('site_name', 'DDB CMS');
+      $site_mail = variable_get('site_mail', ini_get('sendmail_from'));
+      $from_value = format_string('"!site_name" <!site_mail>', [
+        '!site_name' => $site_name,
+        '!site_mail' => $site_mail,
+      ]);
       $message['from'] = $from_value;
       $message['headers']['From'] = $from_value;
       $message['headers']['Reply-To'] = $message['params']['mail'];
-      $message['headers']['Sender'] = $sitename;
+      $message['headers']['Sender'] = $site_mail;
 
       // If it is not an anonymous user that has filled out the form,
       // we want ot make sure their email is included in the message.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4559

#### Description

Update the From and Sender mail headers sent from the contact form. It appears that some mail clients have issues with the current format.

Old:
Sender: SITENAME
From: "SUBJECT via SITENAME" \<SITEMAIL\>

New:
Sender: SITEMAIL
From: "SITENAME" \<SITEMAIL\>

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
