### PR TITLE
4988 by Inlead: Extending and refining the feed for mobile.

### DIFF
--- a/modules/ding_app_content_rss/ding_app_content_rss.info
+++ b/modules/ding_app_content_rss/ding_app_content_rss.info
@@ -23,3 +23,4 @@ features[rules_config][] = rules_ding_app_content_rss_news_update_cache_clear
 features[views_view][] = ding_app_content_event_rss
 features[views_view][] = ding_app_content_news_rss
 files[] = views/ding_app_content_rss_handler_library_id.inc
+files[] = views/ding_app_content_rss_handler_sales_status.inc

--- a/modules/ding_app_content_rss/ding_app_content_rss.module
+++ b/modules/ding_app_content_rss/ding_app_content_rss.module
@@ -162,6 +162,10 @@ function ding_app_content_rss_views_rss_item_elements() {
       'title' => t('Event price'),
       'description' => t('The price of the event.'),
     ),
+    'content-rss:arrangement-sales-status' => array(
+      'title' => t('Event tickets sales status'),
+      'description' => t('The status of event tickets sales.'),
+    ),
     'content-rss:resources' => array(
       'title' => t('Redia resources'),
       'description' => t('The node id of a type which has a relation to ting objects.'),
@@ -195,6 +199,92 @@ function ding_app_content_rss_views_rss_item_elements() {
 }
 
 /**
+ * Preprocess <description> property.
+ */
+function ding_app_content_rss_preprocess_description(&$variables) {
+  if (isset($variables['view']) && $variables['view']->name == 'ding_app_content_news_rss') {
+    $result = [];
+
+    foreach ($variables['raw'] as $key => $paragraph) {
+      /** @var \ParagraphsItemEntity $paragraph_entity */
+      $paragraph_entity = paragraphs_item_load($paragraph['raw']['value']);
+
+      switch ($paragraph_entity->bundle) {
+        case 'ding_paragraphs_text':
+          $build = [];
+          $build['paragraph-markup'] = $paragraph_entity->field_ding_paragraphs_text[LANGUAGE_NONE][0]['safe_value'];
+          break;
+
+        case 'ding_paragraphs_image_and_text':
+          $build = [];
+          $images = [];
+          $images_content = $paragraph_entity->field_ding_paragraphs_image[LANGUAGE_NONE];
+          foreach ($images_content as $item) {
+            $images[] = ['key' => 'paragraph-image', 'value' => file_create_url($item['uri'])];
+          }
+
+          $build['paragraph-images'] = $images;
+          $build['paragraph-image-position'] = $paragraph_entity->field_ding_paragraphs_position[LANGUAGE_NONE][0]['value'];
+          $build['paragraph-display'] = $paragraph_entity->field_ding_paragraphs_display[LANGUAGE_NONE][0]['value'];
+          $build['paragraph-markup'] = $paragraph_entity->field_ding_paragraphs_text[LANGUAGE_NONE][0]['safe_value'];
+          break;
+
+        case 'ding_paragraphs_text_box':
+          $build = [];
+          $build['paragraph-display'] = $paragraph_entity->field_ding_paragraphs_display[LANGUAGE_NONE][0]['value'];
+          $build['paragraph-markup'] = $paragraph_entity->field_ding_paragraphs_box_text[LANGUAGE_NONE][0]['safe_value'];
+          break;
+
+        case 'ding_paragraphs_material_list':
+        case 'ding_paragraphs_carousel':
+          $build = [];
+          $resources = [];
+          $materials = $paragraph_entity->field_ding_paragraphs_material[LANGUAGE_NONE];
+          foreach ($materials as $material) {
+            $relation = relation_load($material['value']->rid);
+            $endpoints = relation_get_endpoints($relation);
+            $ting_object = reset($endpoints['ting_object']);
+            $resources[] = [
+              'key' => 'paragraph-resource',
+              'value' => explode(':', $ting_object->ding_entity_id)[1],
+            ];
+          }
+          $build['paragraph-resources'] = $resources;
+          break;
+
+        case 'ding_paragraphs_image':
+          $build = [];
+          $images = [];
+          $images_content = $paragraph_entity->field_ding_paragraphs_image[LANGUAGE_NONE];
+          foreach ($images_content as $item) {
+            $images[] = ['key' => 'paragraph-image', 'value' => file_create_url($item['uri'])];
+          }
+          $build['paragraph-images'] = $images;
+          $build['paragraph-display'] = $paragraph_entity->field_ding_paragraphs_display[LANGUAGE_NONE][0]['value'];
+          break;
+
+        case 'ding_paragraphs_single_material':
+          $build = [];
+          $build['paragraph-display'] = $paragraph_entity->field_ding_paragraphs_display[LANGUAGE_NONE][0]['value'];
+          $relation = relation_load($paragraph_entity->field_ding_paragraphs_single_mat[LANGUAGE_NONE][0]['value']->rid);
+          $endpoints = relation_get_endpoints($relation);
+          $ting_object = reset($endpoints['ting_object']);
+          $build['paragraph-resource'] = explode(':', $ting_object->ding_entity_id)[1];
+          break;
+      }
+
+      $result['paragraphs'][] = [
+        'key' => 'paragraph',
+        'value' => $build,
+        'attributes' => ['type' => $paragraph_entity->bundle],
+      ];
+    }
+
+    $variables['elements'][0]['value'] = $result;
+  }
+}
+
+/**
  * Preprocess function for item <resources> elements.
  */
 function ding_app_content_rss_preprocess_item_resources(&$variables) {
@@ -218,9 +308,15 @@ function ding_app_content_rss_preprocess_item_resources(&$variables) {
         'value' => $faust_number,
       );
     }
-
   }
 
   // Replace the existing values with the new array.
   $variables['elements']['0']['value'] = $value;
