### PR TITLE
5010: Patch ECK to avoid PDOException

### DIFF
--- a/project.make
+++ b/project.make
@@ -78,7 +78,6 @@ projects[dynamic_background][subdir] = "contrib"
 projects[dynamic_background][version] = "2.0-rc4"
 projects[dynamic_background][patch][] = "https://www.drupal.org/files/issues/create_file_path-2410241-1.patch"
 
-; To be removed together with p2.
 projects[eck][subdir] = "contrib"
 projects[eck][version] = "2.0-rc9"
 ; Avoid PDO exception after installation

--- a/project.make
+++ b/project.make
@@ -81,6 +81,8 @@ projects[dynamic_background][patch][] = "https://www.drupal.org/files/issues/cre
 ; To be removed together with p2.
 projects[eck][subdir] = "contrib"
 projects[eck][version] = "2.0-rc9"
+; Avoid PDO exception after installation
+projects[eck][patch][] = "https://www.drupal.org/files/issues/eck-pdoexception-2109589-17.patch"
 
 projects[email][subdir] = "contrib"
 projects[email][version] = "1.3"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5010

#### Description

For some reason ECK fails after a clean install - currently seen on
Platform.sh. The issue is hard to track down but based on the
community patching the module seems to be the way to go for now.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.