### PR TITLE
4989: Remove type hint causing issues

### DIFF
--- a/modules/ding_base/ding_base.module
+++ b/modules/ding_base/ding_base.module
@@ -432,7 +432,7 @@ function ding_base_pathauto_alias_alter(&$alias, array &$context) {
  *
  * Mainly used by ding_groups.
  *
- * @param Entity $node
+ * @param stdClass $node
  *   Node entity object for the OG group that should have alias updated.
  * @param string $base
  *   Base path for the group (e.g. library or temaer).
@@ -443,7 +443,7 @@ function ding_base_pathauto_alias_alter(&$alias, array &$context) {
  *
  * @todo: used it in ding_libraries to remove the "slug" field.
  */
-function ding_base_updated_taxonomy_aliases(Entity $node, $base, array $terms, array $slugs) {
+function ding_base_updated_taxonomy_aliases(stdClass $node, $base, array $terms, array $slugs) {
   $group_alias = 'node/' . $node->nid;
 
   // Find node pattern from path auto.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4989

#### Description

Just discovered this when doing a `drush fra -y` and thought I would provide a quick solution.

The object passed will not an instance `Entity` but `stdClass`.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
