### PR TITLE
4976: Fix related materials carousel error

### DIFF
--- a/modules/ding_react/plugins/content_types/related_materials.inc
+++ b/modules/ding_react/plugins/content_types/related_materials.inc
@@ -83,7 +83,7 @@ function ding_react_related_materials_content_type_render($subtype, $conf, $pane
 /**
  * Format a set of string values to a format suitable for React app data.
  *
- * @param mixed $data
+ * @param string|string[]|FALSE $data
  *   The data to format. Either string or array.
  *
  * @return string

--- a/modules/ding_react/plugins/content_types/related_materials.inc
+++ b/modules/ding_react/plugins/content_types/related_materials.inc
@@ -62,10 +62,10 @@ function ding_react_related_materials_content_type_render($subtype, $conf, $pane
     $sources = explode(',', $sources);
 
     $data = [
-      'subjects' => ding_react_related_materials_format_strings($object->getSubjects()),
-      'categories' => ding_react_related_materials_format_strings($object->getAudience()),
-      'sources' => ding_react_related_materials_format_strings($sources),
-      'exclude-title' => ding_react_related_materials_format_string($object->getTitle()),
+      'subjects' => ding_react_related_materials_format_data($object->getSubjects()),
+      'categories' => ding_react_related_materials_format_data($object->getAudience()),
+      'sources' => ding_react_related_materials_format_data($sources),
+      'exclude-title' => ding_react_related_materials_format_data($object->getTitle()),
       // We cannot use url() here as it will encode the colon in the placeholder.
       'search-url' => '/search/ting/:query?sort=:sort',
       'material-url' => '/ting/object/:pid',
@@ -83,15 +83,21 @@ function ding_react_related_materials_content_type_render($subtype, $conf, $pane
 /**
  * Format a set of string values to a format suitable for React app data.
  *
- * @param string[] $strings
- *   The string values.
+ * @param mixed $data
+ *   The data to format. Either string or array.
  *
  * @return string
  *   A single formatted string containing all the values.
  */
-function ding_react_related_materials_format_strings(array $strings) {
-  $formatted_strings = array_map('ding_react_related_materials_format_string', $strings);
-  return implode(",", $formatted_strings);
+function ding_react_related_materials_format_data($data) {
+  if (empty($data)) {
+    return '';
+  }
+  if (is_array($data)) {
+    $formatted_strings = array_map('ding_react_related_materials_format_string', $data);
+    return implode(',', $formatted_strings);
+  }
+  return ding_react_related_materials_format_string($data);
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4976

#### Description

The getAudience() method can return FALSE if there's no data, giving a fatal error on the example presented in the case, because of the type hint.

Seems instance of OpenSearchTingObject doesn't follow the doc of TingObjectInterface and can both return array or false where
as the doc for the interface says string is returned. We therefore cannot count on data being an array.

I suggest to change to formatting function to handle all cases and remove type hint.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
