### PR TITLE
4895: Fixed heading level on /registration

### DIFF
--- a/modules/ding_registration/templates/ding-acceptance.tpl.php
+++ b/modules/ding_registration/templates/ding-acceptance.tpl.php
@@ -15,7 +15,7 @@
   <div class="layout-wrapper">
     <div class="pane-content">
       <div class="primary-content ding-auth">
-        <h2 class="pane-title"><?php print t('Self registration form'); ?></h2>
+        <h1 class="pane-title"><?php print t('Self registration form'); ?></h1>
         <div class="ding-auth--registration-acceptance">
           <?php print $variables['element']['#children'] ?>
         </div>

--- a/modules/ding_registration/templates/ding-registration-success.tpl.php
+++ b/modules/ding_registration/templates/ding-registration-success.tpl.php
@@ -20,7 +20,7 @@
   <div class="layout-wrapper">
     <div class="pane-content">
       <div class="primary-content">
-        <h2 class="pane-title"><?php print render($title); ?></h2>
+        <h1 class="pane-title"><?php print render($title); ?></h1>
         <?php print render($content); ?>
       </div>
     </div>

--- a/modules/ding_registration/templates/ding-registration.tpl.php
+++ b/modules/ding_registration/templates/ding-registration.tpl.php
@@ -20,7 +20,7 @@
   <div class="layout-wrapper">
     <div class="pane-content">
       <div class="primary-content ding-auth">
-        <h2 class="pane-title"><?php print render($title); ?></h2>
+        <h1 class="pane-title"><?php print render($title); ?></h1>
         <div class="ding-auth--registration-information">
           <?php print render($content); ?>
         </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4895

#### Description

Fixes heading levels (from `h2` to `h1`) on 

* `/registration`
* `/registration/acceptance`
* `/registration/success`

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
