### PR TITLE
4996: Change default URL for material list and follow searches

### DIFF
--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -1,9 +1,7 @@
 <?php
 
-define('DING_REACT_FOLLOW_SEARCHES_PROD_URL', 'https://prod.followsearches.dandigbib.org');
-define('DING_REACT_FOLLOW_SEARCHES_STAGE_URL', 'https://stage.followsearches.dandigbib.org');
-define('DING_REACT_MATERIAL_LIST_PROD_URL', 'https://prod.materiallist.dandigbib.org');
-define('DING_REACT_MATERIAL_LIST_TEST_URL', 'https://test.materiallist.dandigbib.org');
+define('DING_REACT_FOLLOW_SEARCHES_URL', 'https://prod.followsearches.dandigbib.org');
+define('DING_REACT_MATERIAL_LIST_URL', 'https://prod.materiallist.dandigbib.org');
 define('DING_REACT_COVER_SERVICE_URL', 'https://cover.dandigbib.org/api/v2');
 define('DING_REACT_MIGRATED_UID_PREFIX', 'migrated-');
 
@@ -372,7 +370,7 @@ function ding_react_login_url() {
  *   Url to Material List service instance.
  */
 function ding_react_material_list_url() {
-  return variable_get('ding_react_material_list_url', DING_REACT_MATERIAL_LIST_TEST_URL);
+  return variable_get('ding_react_material_list_url', DING_REACT_MATERIAL_LIST_URL);
 }
 
 /**
@@ -382,7 +380,7 @@ function ding_react_material_list_url() {
  *   Url to Follow Searches service instance.
  */
 function ding_react_follow_searches_url() {
-  return variable_get('ding_react_follow_searches_url', DING_REACT_FOLLOW_SEARCHES_STAGE_URL);
+  return variable_get('ding_react_follow_searches_url', DING_REACT_FOLLOW_SEARCHES_URL);
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4996

#### Description

Change default URL for material list and follow searches to use productions URL's.

Removed the old PROD/TEST/STAGE constants for the URL's and just use one for each.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
