### PR TITLE
Core: Run tests on opensearch.addi.dk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,7 +139,7 @@ jobs:
           --site-name=Ding2 --account-name=admin --account-pass=admin \
           install_configure_form.update_status_module='array(FALSE,FALSE)' \
           ding2_module_selection_form.providers_selection=connie \
-          opensearch_admin_settings.opensearch_url=https://oss-services.dbc.dk/opensearch/5.2/ \
+          opensearch_admin_settings.opensearch_url=https://opensearch.addi.dk/test_5.2/ \
           opensearch_admin_settings.ting_agency=100200 \
           opensearch_admin_settings.opensearch_search_profile=test \
     - run:

--- a/tests/behat/docs/p2/services-mock.md
+++ b/tests/behat/docs/p2/services-mock.md
@@ -34,9 +34,9 @@ https://opensource.dbc.dk/services/open-search-web-service
 
 It's not possible to install a test instance of this service, and
 mocking of this service is quite advanced, so we will be using a test
-service available on oss-services.dbc.dk. The problem using this
+service available on opensearch.addi.dk. The problem using this
 service is that we have no way of knowing, when the service will be
 restarted or updated or for other reasons be unavailable at certain
 times.
 
-Currently using http://oss-services.dbc.dk/opensearch/5.0/
+Currently using https://opensearch.addi.dk/test_5.2/.

--- a/tests/behat/features/bootstrap/LibContext.php
+++ b/tests/behat/features/bootstrap/LibContext.php
@@ -570,7 +570,7 @@ class LibContext implements Context, SnippetAcceptingContext
     private function ICreateFilesForRelationChunk($mfile, $relation, $start)
     {
         // Set up the search as URL.
-        $url = "https://oss-services.dbc.dk/opensearch/5.0/";
+        $url = "https://opensearch.addi.dk/test_5.2/";
         $url_search = "?action=search&query=%22term.type=Bog%22";
         $url_params = "&relationData=full";
         $url_auth = "&agency=100200&profile=test&start=" . $start . "&stepValue=50&sort=date_descending";


### PR DESCRIPTION
oss-services.dbc.dk has been shut down. This causes our tests to
fail.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.