### PR TITLE
Revert "5010: Patch ECK to avoid PDOException"

### DIFF
--- a/project.make
+++ b/project.make
@@ -78,10 +78,9 @@ projects[dynamic_background][subdir] = "contrib"
 projects[dynamic_background][version] = "2.0-rc4"
 projects[dynamic_background][patch][] = "https://www.drupal.org/files/issues/create_file_path-2410241-1.patch"
 
+; To be removed together with p2.
 projects[eck][subdir] = "contrib"
 projects[eck][version] = "2.0-rc9"
-; Avoid PDO exception after installation
-projects[eck][patch][] = "https://www.drupal.org/files/issues/eck-pdoexception-2109589-17.patch"
 
 projects[email][subdir] = "contrib"
 projects[email][version] = "1.3"


### PR DESCRIPTION
Behat tests are broken at the moment. This is the last PR we merged. Might this be the problem?

Reverts ding2/ding2#1726