+}
+
+/**
+ * Implements hook_views_rss_item_elements_alter().
+ */
+function ding_app_content_rss_views_rss_item_elements_alter(&$elements) {
+  $elements['views_rss_core']['description']['preprocess functions'][] = 'ding_app_content_rss_preprocess_description';
 }

--- a/modules/ding_app_content_rss/ding_app_content_rss.views.inc
+++ b/modules/ding_app_content_rss/ding_app_content_rss.views.inc
@@ -25,5 +25,13 @@ function ding_app_content_rss_views_data() {
     ),
   );
 
+  $data['ding_app_content_rss']['ding_app_content_rss_handler_sales_status'] = array(
+    'title' => t('Sales Status'),
+    'help' => t("Provides a event's sales status."),
+    'field' => array(
+      'handler' => 'ding_app_content_rss_handler_sales_status',
+    ),
+  );
+
   return $data;
 }

--- a/modules/ding_app_content_rss/ding_app_content_rss.views_default.inc
+++ b/modules/ding_app_content_rss/ding_app_content_rss.views_default.inc
@@ -102,7 +102,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['field_ding_event_body']['field'] = 'field_ding_event_body';
   $handler->display->display_options['fields']['field_ding_event_body']['label'] = '';
   $handler->display->display_options['fields']['field_ding_event_body']['alter']['strip_tags'] = TRUE;
-  $handler->display->display_options['fields']['field_ding_event_body']['alter']['preserve_tags'] = '<a><b><em><u><i><li><ul><ol><h2><h3><strong><p><br/><br><br />';
+  $handler->display->display_options['fields']['field_ding_event_body']['alter']['preserve_tags'] = '<a><b><em><u><i><li><ul><ol><h2><h3><h4><strong><p><br/><br><br />';
   $handler->display->display_options['fields']['field_ding_event_body']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_ding_event_body']['element_default_classes'] = FALSE;
   /* Field: Indhold: List image (content) */
