### PR TITLE
3916: Add event list filter not null check to views filter

### DIFF
--- a/modules/ding_app_content_rss/ding_app_content_rss.rules_defaults.inc
+++ b/modules/ding_app_content_rss/ding_app_content_rss.rules_defaults.inc
@@ -1,7 +1,7 @@
 <?php
 /**
  * @file
- * Rules configuration.
+ * ding_app_content_rss.rules_defaults.inc
  */
 
 /**
@@ -43,12 +43,7 @@ function ding_app_content_rss_default_rules_configuration() {
         }
       ],
       "DO" : [
-        { "cache_actions_action_clear_views_display_cache" : { "displays" : { "value" : {
-                "ding_app_content_event_rss:feed" : "ding_app_content_event_rss:feed"
-              }
-            }
-          }
-        }
+        { "cache_actions_action_clear_views_display_cache" : { "displays" : { "value" : { "ding_app_content_event_rss:feed" : "ding_app_content_event_rss:feed" } } } }
       ]
     }
   }');
@@ -86,12 +81,7 @@ function ding_app_content_rss_default_rules_configuration() {
         }
       ],
       "DO" : [
-        { "cache_actions_action_clear_views_display_cache" : { "displays" : { "value" : {
-                "ding_app_content_news_rss:feed" : "ding_app_content_news_rss:feed"
-              }
-            }
-          }
-        }
+        { "cache_actions_action_clear_views_display_cache" : { "displays" : { "value" : { "ding_app_content_news_rss:feed" : "ding_app_content_news_rss:feed" } } } }
       ]
     }
   }');

--- a/modules/ding_app_content_rss/ding_app_content_rss.views_default.inc
+++ b/modules/ding_app_content_rss/ding_app_content_rss.views_default.inc
@@ -31,7 +31,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['pager']['type'] = 'full';
   $handler->display->display_options['style_plugin'] = 'default';
   $handler->display->display_options['row_plugin'] = 'fields';
-  /* Relationship: Content: Author */
+  /* Relationship: Content: Content author */
   $handler->display->display_options['relationships']['uid']['id'] = 'uid';
   $handler->display->display_options['relationships']['uid']['table'] = 'node';
   $handler->display->display_options['relationships']['uid']['field'] = 'uid';
@@ -65,7 +65,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['created']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['created']['date_format'] = 'custom';
   $handler->display->display_options['fields']['created']['custom_date_format'] = 'r';
-  /* Field: Content: Promoted to front page */
+  /* Field: Content: Promoted to front page status */
   $handler->display->display_options['fields']['promote']['id'] = 'promote';
   $handler->display->display_options['fields']['promote']['table'] = 'node';
   $handler->display->display_options['fields']['promote']['field'] = 'promote';
@@ -73,7 +73,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['promote']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['promote']['type'] = 'true-false';
   $handler->display->display_options['fields']['promote']['not'] = 0;
-  /* Field: Content: Sticky */
+  /* Field: Content: Sticky status */
   $handler->display->display_options['fields']['sticky']['id'] = 'sticky';
   $handler->display->display_options['fields']['sticky']['table'] = 'node';
   $handler->display->display_options['fields']['sticky']['field'] = 'sticky';
@@ -214,7 +214,7 @@ function ding_app_content_rss_views_default_views() {
     'ding_event' => 'ding_event',
   );
   $handler->display->display_options['filters']['type']['group'] = 1;
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -330,7 +330,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['created']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['created']['date_format'] = 'custom';
   $handler->display->display_options['fields']['created']['custom_date_format'] = 'r';
-  /* Field: Content: Promoted to front page */
+  /* Field: Content: Promoted to front page status */
   $handler->display->display_options['fields']['promote']['id'] = 'promote';
   $handler->display->display_options['fields']['promote']['table'] = 'node';
   $handler->display->display_options['fields']['promote']['field'] = 'promote';
@@ -338,7 +338,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['promote']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['promote']['type'] = 'true-false';
   $handler->display->display_options['fields']['promote']['not'] = 0;
-  /* Field: Content: Sticky */
+  /* Field: Content: Sticky status */
   $handler->display->display_options['fields']['sticky']['id'] = 'sticky';
   $handler->display->display_options['fields']['sticky']['table'] = 'node';
   $handler->display->display_options['fields']['sticky']['field'] = 'sticky';
@@ -479,7 +479,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['field_ding_event_organizers']['type'] = 'taxonomy_term_reference_plain';
   $handler->display->display_options['fields']['field_ding_event_organizers']['delta_offset'] = '0';
   $handler->display->display_options['defaults']['sorts'] = FALSE;
