### PR TITLE
4283: Remove empty "add one more" place2book price

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -242,9 +242,16 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
         ),
       );
 
+      // Initialize prices count first time the form is rendered.
       if (!isset($form_state['prices_count'])) {
-        $form_state['prices_count'] = empty($prices) ? range(0, 0) : range(0, count($prices));
+        if (!empty($prices)) {
+          $form_state['prices_count'] = range(0, count($prices) - 1);
+        }
+        else {
+          $form_state['prices_count'] = [];
+        }
       }
+
       $price_name = variable_get('ding_p2b_default_price_name', '');
 
       // We have elements that are required depending on other fields. This

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -700,14 +700,18 @@ function _ding_place2book_get_age_group($tid) {
 function theme_ding_p2b_prices_table($variables) {
   $form = $variables['form'];
   $rows = array();
-  foreach (element_children($form['prices']) as $id) {
-    $rows[] = array(
-      'name' => drupal_render($form['prices'][$id]['name']),
-      'value' => drupal_render($form['prices'][$id]['value']),
-      'sale_begin' => drupal_render($form['prices'][$id]['sale_begin_at']),
-      'sale_end' => drupal_render($form['prices'][$id]['sale_end_at']),
-      'remove' => drupal_render($form['prices'][$id]['remove']),
-    );
+
+  // Ensure we have an array to pass to element_children().
+  if (!empty($form['prices'])) {
+    foreach (element_children($form['prices']) as $id) {
+      $rows[] = array(
+        'name' => drupal_render($form['prices'][$id]['name']),
+        'value' => drupal_render($form['prices'][$id]['value']),
+        'sale_begin' => drupal_render($form['prices'][$id]['sale_begin_at']),
+        'sale_end' => drupal_render($form['prices'][$id]['sale_end_at']),
+        'remove' => drupal_render($form['prices'][$id]['remove']),
+      );
+    }
   }
 
   $header = array(

--- a/modules/ding_place2book/ding_place2book.module
+++ b/modules/ding_place2book/ding_place2book.module
@@ -721,7 +721,7 @@ function theme_ding_p2b_prices_table($variables) {
   $output = theme('table', array(
     'rows' => $rows,
     'header' => $header,
-    'empty' => t('Click to add more for adding a row.'),
+    'empty' => t('No prices added to this event. Click below to add one.'),
     'attributes' => array('id' => 'p2b-prices-table'),
   ));
   $output .= drupal_render_children($form);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4283

#### Description

Remove empty "add one more" place2book ticket on the field widget.

#### Screenshot of the result

![4283-no-prices](https://user-images.githubusercontent.com/5011234/98389221-0e0ce580-2054-11eb-828b-6fbe83cde8aa.png)

![4283-one-price](https://user-images.githubusercontent.com/5011234/98389237-0fd6a900-2054-11eb-8ddd-4f461d89f693.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