@@ -292,6 +292,7 @@ function ding_app_content_rss_views_default_views() {
         'display-endtime' => '',
         'arrangement-location' => 'field_ding_event_location',
         'arrangement-price' => 'field_ding_event_price',
+        'arrangement-sales-status' => 'ding_app_content_rss_handler_sales_status',
         'resources' => 'nid',
         'library-id' => 'ding_app_content_rss_handler_library_id',
         'booking-url' => 'field_ding_event_ticket_link',
@@ -367,7 +368,7 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['field_ding_event_body']['field'] = 'field_ding_event_body';
   $handler->display->display_options['fields']['field_ding_event_body']['label'] = '';
   $handler->display->display_options['fields']['field_ding_event_body']['alter']['strip_tags'] = TRUE;
-  $handler->display->display_options['fields']['field_ding_event_body']['alter']['preserve_tags'] = '<a><b><em><u><i><li><ul><ol><h2><h3><strong><p><br/><br><br />';
+  $handler->display->display_options['fields']['field_ding_event_body']['alter']['preserve_tags'] = '<a><b><em><u><i><li><ul><ol><h2><h3><h4><strong><p><br/><br><br />';
   $handler->display->display_options['fields']['field_ding_event_body']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_ding_event_body']['element_default_classes'] = FALSE;
   /* Field: Indhold: List image (content) */
@@ -478,6 +479,21 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['field_ding_event_organizers']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_ding_event_organizers']['type'] = 'taxonomy_term_reference_plain';
   $handler->display->display_options['fields']['field_ding_event_organizers']['delta_offset'] = '0';
+  /* Field: Ding App Content RSS: Sales Status */
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_sales_status']['id'] = 'ding_app_content_rss_handler_sales_status';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_sales_status']['table'] = 'ding_app_content_rss';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_sales_status']['field'] = 'ding_app_content_rss_handler_sales_status';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_sales_status']['label'] = '';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_sales_status']['element_label_colon'] = FALSE;
+  /* Field: Content: Place2book */
+  $handler->display->display_options['fields']['field_place2book']['id'] = 'field_place2book';
+  $handler->display->display_options['fields']['field_place2book']['table'] = 'field_data_field_place2book';
+  $handler->display->display_options['fields']['field_place2book']['field'] = 'field_place2book';
+  $handler->display->display_options['fields']['field_place2book']['label'] = '';
+  $handler->display->display_options['fields']['field_place2book']['exclude'] = TRUE;
+  $handler->display->display_options['fields']['field_place2book']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_place2book']['click_sort_column'] = 'event_id';
+  $handler->display->display_options['fields']['field_place2book']['delta_offset'] = '0';
   $handler->display->display_options['defaults']['sorts'] = FALSE;
   /* Sort criterion: Content: Sticky */
   $handler->display->display_options['sorts']['sticky']['id'] = 'sticky';
@@ -488,78 +504,6 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['sorts']['field_ding_event_date_value']['id'] = 'field_ding_event_date_value';
   $handler->display->display_options['sorts']['field_ding_event_date_value']['table'] = 'field_data_field_ding_event_date';
   $handler->display->display_options['sorts']['field_ding_event_date_value']['field'] = 'field_ding_event_date_value';