-  /* Sort criterion: Content: Sticky */
+  /* Sort criterion: Content: Sticky status */
   $handler->display->display_options['sorts']['sticky']['id'] = 'sticky';
   $handler->display->display_options['sorts']['sticky']['table'] = 'node';
   $handler->display->display_options['sorts']['sticky']['field'] = 'sticky';
@@ -517,7 +517,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['filters']['field_ding_event_date_value_1']['operator'] = '<=';
   $handler->display->display_options['filters']['field_ding_event_date_value_1']['group'] = 1;
   $handler->display->display_options['filters']['field_ding_event_date_value_1']['default_date'] = '+180 day';
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -532,6 +532,12 @@ function ding_app_content_rss_views_default_views() {
     'ding_event' => 'ding_event',
   );
   $handler->display->display_options['filters']['type_1']['group'] = 2;
+  /* Filter criterion: Content: Event list filter (field_ding_event_list_filter) */
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value_1']['id'] = 'field_ding_event_list_filter_value_1';
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value_1']['table'] = 'field_data_field_ding_event_list_filter';
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value_1']['field'] = 'field_ding_event_list_filter_value';
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value_1']['operator'] = 'not empty';
+  $handler->display->display_options['filters']['field_ding_event_list_filter_value_1']['group'] = 2;
   /* Filter criterion: Content: Event list filter (field_ding_event_list_filter) */
   $handler->display->display_options['filters']['field_ding_event_list_filter_value']['id'] = 'field_ding_event_list_filter_value';
   $handler->display->display_options['filters']['field_ding_event_list_filter_value']['table'] = 'field_data_field_ding_event_list_filter';
@@ -554,7 +560,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['filters']['field_ding_event_date_value_2']['operator'] = '<=';
   $handler->display->display_options['filters']['field_ding_event_date_value_2']['group'] = 2;
   $handler->display->display_options['filters']['field_ding_event_date_value_2']['default_date'] = '+180 day';
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status_1']['id'] = 'status_1';
   $handler->display->display_options['filters']['status_1']['table'] = 'node';
   $handler->display->display_options['filters']['status_1']['field'] = 'status';
@@ -671,15 +677,6 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['field_ding_news_lead']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_ding_news_lead']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['field_ding_news_lead']['type'] = 'text_plain';
-  /* Field: Content: Body */
-  $handler->display->display_options['fields']['field_ding_news_body']['id'] = 'field_ding_news_body';
-  $handler->display->display_options['fields']['field_ding_news_body']['table'] = 'field_data_field_ding_news_body';
-  $handler->display->display_options['fields']['field_ding_news_body']['field'] = 'field_ding_news_body';
-  $handler->display->display_options['fields']['field_ding_news_body']['label'] = '';
-  $handler->display->display_options['fields']['field_ding_news_body']['alter']['strip_tags'] = TRUE;
-  $handler->display->display_options['fields']['field_ding_news_body']['alter']['preserve_tags'] = '<a><b><em><u><i><li><ul><ol><h2><h3><strong><p><br/><br><br />';
-  $handler->display->display_options['fields']['field_ding_news_body']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_ding_news_body']['element_default_classes'] = FALSE;
   /* Field: Content: Paragraphs */
   $handler->display->display_options['fields']['field_ding_news_paragraphs']['id'] = 'field_ding_news_paragraphs';
   $handler->display->display_options['fields']['field_ding_news_paragraphs']['table'] = 'field_data_field_ding_news_paragraphs';

