### PR TITLE
4803: Don't pause tabroll on pause button focus

### DIFF
--- a/modules/ding_tabroll/js/ding_tabroll.js
+++ b/modules/ding_tabroll/js/ding_tabroll.js
@@ -42,22 +42,22 @@
           }, switch_speed);
 
           // Stop tabs rotate when mouse is over the tab roll.
-          tabroll_wrapper.mouseenter(function() {
+          tabroll.mouseenter(function() {
             mouseIn = true;
           });
 
           // Start tabs rotate when mouse is out.
-          tabroll_wrapper.mouseleave(function () {
+          tabroll.mouseleave(function () {
             mouseIn = false;
           });
 
           // Stops tabs rotation when an element within it is in focus.
-          tabroll_wrapper.focusin(function () {
+          tabroll.focusin(function () {
             focusIn = true;
           });
 
           // Starts tabs rotation when an element within it is out of focus.
-          tabroll_wrapper.focusout(function () {
+          tabroll.focusout(function () {
             focusIn = false;
           });
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4803

#### Description

Mobile browsers leaves the focus hanging on the button after
clicking (really, desktop browsers ought to too?), which means that
the rolltab will stay paused after pressing play. Fix it but ensuring the 
handlers aren't added to the play/pause button.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