-  $handler->display->display_options['defaults']['filter_groups'] = FALSE;
-  $handler->display->display_options['filter_groups']['operator'] = 'OR';
-  $handler->display->display_options['filter_groups']['groups'] = array(
-    1 => 'AND',
-    2 => 'AND',
-  );
-  $handler->display->display_options['defaults']['filters'] = FALSE;
-  /* Filter criterion: Content: Type */
-  $handler->display->display_options['filters']['type']['id'] = 'type';
-  $handler->display->display_options['filters']['type']['table'] = 'node';
-  $handler->display->display_options['filters']['type']['field'] = 'type';
-  $handler->display->display_options['filters']['type']['value'] = array(
-    'ding_event' => 'ding_event',
-  );
-  $handler->display->display_options['filters']['type']['group'] = 1;
-  /* Filter criterion: Content: Date -  start date (field_ding_event_date) */
-  $handler->display->display_options['filters']['field_ding_event_date_value']['id'] = 'field_ding_event_date_value';
-  $handler->display->display_options['filters']['field_ding_event_date_value']['table'] = 'field_data_field_ding_event_date';
-  $handler->display->display_options['filters']['field_ding_event_date_value']['field'] = 'field_ding_event_date_value';
-  $handler->display->display_options['filters']['field_ding_event_date_value']['operator'] = '>=';
-  $handler->display->display_options['filters']['field_ding_event_date_value']['group'] = 1;
-  $handler->display->display_options['filters']['field_ding_event_date_value']['default_date'] = 'now';
-  /* Filter criterion: Content: Date -  start date (field_ding_event_date) */
-  $handler->display->display_options['filters']['field_ding_event_date_value_1']['id'] = 'field_ding_event_date_value_1';
-  $handler->display->display_options['filters']['field_ding_event_date_value_1']['table'] = 'field_data_field_ding_event_date';
-  $handler->display->display_options['filters']['field_ding_event_date_value_1']['field'] = 'field_ding_event_date_value';
-  $handler->display->display_options['filters']['field_ding_event_date_value_1']['operator'] = '<=';
-  $handler->display->display_options['filters']['field_ding_event_date_value_1']['group'] = 1;
-  $handler->display->display_options['filters']['field_ding_event_date_value_1']['default_date'] = '+180 day';
-  /* Filter criterion: Content: Published */
-  $handler->display->display_options['filters']['status']['id'] = 'status';
-  $handler->display->display_options['filters']['status']['table'] = 'node';
-  $handler->display->display_options['filters']['status']['field'] = 'status';
-  $handler->display->display_options['filters']['status']['value'] = 1;
-  $handler->display->display_options['filters']['status']['group'] = 1;
-  $handler->display->display_options['filters']['status']['expose']['operator'] = FALSE;
-  /* Filter criterion: Content: Type */
-  $handler->display->display_options['filters']['type_1']['id'] = 'type_1';
-  $handler->display->display_options['filters']['type_1']['table'] = 'node';
-  $handler->display->display_options['filters']['type_1']['field'] = 'type';
-  $handler->display->display_options['filters']['type_1']['value'] = array(
-    'ding_event' => 'ding_event',
-  );
-  $handler->display->display_options['filters']['type_1']['group'] = 2;
-  /* Filter criterion: Content: Event list filter (field_ding_event_list_filter) */
-  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['id'] = 'field_ding_event_list_filter_value';
-  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['table'] = 'field_data_field_ding_event_list_filter';
-  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['field'] = 'field_ding_event_list_filter_value';
-  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['value'] = array(
-    'show_all' => 'show_all',
-  );
-  $handler->display->display_options['filters']['field_ding_event_list_filter_value']['group'] = 2;
-  /* Filter criterion: Content: Date - end date (field_ding_event_date:value2) */
-  $handler->display->display_options['filters']['field_ding_event_date_value2']['id'] = 'field_ding_event_date_value2';
-  $handler->display->display_options['filters']['field_ding_event_date_value2']['table'] = 'field_data_field_ding_event_date';
-  $handler->display->display_options['filters']['field_ding_event_date_value2']['field'] = 'field_ding_event_date_value2';
-  $handler->display->display_options['filters']['field_ding_event_date_value2']['operator'] = '>=';
-  $handler->display->display_options['filters']['field_ding_event_date_value2']['group'] = 2;
-  $handler->display->display_options['filters']['field_ding_event_date_value2']['default_date'] = 'now';
-  /* Filter criterion: Content: Date -  start date (field_ding_event_date) */
-  $handler->display->display_options['filters']['field_ding_event_date_value_2']['id'] = 'field_ding_event_date_value_2';
-  $handler->display->display_options['filters']['field_ding_event_date_value_2']['table'] = 'field_data_field_ding_event_date';
-  $handler->display->display_options['filters']['field_ding_event_date_value_2']['field'] = 'field_ding_event_date_value';
-  $handler->display->display_options['filters']['field_ding_event_date_value_2']['operator'] = '<=';
-  $handler->display->display_options['filters']['field_ding_event_date_value_2']['group'] = 2;
-  $handler->display->display_options['filters']['field_ding_event_date_value_2']['default_date'] = '+180 day';
-  /* Filter criterion: Content: Published */
-  $handler->display->display_options['filters']['status_1']['id'] = 'status_1';
-  $handler->display->display_options['filters']['status_1']['table'] = 'node';
-  $handler->display->display_options['filters']['status_1']['field'] = 'status';
-  $handler->display->display_options['filters']['status_1']['value'] = '1';
-  $handler->display->display_options['filters']['status_1']['group'] = 2;
   $handler->display->display_options['path'] = 'ding-redia-rss/event';
   $translatables['ding_app_content_event_rss'] = array(
     t('Master'),
@@ -671,15 +615,6 @@ function ding_app_content_rss_views_default_views() {
   $handler->display->display_options['fields']['field_ding_news_lead']['element_label_colon'] = FALSE;
   $handler->display->display_options['fields']['field_ding_news_lead']['element_default_classes'] = FALSE;
   $handler->display->display_options['fields']['field_ding_news_lead']['type'] = 'text_plain';
-  /* Field: Content: Body */
-  $handler->display->display_options['fields']['field_ding_news_body']['id'] = 'field_ding_news_body';
-  $handler->display->display_options['fields']['field_ding_news_body']['table'] = 'field_data_field_ding_news_body';
-  $handler->display->display_options['fields']['field_ding_news_body']['field'] = 'field_ding_news_body';
-  $handler->display->display_options['fields']['field_ding_news_body']['label'] = '';
-  $handler->display->display_options['fields']['field_ding_news_body']['alter']['strip_tags'] = TRUE;
-  $handler->display->display_options['fields']['field_ding_news_body']['alter']['preserve_tags'] = '<a><b><em><u><i><li><ul><ol><h2><h3><strong><p><br/><br><br />';
-  $handler->display->display_options['fields']['field_ding_news_body']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['field_ding_news_body']['element_default_classes'] = FALSE;
   /* Field: Content: Paragraphs */
   $handler->display->display_options['fields']['field_ding_news_paragraphs']['id'] = 'field_ding_news_paragraphs';
   $handler->display->display_options['fields']['field_ding_news_paragraphs']['table'] = 'field_data_field_ding_news_paragraphs';
@@ -826,6 +761,114 @@ function ding_app_content_rss_views_default_views() {
     'absolute_paths' => 1,
     'feed_in_links' => 0,
   );
+  $handler->display->display_options['defaults']['fields'] = FALSE;
+  /* Field: Content: Nid */
+  $handler->display->display_options['fields']['nid']['id'] = 'nid';
+  $handler->display->display_options['fields']['nid']['table'] = 'node';
+  $handler->display->display_options['fields']['nid']['field'] = 'nid';
+  $handler->display->display_options['fields']['nid']['label'] = '';
+  $handler->display->display_options['fields']['nid']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['nid']['element_default_classes'] = FALSE;
+  /* Field: Content: Title */
+  $handler->display->display_options['fields']['title']['id'] = 'title';
+  $handler->display->display_options['fields']['title']['table'] = 'node';
+  $handler->display->display_options['fields']['title']['field'] = 'title';
+  $handler->display->display_options['fields']['title']['label'] = '';
+  $handler->display->display_options['fields']['title']['alter']['word_boundary'] = FALSE;
+  $handler->display->display_options['fields']['title']['alter']['ellipsis'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['title']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['title']['link_to_node'] = FALSE;
+  /* Field: Content: Post date */
+  $handler->display->display_options['fields']['created']['id'] = 'created';
+  $handler->display->display_options['fields']['created']['table'] = 'node';
+  $handler->display->display_options['fields']['created']['field'] = 'created';
+  $handler->display->display_options['fields']['created']['label'] = '';
+  $handler->display->display_options['fields']['created']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['created']['date_format'] = 'custom';
+  $handler->display->display_options['fields']['created']['custom_date_format'] = 'r';
+  /* Field: Content: Promoted to front page status */
+  $handler->display->display_options['fields']['promote']['id'] = 'promote';
+  $handler->display->display_options['fields']['promote']['table'] = 'node';
+  $handler->display->display_options['fields']['promote']['field'] = 'promote';
+  $handler->display->display_options['fields']['promote']['label'] = '';
+  $handler->display->display_options['fields']['promote']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['promote']['type'] = 'true-false';
+  $handler->display->display_options['fields']['promote']['not'] = 0;
+  /* Field: Content: Sticky status */
+  $handler->display->display_options['fields']['sticky']['id'] = 'sticky';
+  $handler->display->display_options['fields']['sticky']['table'] = 'node';
+  $handler->display->display_options['fields']['sticky']['field'] = 'sticky';
+  $handler->display->display_options['fields']['sticky']['label'] = '';
+  $handler->display->display_options['fields']['sticky']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['sticky']['type'] = 'true-false';
+  $handler->display->display_options['fields']['sticky']['not'] = 0;
+  /* Field: User: Name */
+  $handler->display->display_options['fields']['name']['id'] = 'name';
+  $handler->display->display_options['fields']['name']['table'] = 'users';
+  $handler->display->display_options['fields']['name']['field'] = 'name';
+  $handler->display->display_options['fields']['name']['relationship'] = 'uid';
+  $handler->display->display_options['fields']['name']['label'] = '';
+  $handler->display->display_options['fields']['name']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['name']['link_to_user'] = FALSE;
+  /* Field: Content: Lead */
+  $handler->display->display_options['fields']['field_ding_news_lead']['id'] = 'field_ding_news_lead';
+  $handler->display->display_options['fields']['field_ding_news_lead']['table'] = 'field_data_field_ding_news_lead';
+  $handler->display->display_options['fields']['field_ding_news_lead']['field'] = 'field_ding_news_lead';
+  $handler->display->display_options['fields']['field_ding_news_lead']['label'] = '';
+  $handler->display->display_options['fields']['field_ding_news_lead']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_news_lead']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_news_lead']['type'] = 'text_plain';
+  /* Field: Content: Paragraphs */
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['id'] = 'field_ding_news_paragraphs';
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['table'] = 'field_data_field_ding_news_paragraphs';
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['field'] = 'field_ding_news_paragraphs';
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['label'] = '';
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['alter']['preserve_tags'] = '<a><b><em><u><i><li><ul><ol><h2><h3><h4><strong><p><br/><br><br />';
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['settings'] = array(
+    'view_mode' => 'full',
+  );
+  $handler->display->display_options['fields']['field_ding_news_paragraphs']['delta_offset'] = '0';
+  /* Field: Indhold: List image (content) */
+  $handler->display->display_options['fields']['field_ding_news_list_image']['id'] = 'field_ding_news_list_image';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['table'] = 'field_data_field_ding_news_list_image';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['field'] = 'field_ding_news_list_image';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['ui_name'] = 'Indhold: List image (content)';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['label'] = '';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['alter']['alter_text'] = TRUE;
+  $handler->display->display_options['fields']['field_ding_news_list_image']['alter']['text'] = '[field_ding_news_list_image]';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_news_list_image']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_news_list_image']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['type'] = 'media_content';
+  $handler->display->display_options['fields']['field_ding_news_list_image']['settings'] = array(
+    'image_style' => '',
+    'group_multiple_values' => 0,
+    'medium' => 'image',
+    'expression' => '',
+    'generate_hash' => 1,
+    'hash_algo' => 'md5',
+  );
+  /* Field: Indhold: List image (thumbnail) */
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['id'] = 'field_ding_news_list_image_1';
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['table'] = 'field_data_field_ding_news_list_image';
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['field'] = 'field_ding_news_list_image';
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['ui_name'] = 'Indhold: List image (thumbnail)';
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['label'] = '';
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['element_label_colon'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['element_default_classes'] = FALSE;
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['click_sort_column'] = 'fid';
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['type'] = 'media_thumbnail';
+  $handler->display->display_options['fields']['field_ding_news_list_image_1']['settings'] = array(
+    'image_style' => 'medium',
+  );
+  /* Field: Ding App Content RSS: Library ID */
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_library_id']['id'] = 'ding_app_content_rss_handler_library_id';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_library_id']['table'] = 'ding_app_content_rss';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_library_id']['field'] = 'ding_app_content_rss_handler_library_id';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_library_id']['label'] = '';
+  $handler->display->display_options['fields']['ding_app_content_rss_handler_library_id']['element_label_colon'] = FALSE;
   $handler->display->display_options['defaults']['sorts'] = FALSE;
   /* Sort criterion: Content: Sticky status */
   $handler->display->display_options['sorts']['sticky']['id'] = 'sticky';