--- a/modules/ding_event/ding_event.features.field_instance.inc
+++ b/modules/ding_event/ding_event.features.field_instance.inc
@@ -87,7 +87,9 @@ function ding_event_field_default_field_instances() {
     'widget' => array(
       'active' => 1,
       'module' => 'options',
-      'settings' => array(),
+      'settings' => array(
+        'match_operator' => 'CONTAINS',
+      ),
       'type' => 'options_select',
       'weight' => 10,
     ),
@@ -221,7 +223,9 @@ function ding_event_field_default_field_instances() {
     'widget' => array(
       'active' => 1,
       'module' => 'options',
-      'settings' => array(),
+      'settings' => array(
+        'match_operator' => 'CONTAINS',
+      ),
       'type' => 'options_select',
       'weight' => 11,
     ),
@@ -499,7 +503,7 @@ function ding_event_field_default_field_instances() {
     'entity_type' => 'node',
     'field_name' => 'field_ding_event_list_filter',
     'label' => 'Event list filter',
-    'required' => 0,
+    'required' => 1,
     'settings' => array(
       'user_register_form' => FALSE,
     ),
@@ -929,8 +933,6 @@ function ding_event_field_default_field_instances() {
         'label' => 'above',
         'module' => 'text',
         'settings' => array(),
-        'type' => 'number_integer',
-        'weight' => 8,
         'type' => 'text_default',
         'weight' => 3,
       ),
@@ -1106,7 +1108,9 @@ function ding_event_field_default_field_instances() {
     'widget' => array(
       'active' => 1,
       'module' => 'options',
-      'settings' => array(),
+      'settings' => array(
+        'match_operator' => 'CONTAINS',
+      ),
       'type' => 'options_select',
       'weight' => 13,
     ),
@@ -1381,7 +1385,9 @@ function ding_event_field_default_field_instances() {
     'widget' => array(
       'active' => 1,
       'module' => 'options',
-      'settings' => array(),
+      'settings' => array(
+        'match_operator' => 'CONTAINS',
+      ),
       'type' => 'options_select',
       'weight' => 6,
     ),

--- a/modules/ding_event/ding_event.views_default.inc
+++ b/modules/ding_event/ding_event.views_default.inc
@@ -214,7 +214,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['arguments']['tid']['validate_options']['vocabularies'] = array(
     'event_category' => 'event_category',
   );
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -551,7 +551,7 @@ function ding_event_views_default_views() {
   );
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -801,7 +801,7 @@ function ding_event_views_default_views() {
     'multiple_to' => '',
   );
   $handler->display->display_options['defaults']['sorts'] = FALSE;
-  /* Sort criterion: Content: Sticky */
+  /* Sort criterion: Content: Sticky status */
   $handler->display->display_options['sorts']['sticky']['id'] = 'sticky';
   $handler->display->display_options['sorts']['sticky']['table'] = 'node';
   $handler->display->display_options['sorts']['sticky']['field'] = 'sticky';
@@ -813,7 +813,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -828,7 +828,7 @@ function ding_event_views_default_views() {
     'ding_event' => 'ding_event',
   );
   $handler->display->display_options['filters']['type']['group'] = 1;
-  /* Filter criterion: Content: Promoted to front page */
+  /* Filter criterion: Content: Promoted to front page status */
   $handler->display->display_options['filters']['promote']['id'] = 'promote';
   $handler->display->display_options['filters']['promote']['table'] = 'node';
   $handler->display->display_options['filters']['promote']['field'] = 'promote';
@@ -1147,7 +1147,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['arguments']['gid']['summary_options']['items_per_page'] = '25';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -1306,7 +1306,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['arguments']['tid']['summary_options']['items_per_page'] = '25';
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -1635,7 +1635,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['fields']['title']['element_wrapper_type'] = '0';
   $handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['title']['hide_alter_empty'] = FALSE;
-  /* Field: Content: Edit link */
+  /* Field: Content: Link to edit content */
   $handler->display->display_options['fields']['edit_node']['id'] = 'edit_node';
   $handler->display->display_options['fields']['edit_node']['table'] = 'views_entity_node';
   $handler->display->display_options['fields']['edit_node']['field'] = 'edit_node';
@@ -1666,7 +1666,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';
@@ -1742,7 +1742,7 @@ function ding_event_views_default_views() {
   $handler->display->display_options['defaults']['arguments'] = FALSE;
   $handler->display->display_options['defaults']['filter_groups'] = FALSE;
   $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Published */
+  /* Filter criterion: Content: Published status */
   $handler->display->display_options['filters']['status']['id'] = 'status';
   $handler->display->display_options['filters']['status']['table'] = 'node';
   $handler->display->display_options['filters']['status']['field'] = 'status';


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3916

#### Description

For old events the event list filter might not be set at all. For some reason this filters them out of event feed even when mobile flag is set.

Turns out we can fix this by adding a not null check filter to second views filter group, before the filter that actually checks the value. Otherwise it must give some query error resulting in the whole row being discarded. See screenshot below.

Additionally the feature export also includes some cleanup:
1. Remove body field from news rss feed views export. This was not
done in #1540.
2. Some rules config and other export was refactored. Better keep it as
features exported it to avoid getting overriden status.

#### Screenshot of the result

![3916-event-filter-not-null-check](https://user-images.githubusercontent.com/5011234/99293328-cd2a8300-2842-11eb-8517-352791214ad6.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
