### PR TITLE
4927: Fixed heading level on section page

### DIFF
--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
@@ -162,9 +162,9 @@ function ding_sections_term_panel_get_handler() {
     $pane->access = array();
     $pane->configuration = array(
       'context' => 'argument_term_1',
-      'override_title' => 0,
-      'override_title_text' => '',
-      'override_title_heading' => 'h2',
+      'override_title' => 1,
+      'override_title_text' => '%title',
+      'override_title_heading' => 'h1',
     );
     $pane->cache = array();
     $pane->style = array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4927

#### Description

Fixes heading level (from `h2` to `h1`) on section pages

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