--- a/modules/ding_app_content_rss/views/ding_app_content_rss_handler_sales_status.inc
+++ b/modules/ding_app_content_rss/views/ding_app_content_rss_handler_sales_status.inc
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @file
+ * Expose event's ticket sales status.
+ */
+
+/**
+ * Class ding_app_content_rss_handler_sales_status.
+ */
+class ding_app_content_rss_handler_sales_status extends views_handler_field {
+  /**
+   * {@inheritdoc}
+   */
+  function query() {}
+
+  /**
+   * {@inheritdoc}
+   */
+  function render($values) {
+    if (empty($values->field_field_place2book)) {
+      return;
+    }
+
+    $p2b_field = $values->field_field_place2book[0]['raw'];
+    $event_id = $p2b_field['event_id'];
+    $event_maker_id = $p2b_field['event_maker_id'];
+
+    if (empty($event_id) || empty($event_maker_id)) {
+      return;
+    }
+
+    $p2b = ding_place2book_instance();
+    $event = $p2b->getEvent($event_maker_id, $event_id);
+    $meta_data = $event->meta_data;
+    $state = $event->state;
+    $available_tickets = $meta_data->available_tickets;
+
+    // Try to derive a status for the ticket link in frontend by looking at the
+    // p2b event's state, ticket types and sale periods.
+    // See: http://developer.place2book.com/v1/events/
+    $ticket_link_status = '';
+    if (in_array($state, ['held', 'completed'])) {
+      $ticket_link_status = 'event-over';
+    }
+    elseif (!$event->active) {
+      $ticket_link_status = 'closed';
+    }
+    elseif ($state === 'published') {
+      // If event is published we first check to see if there's any available
+      // tickets at all. If not the event is sold out and we can avoid fetching
+      // ticket types and sale periods. There might be a waiting-list so we
+      // check for that first before setting sold out.
+      if (empty($available_tickets)) {
+        if (!empty($event->waiting_list)) {
+          $ticket_link_status = 'waiting-list';
+        }
+        else {
+          $ticket_link_status = 'sold-out';
+        }
+      }
+      else {
+        // Else we have no other options than to fetch the tickets and look
+        // for open or upcoming sale periods.
+        $sale_periods = [];
+        foreach ($p2b->getPrices($event_maker_id, $event_id) as $price) {
+          $sale_periods[] = [
+            'begin' => strtotime($price->sale_begin_at),
+            'end' => strtotime($price->sale_end_at),
+          ];
+        }
+
+        // Some events, for example those migrated from the old API, will have
+        // sales period on the event and not on the individual tickets.
+        if (isset($event->sale_open_at) && isset($event->sale_close_at)) {
+          $sale_periods[] = [
+            'begin' => strtotime($event->sale_open_at),
+            'end' => strtotime($event->sale_close_at),
+          ];
+        }
+
+        $now = time();
+
+        // Filter out periods which are already over.
+        $sale_periods = array_filter($sale_periods, function ($p) use ($now) {
+          return $p['end'] >= $now;
+        });
+
+        // Check if we still have any active sale periods. If such are - go on!
+        if (!empty($sale_periods)) {
+          // Find the closest sale period.
+          $begin_values = array_column($sale_periods, 'begin');
+          // Get the closest sale period. In case when event has upcoming sales,
+          // its start value will be used in button label.
+          $min_period_begin = min($begin_values);
+          $min_period = array_filter($sale_periods, function ($sale_period) use ($min_period_begin) {
+            return ($sale_period['begin']) == $min_period_begin;
+          });
+          $min_period = array_shift($min_period);
+
+          // We have found an open sales period.
+          $ticket_link_status = 'open';
+
+          // Check for 'upcoming' sale.
+          if ($now < $min_period['begin']) {
+            // We haven't found any open sales period yet, but at least there's
+            // an upcoming, so set that status for now.
+            $ticket_link_status = 'upcoming';
+          }
+        }
+
+        // If no upcoming or open sales period was found for the published event
+        // we consider the sales status to be closed.
+        if (empty($ticket_link_status)) {
+          $ticket_link_status = 'closed';
+        }
+
+      }
+    }
+
+    return $ticket_link_status;
+  }
+
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4988

#### Description

- Extended the `description` property of news item of News feed. This should ensure that paragraphs content is displayed in the feed and also makes feed's data cleaner (no tons of un-neded markup).
**This will require modification of mobile app.**
```
<description>
	<paragraphs>
		<paragraph type="ding_paragraphs_image">
			<paragraph-images>
				<paragraph-image>http://ddbcms.localhost/sites/default/files/paragraph_media/news/pack_nr.20_minimalism_10.jpg</paragraph-image>
			</paragraph-images>
			<paragraph-display>half_left</paragraph-display>
		</paragraph>
		<paragraph type="ding_paragraphs_text_box">
			<paragraph-display>half_right</paragraph-display>
			<paragraph-markup>&lt;p&gt;Accusamus voluptatum occaecat veritatis dolores nullam rerum qui? Eleifend tempus quos magna fugiat dolorem praesentium laoreet phasellus et illo debitis occaecati dolores dis vero sociis neque convallis! Optio delectus sit provident platea? Dolorem, lectus dolore repudiandae, assumenda voluptatem, laudantium nostrud erat blandit molestias fames ultricies mollitia neque excepteur, senectus vitae.&lt;/p&gt;
&lt;p&gt;Doloremque, praesentium turpis fugit delectus in do odit deleniti asperiores, architecto harum, auctor aenean tempus! Labore facilis cum ultrices. Laborum, officiis accusamus at per cubilia molestias debitis, platea, vestibulum conubia augue inceptos ullamcorper fringilla. Ultrices habitant! Qui eiusmod sem laudantium praesentium corporis! Sodales necessitatibus, ridiculus dignissim nostra mollis, excepteur eos.&lt;/p&gt;
&lt;p&gt;Luctus facere voluptas. Risus. Ut nullam. Quisquam nec, nullam etiam recusandae anim wisi odit, pellentesque dolorem mattis mattis ridiculus mus, suscipit accusamus proin sint culpa debitis sapien platea urna! Magni, pariatur modi nunc consequatur auctor dignissim excepturi magni iusto, suscipit, bibendum eget, quis ab, auctor neque vitae. Commodo veritatis vitae.&lt;/p&gt;
&lt;p&gt;Feugiat erat, illo ipsa adipisicing dictumst fuga deserunt. Veritatis, eget volutpat netus hic adipisicing? Pariatur? Aut fugit aliquam, exercitationem repellat magna nascetur sodales? Fames! Viverra cumque. Eos facere! Fugiat tristique justo euismod facilisi leo curabitur, suspendisse cum mollitia, pretium class distinctio justo vestibulum voluptatum scelerisque praesentium aliquid eaque luctus adipisci.&lt;/p&gt;</paragraph-markup>
		</paragraph>
		<paragraph type="ding_paragraphs_material_list">
			<paragraph-resources>
				<paragraph-resource>EBC5437577</paragraph-resource>
				<paragraph-resource>EBC1675006</paragraph-resource>
				<paragraph-resource>EBC1790748</paragraph-resource>
				<paragraph-resource>ODN0000912438</paragraph-resource>
			</paragraph-resources>
		</paragraph>
		<paragraph type="ding_paragraphs_text">
			<paragraph-markup>&lt;p&gt;Fugiat consectetur dignissim ea, volutpat fermentum incidunt quidem eligendi optio ultricies repellat, provident aute erat! Sequi habitasse massa imperdiet elementum quidem litora perspiciatis consequuntur tortor, repudiandae atque, itaque? Augue nobis purus tempor ex phasellus aut. Aperiam aspernatur sit accumsan quibusdam nulla excepturi perferendis aliquet! Hic. Ullamco, earum nam fames vestibulum.&lt;/p&gt;</paragraph-markup>
		</paragraph>
		<paragraph type="ding_paragraphs_image_and_text">
			<paragraph-images>
				<paragraph-image>http://ddbcms.localhost/sites/default/files/paragraph_media/news/pack_nr.20_minimalism_30.jpg</paragraph-image>
			</paragraph-images>
			<paragraph-image-position>ting_object_left</paragraph-image-position>
			<paragraph-display>full_width</paragraph-display>
			<paragraph-markup>&lt;p&gt;Venenatis provident eu? Aliquam venenatis sed quia aut error fringilla euismod officiis sodales? Necessitatibus quisque perspiciatis! Maecenas pariatur corrupti vitae molestias elit laborum elementum! Ea aenean! Nostrud debitis consequat posuere, consectetur accusantium conubia molestie, cupidatat leo? Eum tempor potenti facilisi! Laboris eaque habitasse elementum potenti venenatis beatae sint? Doloremque senectus.&lt;/p&gt;</paragraph-markup>
		</paragraph>
		<paragraph type="ding_paragraphs_single_material">
			<paragraph-display>full_width</paragraph-display>
			<paragraph-resource>EBC423061</paragraph-resource>
		</paragraph>
		<paragraph type="ding_paragraphs_carousel">
			<paragraph-resources>
				<paragraph-resource>03716090</paragraph-resource>
				<paragraph-resource>00281905</paragraph-resource>
				<paragraph-resource>EBC2093048</paragraph-resource>
				<paragraph-resource>47919851</paragraph-resource>
			</paragraph-resources>
		</paragraph>
	</paragraphs>
</description>
```
- Added new views field handler to display the ticket sales status for events feed in `content-rss:arrangement-sales-status` property.
- Added `<h4>` tag to exclusions list so it will not be wiped from the output.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.