### PR TITLE
Issue 4964: Heading levels

### DIFF
--- a/modules/ding_contact/ding_contact.pages_default.inc
+++ b/modules/ding_contact/ding_contact.pages_default.inc
@@ -71,8 +71,9 @@ function ding_contact_default_page_manager_handlers() {
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'override_title' => 0,
-      'override_title_text' => '',
+      'override_title' => 1,
+      'override_title_text' => '%title',
+      'override_title_heading' => 'h1',
     );
     $pane->cache = array();
     $pane->style = array(

--- a/modules/ding_event/ding_event.pages_default.inc
+++ b/modules/ding_event/ding_event.pages_default.inc
@@ -630,8 +630,9 @@ events
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'override_title' => 0,
+      'override_title' => 1,
       'override_title_text' => '',
+      'override_title_heading' => 'h1',
     );
     $pane->cache = array();
     $pane->style = array(

--- a/modules/ding_library/ding_library.pages_default.inc
+++ b/modules/ding_library/ding_library.pages_default.inc
@@ -546,9 +546,9 @@ function ding_library_default_page_manager_pages() {
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'override_title' => 0,
-      'override_title_text' => '',
-      'override_title_heading' => 'h2',
+      'override_title' => 1,
+      'override_title_text' => '%title',
+      'override_title_heading' => 'h1',
     );
     $pane->cache = array();
     $pane->style = array(

--- a/modules/ding_library/plugins/content_types/menu_title.inc
+++ b/modules/ding_library/plugins/content_types/menu_title.inc
@@ -10,7 +10,7 @@ $plugin = array(
 );
 
 function ding_library_menu_title_content_type_render($subtype, $conf, $panel_args, $context = NULL) {
-  $heading_tag_name = $conf['override_title_heading'] ?? 'h2';
+  $heading_tag_name = isset($conf['override_title_heading']) ? $conf['override_title_heading'] : 'h2';
 
   $block = new stdClass();
   $block->content = '<' . $heading_tag_name . '>' . menu_get_active_title() . '</' . $heading_tag_name . '>';

--- a/modules/ding_library/plugins/content_types/menu_title.inc
+++ b/modules/ding_library/plugins/content_types/menu_title.inc
@@ -10,8 +10,10 @@ $plugin = array(
 );
 
 function ding_library_menu_title_content_type_render($subtype, $conf, $panel_args, $context = NULL) {
+  $heading_tag_name = $conf['override_title_heading'] ?? 'h2';
+
   $block = new stdClass();
-  $block->content = '<h2>' . menu_get_active_title() . '</h2>';
+  $block->content = '<' . $heading_tag_name . '>' . menu_get_active_title() . '</' . $heading_tag_name . '>';
 
   return $block;
 }
@@ -22,5 +24,3 @@ function ding_library_menu_title_content_type_render($subtype, $conf, $panel_arg
 function ding_library_menu_title_content_type_edit_form($form, &$form_state) {
   return $form;
 }
-
-

--- a/modules/ding_news/ding_news.pages_default.inc
+++ b/modules/ding_news/ding_news.pages_default.inc
@@ -877,8 +877,9 @@ news/%tid:name',
     $pane->shown = TRUE;
     $pane->access = array();
     $pane->configuration = array(
-      'override_title' => 0,
+      'override_title' => 1,
       'override_title_text' => '',
+      'override_title_heading' => 'h1',
     );
     $pane->cache = array();
     $pane->style = array(

--- a/themes/ddbasic/templates/panel/panels-pane.tpl.php
+++ b/themes/ddbasic/templates/panel/panels-pane.tpl.php
@@ -31,7 +31,7 @@
   
     <?php print render($title_prefix); ?>
     <?php if (!empty($title)): ?>
-      <?php $heading_tag_name = $pane->configuration['override_title_heading'] ?? 'h2'; ?>
+      <?php $heading_tag_name = isset($pane->configuration['override_title_heading']) ? $pane->configuration['override_title_heading'] : 'h2'; ?>
       <<?php print $heading_tag_name; ?> <?php print $title_attributes; ?>><?php print t($title); ?></<?php print $heading_tag_name; ?>>
     <?php endif; ?>
     <?php print render($title_suffix); ?>

--- a/themes/ddbasic/templates/panel/panels-pane.tpl.php
+++ b/themes/ddbasic/templates/panel/panels-pane.tpl.php
@@ -31,7 +31,8 @@
   
     <?php print render($title_prefix); ?>
     <?php if (!empty($title)): ?>
-      <h2<?php print $title_attributes; ?>><?php print t($title); ?></h2>
+      <?php $heading_tag_name = $pane->configuration['override_title_heading'] ?? 'h2'; ?>
+      <<?php print $heading_tag_name; ?> <?php print $title_attributes; ?>><?php print t($title); ?></<?php print $heading_tag_name; ?>>
     <?php endif; ?>
     <?php print render($title_suffix); ?>
   


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4964

#### Description

Fixes heading levels on pages and blocks (from `h2` to `h1`) on 

* `/biblioteker`
* `/contact`
* `/nyheder`
* `/arrangementer`

#### Checklist

- [x] My code complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.