### PR TITLE
4983 bugfixes

### DIFF
--- a/themes/ddbasic/sass/components/panel/class-panel.scss
+++ b/themes/ddbasic/sass/components/panel/class-panel.scss
@@ -560,6 +560,10 @@
   .views-widget-filter-field_ding_event_date_value_1 {
     @include omega();
   }
+  .form-type-bef-checkbox {
+    margin-top: 0.4em;
+    margin-bottom: 0.4em;
+  }
   label:not(.option) {
     @include font('display-small');
     font-weight: normal;
@@ -577,7 +581,7 @@
     .form-item {
       float: none;
     }
-    input {
+    input:not([type="checkbox"]) {
       width: 100%;
       margin-right: 0;
       background-color: $grey;
@@ -650,6 +654,10 @@
       margin-bottom: 10px;
     }
   }
+  .form-type-bef-checkbox {
+    margin-top: 0.4em;
+    margin-bottom: 0.4em;
+  }
   .form-item {
     display: block;
     margin-right: 0;
@@ -657,7 +665,7 @@
     .form-item {
       float: none;
     }
-    input {
+    input:not([type="checkbox"]) {
       width: 100%;
       margin-right: 0;
       background-color: $grey;

--- a/themes/ddbasic/scripts/view.js
+++ b/themes/ddbasic/scripts/view.js
@@ -269,8 +269,8 @@
 
   // Call masonry resize when images are loaded.
   Drupal.behaviors.ding_event_teaser_masonry = {
-    if (jQuery.isFunction($.fn.imagesLoaded)) {
-      attach: function (context, settings) {
+    attach: function (context, settings) {
+      if (jQuery.isFunction($.fn.imagesLoaded)) {
         $('.js-masonry-view', context).imagesLoaded(function () {
           handle_ding_event_masonry(true);
         });


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4983

#### Description

Fix JS syntax error and properly style events and news pages checkboxes. Apparently the latter was `display: none` until someone decided to do it properly for facets but forgot to check other pages.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/97630644-2d8e8780-1a30-11eb-8f2c-b31efadc5fb8.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
