### PR TITLE
4969: Fix periodical reservation issue

### DIFF
--- a/modules/ding_availability/ding_availability.field.inc
+++ b/modules/ding_availability/ding_availability.field.inc
@@ -115,6 +115,11 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
         // If item is of type 'library materials' (where we can lookup holding
         // data), prepare to check holding on the item.
         if ($entity->is('library_material')) {
+          // Ensure that Drupal ajax is loaded. If the holdings is periodical
+          // there might be reservation buttons for individual issues, which
+          // uses 'use-ajax' links.
+          drupal_add_library('system', 'drupal.ajax');
+
           $attached['js'][] = array(
             'data' => array(
               'ding_availability_mode' => 'holdings',

--- a/modules/ding_availability/ding_availability.field.inc
+++ b/modules/ding_availability/ding_availability.field.inc
@@ -118,7 +118,7 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
           // Ensure that Drupal ajax is loaded. If the holdings is periodical
           // there might be reservation buttons for individual issues, which
           // uses 'use-ajax' links.
-          drupal_add_library('system', 'drupal.ajax');
+          $attached['library'][] = array('system', 'drupal.ajax');
 
           $attached['js'][] = array(
             'data' => array(

--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -449,7 +449,6 @@ function theme_ding_holdings_periodical($variables) {
                   'available',
                   'use-ajax',
                 ),
-                'id' => 'reservation-' . $issue_id,
               ),
               'html' => FALSE,
             ),
@@ -468,7 +467,7 @@ function theme_ding_holdings_periodical($variables) {
 
       // Normal behavior - periodicals, dc.type=tidsskrift.
       $iss[$i] = array(
-        'data' => '<span id="periodical-id-' . $normalized_id . '" class="ding-periodical-fold ding-reservable-periodical periodical-id-' . $normalized_id . '">' . $issue . '</span>',
+        'data' => '<span class="ding-periodical-fold ding-reservable-periodical">' . $issue . '</span>',
         'class' => array(
           drupal_html_class('ding-periodical-container'),
         ),
@@ -480,7 +479,6 @@ function theme_ding_holdings_periodical($variables) {
         $iss[$i]['data'] = $holdings[0]['data'];
         $iss[$i]['class'][] = drupal_html_class('ding-periodical-no-issues');
         $iss[$i]['class'][] = drupal_html_class('ding-reservable-periodical');
-        $iss[$i]['id'][] = drupal_html_id('periodical-id-' . $normalized_id);
       }
       else {
         // Set children with holding information for periodicals.

--- a/modules/ding_availability/js/ding_availability.js
+++ b/modules/ding_availability/js/ding_availability.js
@@ -114,6 +114,7 @@
         // Insert/update holding information for material.
         var holdings = Drupal.DADB[entity_id];
         $('#' + id).html(holdings.html);
+        Drupal.attachBehaviors(holdings.html);
 
         if (holdings.is_periodical) {
           // Hide all elements.

--- a/modules/ding_availability/js/ding_availability.js
+++ b/modules/ding_availability/js/ding_availability.js
@@ -114,7 +114,7 @@
         // Insert/update holding information for material.
         var holdings = Drupal.DADB[entity_id];
         $('#' + id).html(holdings.html);
-        Drupal.attachBehaviors(holdings.html);
+        Drupal.attachBehaviors($('#' + id));
 
         if (holdings.is_periodical) {
           // Hide all elements.

--- a/modules/ding_reservation/ding_reservation.module
+++ b/modules/ding_reservation/ding_reservation.module
@@ -136,8 +136,6 @@ function ding_reservation_ding_entity_buttons($type, $entity, $view_mode, $widge
   if ($type == 'ding_entity' && $entity->is('library_material')) {
     switch ($widget) {
       case 'ajax':
-        drupal_add_library('system', 'drupal.ajax');
-
         // The AJAX-widget will use AJAX-request for checking reservability and
         // also when performing the reservation.
         $button = array(
@@ -163,6 +161,9 @@ function ding_reservation_ding_entity_buttons($type, $entity, $view_mode, $widge
                   'type' => 'file',
                   'data' => drupal_get_path('module', 'ding_reservation') . '/js/ding_reservation_reservability.js',
                 ),
+              ),
+              'library' => array(
+                array('system', 'drupal.ajax'),
               ),
             ),
           ),


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4969

#### Description

The changes from #1603 has resulted in some potential errors when making periodical reservations. Since periodical holdings is now pulled in async via AJAX, we now have to take extra care that everything is done right, since these holdings can now contain 'use-ajax' - reservation links:

1. Ensure Drupal AJAX script is loaded when holdings field is rendered on initial page request. We cannot do this in the AJAX-callback.
2. Call `drupal.attachBehaviors()` when recieving holdings HTML. This was not done before, but since holdings can now contain 'use-ajax' links it has consequences.

Additional I've removed all unneeded HTML IDs in periodical holdings HTML. For some periodicals with many issues it could result in a lot HTML IDs being posted back in reservation callback. In rare cases this could result in the error described here:

https://www.drupal.org/project/drupal/issues/2541722

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
