### PR TITLE
4991: Add subsearch overview page as default tab

### DIFF
--- a/modules/ting_subsearch/ting_subsearch.module
+++ b/modules/ting_subsearch/ting_subsearch.module
@@ -20,7 +20,29 @@ function ting_subsearch_menu() {
     'access arguments' => array('access content'),
   ];
 
+  $items['admin/config/ding/subsearch'] = [
+    'title' => 'Ting subsearch',
+    'description' => 'Configure subsearch modules.',
+    'page callback' => 'ting_subsearch_admin_overview',
+    'access arguments' => array('configure ting subsearch'),
+  ];
+  $items['admin/config/ding/subsearch/subsearch'] = [
+    'title' => 'Overview',
+    'description' => 'Ting subsearch overview',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+    'weight' => -10,
+  ];
+
   return $items;
+}
+
+/**
+ * Ting subsearch admin overview page.
+ */
+function ting_subsearch_admin_overview() {
+  return [
+    '#markup' => t('Subsearch modules allow additional searches to be made based on predefined conditions.'),
+  ];
 }
 
 /**

--- a/modules/ting_subsearch/ting_subsearch_suggestions/ting_subsearch_suggestions.module
+++ b/modules/ting_subsearch/ting_subsearch_suggestions/ting_subsearch_suggestions.module
@@ -25,20 +25,15 @@ function ting_subsearch_suggestions_ctools_plugin_directory($module, $plugin) {
 function ting_subsearch_suggestions_menu() {
   $items = [];
 
-  $items['admin/config/ding/subsearch'] = [
-    'title' => 'Ting subsearch',
-    'description' => 'Configure subsearch modules.',
+  $items['admin/config/ding/subsearch/suggestions'] = [
+    'title' => 'Ting subsearch suggestions',
+    'description' => 'Configure ting subsearch suggestions.',
     'page callback' => 'drupal_get_form',
     'page arguments' => array('ting_subsearch_suggestions_admin_settings_form'),
     'access arguments' => array('configure ting subsearch'),
     'file' => 'ting_subsearch_suggestions.admin.inc',
-  ];
-
-  $items['admin/config/ding/subsearch/suggestions'] = [
-    'title' => 'Ting subsearch suggestions',
-    'description' => 'Configure ting subsearch suggestions.',
-    'type' => MENU_DEFAULT_LOCAL_TASK,
-    'weight' => -10,
+    'type' => MENU_LOCAL_TASK,
+    'weight' => -9,
   ];
 
   return $items;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4991

#### Description

Add subsearch overview page as default tab.

Also change suggestions admin settings form to normal tab, so that
it doesn't stand out compared to the other subsearch modules.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
