### PR TITLE
4325: Config import (yaml)

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -113,6 +113,7 @@ hooks:
     drush -y updatedb
     drush secure-permissions-rebuild
     drush css-generate
+    drush pm-enable ding_config_import
     drush cc all
 
   # The configuration of scheduled execution.

--- a/modules/ding_config_import/README.md
+++ b/modules/ding_config_import/README.md
@@ -1,0 +1,74 @@
+# Ding configuration import
+This module can be used to import configuration changes into the site and enable/disable modules.
+
+The configuration is described by using YAML files with arrays that are flattened to variable keys
+if they are associative arrays. If "normal" arrays they are written as arrays to variables.
+
+If an associative array contains the stop key `array: 1` the array it is placed in is not flattened
+thereby allow for complex variable configuration.
+
+The module comes with an example file to help users getting started with the configuration files.
+
+## How to use
+Simply download the example file that comes with the module add edit it to set the different
+configuration variables.
+
+Upload the file at `/admin/config/ding/config` and clear the cache.
+
+## How it is parsed
+
+This yaml snippet will be transformed to the following variables as store in the database.
+```yaml
+---
+opensearch:
+  url: "https://opensearch.addi.dk/b3.5_5.2/"
+  auth:
+    group: "xxxxx"
+    name: "yyyy"
+    pass: "zzzz"
+```
+
+Translate into:
+```txt
+opensearch_url = "https://opensearch.addi.dk/b3.5_5.2/"
+opensearch_auth_group = "xxxx"
+opensearch_auth_name = "xxxx"
+opensearch_auth_pass = "xxxx"
+```
+
+More advanced configuration using the `array: 1` "key-word" to prevent flatting.
+```yaml
+ding:
+  ting_frontend_group_holdings_available: "open"
+  adgangsplatformen:
+    settings:
+      array: 1
+      clientId: ''
+      clientSecret: ''
+      auth_client:
+        authClientId: ''
+        authClientSecret: ''
+```
+
+Translate into:
+```txt
+ding_ting_frontend_group_holdings_available = "open"
+ding_adgangsplatformen_settings = [
+  clientId => ''
+  clientSecret => ''
+  auth_client => [
+    authClientId => ''
+    authClientSecret => ''
+  ]
+]
+```
+
+You can enable/disable modules using the `modules` section in the yaml file.
+```yaml
+modules:
+  enable:
+    - ding_user_form
+  disable:
+    - ding_adgangsplatformen
+    - ding_registration
+```

--- a/modules/ding_config_import/README.md
+++ b/modules/ding_config_import/README.md
@@ -17,6 +17,26 @@ Upload the file at `/admin/config/ding/config` and clear the cache.
 
 ## How it is parsed
 
+The yaml file has two root elements `settings` and `modules`, so the basic file looks like this.
+```yaml
+---
+settings:
+  opensearch:
+    url: "https://opensearch.addi.dk/b3.5_5.2/"
+    auth:
+      group: "xxxxx"
+      name: "yyyy"
+      pass: "zzzz"
+
+modules:
+  enable:
+    - ding_user_form
+  disable:
+    - ding_adgangsplatformen
+    - ding_registration
+```
+Note that it is not required that both root elements are present in a given file.
+
 This yaml snippet will be transformed to the following variables as store in the database.
 ```yaml
 ---

--- a/modules/ding_config_import/ding_config_import.info
+++ b/modules/ding_config_import/ding_config_import.info
@@ -1,0 +1,4 @@
+name = Ding Config Import
+description = Import configuration from YAML file
+core = 7.x
+package = Ding!

--- a/modules/ding_config_import/ding_config_import.info
+++ b/modules/ding_config_import/ding_config_import.info
@@ -2,3 +2,5 @@ name = Ding Config Import
 description = Import configuration from YAML file
 core = 7.x
 package = Ding!
+hidden = TRUE
+dependencies[] = ding_libs

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -140,14 +140,13 @@ function _ding_config_import_modules(array $modules) {
 function _ding_config_import_set_values(array $values, $prefix = '') {
   foreach ($values as $key => $value) {
     if (is_array($value) && _ding_config_import_is_associative($value)) {
-      if (!isset($value['array'])) {
+      if (!isset($value['array']) || $value['array'] != 1) {
         _ding_config_import_set_values($value, _ding_config_import_prefix($prefix, $key));
         break;
       }
-    }
-
-    if (isset($value['array']) && $value['array'] == 1) {
-      unset($value['array']);
+      else {
+        unset($value['array']);
+      }
     }
 
     $key = _ding_config_import_prefix($prefix, $key);

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -61,9 +61,8 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
   $file = $_FILES['files']['tmp_name']['upload'];
 
   if (libraries_load('yaml')) {
-    $data = file_get_contents($file);
     try {
-      $values = Yaml::parseFile($data);
+      $values = Yaml::parseFile($file);
       if (is_array($values)) {
         foreach (array_keys($values) as $key => $data) {
           switch (mb_strtolower($key)) {

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @file
+ * Implementation of simple form to upload YAML file.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function ding_config_import_menu() {
+  $item = [];
+
+  $item['admin/config/ding/config'] = [
+    'title' => 'Upload configuration',
+    'description' => 'Upload and import configuration from YAML.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ding_config_import_admin_form'),
+    'access arguments' => array('administer site configuration'),
+  ];
+
+  return $item;
+}
+
+/**
+ * Administration form for yaml file upload.
+ */
+function ding_config_import_admin_form() {
+  $form = [];
+
+  $form['#attributes']['enctype'] = 'multipart/form-data';
+  $form['upload'] = [
+    '#title' => t('Upload configurations file'),
+    '#type'  => 'file',
+  ];
+
+  $form['submit_upload'] = array(
+    '#type'  =>  'submit',
+    '#value'  =>  t('Upload'),
+  );
+
+  return $form;
+}
+
+/**
+ * Form submit handler.
+ */
+function ding_config_import_admin_form_submit($form, &$form_state) {
+
+  $error = false;
+  $msg = t('The configuration options have been saved.');
+  $file = $_FILES['files']['tmp_name']['upload'];
+
+  if (libraries_load('yaml')) {
+    $data = file_get_contents($file);
+    $values = \Symfony\Component\Yaml\Yaml::parse($data);
+    if (is_array($values)) {
+      _ding_config_import_set_values($values);
+    }
+    else {
+      $error = true;
+      $msg = t('Fail to parse the YAML file.');
+    }
+  }
+  else {
+    $error = true;
+    $msg = t('Fail to load YAML parsing library. Please contact the system administrator.');
+  }
+
+  if ($error) {
+    drupal_set_message($msg, 'error');
+  }
+  else {
+    drupal_set_message($msg, 'status');
+  }
+
+  // Ensure tmp file is removed. It contains secrets.
+  @unlink($file);
+}
+
+/**
+ * Recursive walk the array using the key as prefix if this multilevel joined
+ * with "_".
+ *
+ * @param array $values
+ *   The values.
+ * @param string $prefix
+ *   The prefix, array key form previous recursion.
+ */
+function _ding_config_import_set_values(array $values, $prefix = '') {
+  foreach ($values as $key => $value) {
+    if (is_array($value)) {
+      _ding_config_import_set_values($value, _ding_config_import_prefix($prefix, $key));
+      return;
+    }
+
+    $key = _ding_config_import_prefix($prefix, $key);
+    variable_set($key, $key);
+  }
+}
+
+/**
+ * Help function to prefix key.
+ *
+ * @param $prefix
+ *   The prefix.
+ * @param $key
+ *   The key to suffix the prefix.
+ *
+ * @return string
+ *   The key prefixed with prefix if prefix was not empty.
+ */
+function _ding_config_import_prefix($prefix, $key) {
+  return empty($prefix) ? $key : $prefix . '_' . $key;
+}

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -37,19 +37,13 @@ function ding_config_import_admin_form() {
     'wrapper' => [
       '#type' => 'fieldset',
       '#title' => t('Configuration upload'),
-      '#description' => t('This module comes with an <a href="/@url">example file</a> that can be used as an template for the upload.', ['@url' => $url]),
+      '#description' => t('This module comes with an <a href="/@url">example file</a> that can be used as an template for the upload. Note that enabled/disable modules may timeout, if it takes longer than the web-servers configuration allows.', ['@url' => $url]),
     ],
   ];
 
   $form['wrapper']['upload'] = [
     '#title' => t('Upload configurations file (yml)'),
     '#type'  => 'file',
-  ];
-
-  $form['wrapper']['combine'] = [
-    '#title' => t('Flatten the YAML array keys into variable set key combined with underscores.'),
-    '#type'  => 'checkbox',
-    '#default_value' => 1,
   ];
 
   $form['submit_upload'] = array(
@@ -65,15 +59,14 @@ function ding_config_import_admin_form() {
  */
 function ding_config_import_admin_form_submit($form, &$form_state) {
   $error = false;
-  $msg = t('The configuration options have been saved.');
-  $flatten = (bool) $form_state['values']['combine'];
+  $msg = t('The configuration options have been saved. You may need to clear cache to rebuild things if you have enabled/disabled modules etc.');
   $file = $_FILES['files']['tmp_name']['upload'];
 
   if (libraries_load('yaml')) {
     $data = file_get_contents($file);
     $values = Yaml::parse($data);
     if (is_array($values)) {
-      _ding_config_import_set_values($values, $flatten);
+      _ding_config_import_set_values($values);
     }
     else {
       $error = true;
@@ -104,21 +97,44 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
  *
  * @param array $values
  *   The values.
- * @param bool $flatten
- *   If true the arrays will be flatten combine the keys to on with underscore
- *   as separator.
  * @param string $prefix
  *   The prefix, array key form previous recursion.
  */
-function _ding_config_import_set_values(array $values, $flatten = TRUE, $prefix = '') {
+function _ding_config_import_set_values(array $values, $prefix = '') {
   foreach ($values as $key => $value) {
-    if ($flatten && is_array($value)) {
-      _ding_config_import_set_values($value, $flatten, _ding_config_import_prefix($prefix, $key));
-      return;
-    }
+    switch ($key) {
+      case 'modules':
+        // Disable modules.
+        if (!empty($value['disable'])) {
+          module_disable($value['disable']);
+        }
 
-    $key = _ding_config_import_prefix($prefix, $key);
-    variable_set($key, $value);
+        // Enabled modules.
+        if (!empty($value['enable'])) {
+          if (!module_enable($value['enable'])) {
+            // Can not throw an exception here as that would stop the other
+            // changes from being applied. So use set message directly here to
+            // notify the use that module enable failed.
+            drupal_set_message(t('Not all module was enabled check the name and the drupal logs for errors.'), 'error');
+          }
+        }
+        break;
+
+      default:
+        if (is_array($value) && _ding_config_import_is_associative($value)) {
+          if (!isset($value['array'])) {
+            _ding_config_import_set_values($value, _ding_config_import_prefix($prefix, $key));
+            break;
+          }
+        }
+
+        if (isset($value['array']) && $value['array'] == 1) {
+          unset($value['array']);
+        }
+
+        $key = _ding_config_import_prefix($prefix, $key);
+        variable_set($key, $value);
+    }
   }
 }
 
@@ -135,4 +151,19 @@ function _ding_config_import_set_values(array $values, $flatten = TRUE, $prefix 
  */
 function _ding_config_import_prefix($prefix, $key) {
   return empty($prefix) ? $key : $prefix . '_' . $key;
+}
+
+/**
+ * Helper function to detect if array is associative.
+ *
+ * This is done by detecting if the array has any keys that is a string.
+ *
+ * @param array $array
+ *   The array to test.
+ *
+ * @return bool
+ *   TRUE if associative else FALSE.
+ */
+function _ding_config_import_is_associative(array $array) {
+  return count(array_filter(array_keys($array), 'is_string')) > 0;
 }

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -64,7 +64,7 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
     try {
       $values = Yaml::parseFile($file);
       if (is_array($values)) {
-        foreach (array_keys($values) as $key => $data) {
+        foreach ($values as $key => $data) {
           switch (mb_strtolower($key)) {
             case "settings":
               _ding_config_import_set_values($data);
@@ -132,17 +132,19 @@ function _ding_config_import_modules(array $modules) {
 function _ding_config_import_set_values(array $values, $prefix = '') {
   foreach ($values as $key => $value) {
     if (is_array($value) && _ding_config_import_is_associative($value)) {
-      if (!isset($value['array']) || $value['array'] != 1) {
+      if (!isset($value['_array']) || $value['_array'] != 1) {
         _ding_config_import_set_values($value, _ding_config_import_prefix($prefix, $key));
-        break;
       }
       else {
-        unset($value['array']);
+        unset($value['_array']);
+        $key = _ding_config_import_prefix($prefix, $key);
+        variable_set($key, $value);
       }
     }
-
-    $key = _ding_config_import_prefix($prefix, $key);
-    variable_set($key, $value);
+    else {
+      $key = _ding_config_import_prefix($prefix, $key);
+      variable_set($key, $value);
+    }
   }
 }
 

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -6,6 +6,7 @@
  */
 
 use Symfony\Component\Yaml\Yaml;
+use Symfony\Component\Yaml\Exception\ParseException;
 
 /**
  * Implements hook_menu().
@@ -13,7 +14,7 @@ use Symfony\Component\Yaml\Yaml;
 function ding_config_import_menu() {
   $item = [];
 
-  $item['admin/config/ding/config'] = [
+  $item['admin/config/ding/config_import'] = [
     'title' => 'Upload configuration',
     'description' => 'Upload and import configuration from YAML.',
     'page callback' => 'drupal_get_form',
@@ -31,9 +32,6 @@ function ding_config_import_admin_form() {
   $url = drupal_get_path('module', 'ding_config_import') . '/example.config.yml';
 
   $form = [
-    '#attributes' => [
-      'enctype' => 'multipart/form-data',
-    ],
     'wrapper' => [
       '#type' => 'fieldset',
       '#title' => t('Configuration upload'),
@@ -58,47 +56,44 @@ function ding_config_import_admin_form() {
  * Form submit handler.
  */
 function ding_config_import_admin_form_submit($form, &$form_state) {
-  $error = false;
+  $type = 'status';
   $msg = t('The configuration options have been saved. You may need to clear cache to rebuild things if you have enabled/disabled modules etc.');
   $file = $_FILES['files']['tmp_name']['upload'];
 
   if (libraries_load('yaml')) {
     $data = file_get_contents($file);
-    $values = Yaml::parse($data);
-    if (is_array($values)) {
-      foreach (array_keys($values) as $key => $data) {
-        switch (mb_strtolower($key)) {
-          case "settings":
-            _ding_config_import_set_values($data);
-            break;
+    try {
+      $values = Yaml::parseFile($data);
+      if (is_array($values)) {
+        foreach (array_keys($values) as $key => $data) {
+          switch (mb_strtolower($key)) {
+            case "settings":
+              _ding_config_import_set_values($data);
+              break;
 
-          case "modules":
-            _ding_config_import_modules($data);
-            break;
+            case "modules":
+              _ding_config_import_modules($data);
+              break;
 
-          default:
-            $error = true;
-            $msg = t('Fail to load understand root element: %key', ['%key' => $key]);
-            break;
+            default:
+              $type = 'error';
+              $msg = t('Failed to use the root element: %key', ['%key' => $key]);
+              break;
+          }
         }
       }
     }
-    else {
-      $error = true;
-      $msg = t('Fail to parse the YAML file.');
+    catch (ParseException $e) {
+      $type = 'error';
+      $msg = t('Error parsing YAML file: %msg', ['%msg' => $e->getMessage()]);
     }
   }
   else {
-    $error = true;
+    $type = 'error';
     $msg = t('Fail to load YAML parsing library. Please contact the system administrator.');
   }
 
-  if ($error) {
-    drupal_set_message($msg, 'error');
-  }
-  else {
-    drupal_set_message($msg);
-  }
+  drupal_set_message($msg, $type);
 
   // Ensure tmp file is removed. It may contain secrets.
   @unlink($file);
@@ -108,6 +103,7 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
  * Helper function to dis-/en-able modules.
  *
  * @param array $modules
+ *   Arrays of modules to disable or enable keyed by "disable" or "enable".
  */
 function _ding_config_import_modules(array $modules) {
   if (!empty($modules['disable'])) {
@@ -128,9 +124,6 @@ function _ding_config_import_modules(array $modules) {
 
 /**
  * Recursive walk the array using the key as prefix.
- *
- * If this an multilevel array the keys are joined with "_". If the flatten
- * parameter is FALSE.
  *
  * @param array $values
  *   The values.

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -115,7 +115,7 @@ function _ding_config_import_set_values(array $values, $prefix = '') {
             // Can not throw an exception here as that would stop the other
             // changes from being applied. So use set message directly here to
             // notify the use that module enable failed.
-            drupal_set_message(t('Not all module was enabled check the name and the drupal logs for errors.'), 'error');
+            drupal_set_message(t('Not all modules were enabled check the name and the drupal logs for errors.'), 'error');
           }
         }
         break;

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -66,7 +66,22 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
     $data = file_get_contents($file);
     $values = Yaml::parse($data);
     if (is_array($values)) {
-      _ding_config_import_set_values($values);
+      foreach (array_keys($values) as $key => $data) {
+        switch (mb_strtolower($key)) {
+          case "settings":
+            _ding_config_import_set_values($data);
+            break;
+
+          case "modules":
+            _ding_config_import_modules($data);
+            break;
+
+          default:
+            $error = true;
+            $msg = t('Fail to load understand root element: %key', ['%key' => $key]);
+            break;
+        }
+      }
     }
     else {
       $error = true;
@@ -82,11 +97,33 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
     drupal_set_message($msg, 'error');
   }
   else {
-    drupal_set_message($msg, 'status');
+    drupal_set_message($msg);
   }
 
-  // Ensure tmp file is removed. It contains secrets.
+  // Ensure tmp file is removed. It may contain secrets.
   @unlink($file);
+}
+
+/**
+ * Helper function to dis-/en-able modules.
+ *
+ * @param array $modules
+ */
+function _ding_config_import_modules(array $modules) {
+  if (!empty($modules['disable'])) {
+    // Disable modules.
+    module_disable($modules['disable']);
+  }
+
+  if (!empty($modules['enable'])) {
+    // Enabled modules.
+    if (!module_enable($modules['enable'])) {
+      // Can not throw an exception here as that would stop the other
+      // changes from being applied. So use set message directly here to
+      // notify the use that module enable failed.
+      drupal_set_message(t('Not all modules were enabled check the name and the drupal logs for errors.'), 'error');
+    }
+  }
 }
 
 /**
@@ -102,39 +139,19 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
  */
 function _ding_config_import_set_values(array $values, $prefix = '') {
   foreach ($values as $key => $value) {
-    switch ($key) {
-      case 'modules':
-        // Disable modules.
-        if (!empty($value['disable'])) {
-          module_disable($value['disable']);
-        }
-
-        // Enabled modules.
-        if (!empty($value['enable'])) {
-          if (!module_enable($value['enable'])) {
-            // Can not throw an exception here as that would stop the other
-            // changes from being applied. So use set message directly here to
-            // notify the use that module enable failed.
-            drupal_set_message(t('Not all modules were enabled check the name and the drupal logs for errors.'), 'error');
-          }
-        }
+    if (is_array($value) && _ding_config_import_is_associative($value)) {
+      if (!isset($value['array'])) {
+        _ding_config_import_set_values($value, _ding_config_import_prefix($prefix, $key));
         break;
-
-      default:
-        if (is_array($value) && _ding_config_import_is_associative($value)) {
-          if (!isset($value['array'])) {
-            _ding_config_import_set_values($value, _ding_config_import_prefix($prefix, $key));
-            break;
-          }
-        }
-
-        if (isset($value['array']) && $value['array'] == 1) {
-          unset($value['array']);
-        }
-
-        $key = _ding_config_import_prefix($prefix, $key);
-        variable_set($key, $value);
+      }
     }
+
+    if (isset($value['array']) && $value['array'] == 1) {
+      unset($value['array']);
+    }
+
+    $key = _ding_config_import_prefix($prefix, $key);
+    variable_set($key, $value);
   }
 }
 

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -5,6 +5,8 @@
  * Implementation of simple form to upload YAML file.
  */
 
+use Symfony\Component\Yaml\Yaml;
+
 /**
  * Implements hook_menu().
  */
@@ -51,8 +53,8 @@ function ding_config_import_admin_form() {
   ];
 
   $form['submit_upload'] = array(
-    '#type'  =>  'submit',
-    '#value'  =>  t('Upload'),
+    '#type' => 'submit',
+    '#value' => t('Upload'),
   );
 
   return $form;
@@ -62,16 +64,14 @@ function ding_config_import_admin_form() {
  * Form submit handler.
  */
 function ding_config_import_admin_form_submit($form, &$form_state) {
-
   $error = false;
   $msg = t('The configuration options have been saved.');
   $flatten = (bool) $form_state['values']['combine'];
   $file = $_FILES['files']['tmp_name']['upload'];
 
-
   if (libraries_load('yaml')) {
     $data = file_get_contents($file);
-    $values = \Symfony\Component\Yaml\Yaml::parse($data);
+    $values = Yaml::parse($data);
     if (is_array($values)) {
       _ding_config_import_set_values($values, $flatten);
     }
@@ -97,8 +97,10 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
 }
 
 /**
- * Recursive walk the array using the key as prefix if this multilevel joined
- * with "_".
+ * Recursive walk the array using the key as prefix.
+ *
+ * If this an multilevel array the keys are joined with "_". If the flatten
+ * parameter is FALSE.
  *
  * @param array $values
  *   The values.
@@ -123,9 +125,9 @@ function _ding_config_import_set_values(array $values, $flatten = TRUE, $prefix 
 /**
  * Help function to prefix key.
  *
- * @param $prefix
+ * @param string $prefix
  *   The prefix.
- * @param $key
+ * @param string $key
  *   The key to suffix the prefix.
  *
  * @return string

--- a/modules/ding_config_import/ding_config_import.module
+++ b/modules/ding_config_import/ding_config_import.module
@@ -26,12 +26,28 @@ function ding_config_import_menu() {
  * Administration form for yaml file upload.
  */
 function ding_config_import_admin_form() {
-  $form = [];
+  $url = drupal_get_path('module', 'ding_config_import') . '/example.config.yml';
 
-  $form['#attributes']['enctype'] = 'multipart/form-data';
-  $form['upload'] = [
-    '#title' => t('Upload configurations file'),
+  $form = [
+    '#attributes' => [
+      'enctype' => 'multipart/form-data',
+    ],
+    'wrapper' => [
+      '#type' => 'fieldset',
+      '#title' => t('Configuration upload'),
+      '#description' => t('This module comes with an <a href="/@url">example file</a> that can be used as an template for the upload.', ['@url' => $url]),
+    ],
+  ];
+
+  $form['wrapper']['upload'] = [
+    '#title' => t('Upload configurations file (yml)'),
     '#type'  => 'file',
+  ];
+
+  $form['wrapper']['combine'] = [
+    '#title' => t('Flatten the YAML array keys into variable set key combined with underscores.'),
+    '#type'  => 'checkbox',
+    '#default_value' => 1,
   ];
 
   $form['submit_upload'] = array(
@@ -49,13 +65,15 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
 
   $error = false;
   $msg = t('The configuration options have been saved.');
+  $flatten = (bool) $form_state['values']['combine'];
   $file = $_FILES['files']['tmp_name']['upload'];
+
 
   if (libraries_load('yaml')) {
     $data = file_get_contents($file);
     $values = \Symfony\Component\Yaml\Yaml::parse($data);
     if (is_array($values)) {
-      _ding_config_import_set_values($values);
+      _ding_config_import_set_values($values, $flatten);
     }
     else {
       $error = true;
@@ -84,18 +102,21 @@ function ding_config_import_admin_form_submit($form, &$form_state) {
  *
  * @param array $values
  *   The values.
+ * @param bool $flatten
+ *   If true the arrays will be flatten combine the keys to on with underscore
+ *   as separator.
  * @param string $prefix
  *   The prefix, array key form previous recursion.
  */
-function _ding_config_import_set_values(array $values, $prefix = '') {
+function _ding_config_import_set_values(array $values, $flatten = TRUE, $prefix = '') {
   foreach ($values as $key => $value) {
-    if (is_array($value)) {
-      _ding_config_import_set_values($value, _ding_config_import_prefix($prefix, $key));
+    if ($flatten && is_array($value)) {
+      _ding_config_import_set_values($value, $flatten, _ding_config_import_prefix($prefix, $key));
       return;
     }
 
     $key = _ding_config_import_prefix($prefix, $key);
-    variable_set($key, $key);
+    variable_set($key, $value);
   }
 }
 

--- a/modules/ding_config_import/example.config.yml
+++ b/modules/ding_config_import/example.config.yml
@@ -1,0 +1,4 @@
+---
+fbs:
+  endpoint: https://cicero-fbs.com/rest/
+  agency: DK-775100

--- a/modules/ding_config_import/example.config.yml
+++ b/modules/ding_config_import/example.config.yml
@@ -1,75 +1,76 @@
 ---
-ting:
-  agency: "DK-xxxxxx"
-  infomedia_url: "https://useraccessinfomedia.addi.dk/1.5/"
-  search_form_style: "extended"
-  covers:
-    ddb_url: "http://cover.dandigbib.org"
-    ddb_enable_logging: 1
-    ddb_development_token: "INSERT TOKEN"
-  language_default: "Dansk"
-  smart:
+settings:
+  ting:
+    agency: "DK-xxxxxx"
+    infomedia_url: "https://useraccessinfomedia.addi.dk/1.5/"
+    search_form_style: "extended"
+    covers:
+      ddb_url: "http://cover.dandigbib.org"
+      ddb_enable_logging: 1
+      ddb_development_token: "INSERT TOKEN"
+    language_default: "Dansk"
+    smart:
+      search:
+        automatic_active: 1
+        master_server: "https://staging.randersbib.dk/data/autodata.txt"
+        webtrekk_server_feed: "https://staging.randersbib.dk/data/searchdata.csv"
+
+  fbs:
+    endpoint: "https://cicero-fbs.com/rest/"
+    agency: "DK-xxxxxx"
+    username: "xxxx"
+    password: "yyyy"
+    enable_reservation_deletion: 1
+    holdings_suffix_type: "shelf_mark"
+    branches_blacklist:
+      - "FBS-751010"
+    user_branches_blacklist:
+      - "FBS-751010"
+      - "FBS-751031"
+      - "FBS-751009"
+    holdings_branches_blacklist:
+      - "FBS-751010"
+      - "FBS-751010"
+      - "FBS-751024"
+
+  opensearch:
+    url: "https://opensearch.addi.dk/b3.5_5.2/"
+    use_auth: 1
+    search_profile: "opac"
+    auth:
+      group: "xxxxx"
+      name: "yyyy"
+      pass: "zzzz"
+    enable_logging: 0
+    recommendation_url: "http://openadhl.addi.dk/1.1/"
     search:
-      automatic_active: 1
-      master_server: "https://staging.randersbib.dk/data/autodata.txt"
-      webtrekk_server_feed: "https://staging.randersbib.dk/data/searchdata.csv"
+      autocomplete_method: "facets"
+      autocomplete_suggestion_url: "http://opensuggestion.addi.dk/b3.5_2.0/"
 
-fbs:
-  endpoint: "https://cicero-fbs.com/rest/"
-  agency: "DK-xxxxxx"
-  username: "xxxx"
-  password: "yyyy"
-  enable_reservation_deletion: 1
-  holdings_suffix_type: "shelf_mark"
-  branches_blacklist:
-    - "FBS-751010"
-  user_branches_blacklist:
-    - "FBS-751010"
-    - "FBS-751031"
-    - "FBS-751009"
-  holdings_branches_blacklist:
-    - "FBS-751010"
-    - "FBS-751010"
-    - "FBS-751024"
+  ding:
+    ting_frontend_group_holdings_available: "open"
+    adgangsplatformen:
+      settings:
+        array: 1
+        clientId: ''
+        clientSecret: ''
+        auth_client:
+          authClientId: ''
+          authClientSecret: ''
+        redirectUri: "https://www.aakb.dk/adgangsplatformen/callback"
+        urlAuthorize: "https://login.bib.dk/oauth/authorize"
+        urlAccessToken: "https://login.bib.dk/oauth/token/"
+        urlResourceOwnerDetails: "https://login.bib.dk/userinfo/"
+        urlLogout: "https://login.bib.dk/logout/"
+        singleLogout: 1
+        automaticallyAgency: 1
+        singleLogoutOrigin: "https://login.bib.dk/"
+        revoke: "https://login.bib.dk/oauth/revoke"
 
-opensearch:
-  url: "https://opensearch.addi.dk/b3.5_5.2/"
-  use_auth: 1
-  search_profile: "opac"
-  auth:
-    group: "xxxxx"
-    name: "yyyy"
-    pass: "zzzz"
-  enable_logging: 0
-  recommendation_url: "http://openadhl.addi.dk/1.1/"
-  search:
-    autocomplete_method: "facets"
-    autocomplete_suggestion_url: "http://opensuggestion.addi.dk/b3.5_2.0/"
-
-ding:
-  ting_frontend_group_holdings_available: "open"
-  adgangsplatformen:
-    settings:
-      array: 1
-      clientId: ''
-      clientSecret: ''
-      auth_client:
-        authClientId: ''
-        authClientSecret: ''
-      redirectUri: "https://www.aakb.dk/adgangsplatformen/callback"
-      urlAuthorize: "https://login.bib.dk/oauth/authorize"
-      urlAccessToken: "https://login.bib.dk/oauth/token/"
-      urlResourceOwnerDetails: "https://login.bib.dk/userinfo/"
-      urlLogout: "https://login.bib.dk/logout/"
-      singleLogout: 1
-      automaticallyAgency: 1
-      singleLogoutOrigin: "https://login.bib.dk/"
-      revoke: "https://login.bib.dk/oauth/revoke"
-
-ding_adgangsplatformen_token:
-  client:
-    id: 'xxxx'
-    secret: 'yyyy'
+  ding_adgangsplatformen_token:
+    client:
+      id: 'xxxx'
+      secret: 'yyyy'
 
 modules:
   enable:

--- a/modules/ding_config_import/example.config.yml
+++ b/modules/ding_config_import/example.config.yml
@@ -1,4 +1,79 @@
 ---
+ting:
+  agency: "DK-xxxxxx"
+  infomedia_url: "https://useraccessinfomedia.addi.dk/1.5/"
+  search_form_style: "extended"
+  covers:
+    ddb_url: "http://cover.dandigbib.org"
+    ddb_enable_logging: 1
+    ddb_development_token: "INSERT TOKEN"
+  language_default: "Dansk"
+  smart:
+    search:
+      automatic_active: 1
+      master_server: "https://staging.randersbib.dk/data/autodata.txt"
+      webtrekk_server_feed: "https://staging.randersbib.dk/data/searchdata.csv"
+
 fbs:
-  endpoint: https://cicero-fbs.com/rest/
-  agency: DK-775100
+  endpoint: "https://cicero-fbs.com/rest/"
+  agency: "DK-xxxxxx"
+  username: "xxxx"
+  password: "yyyy"
+  enable_reservation_deletion: 1
+  holdings_suffix_type: "shelf_mark"
+  branches_blacklist:
+    - "FBS-751010"
+  user_branches_blacklist:
+    - "FBS-751010"
+    - "FBS-751031"
+    - "FBS-751009"
+  holdings_branches_blacklist:
+    - "FBS-751010"
+    - "FBS-751010"
+    - "FBS-751024"
+
+opensearch:
+  url: "https://opensearch.addi.dk/b3.5_5.2/"
+  use_auth: 1
+  search_profile: "opac"
+  auth:
+    group: "xxxxx"
+    name: "yyyy"
+    pass: "zzzz"
+  enable_logging: 0
+  recommendation_url: "http://openadhl.addi.dk/1.1/"
+  search:
+    autocomplete_method: "facets"
+    autocomplete_suggestion_url: "http://opensuggestion.addi.dk/b3.5_2.0/"
+
+ding:
+  ting_frontend_group_holdings_available: "open"
+  adgangsplatformen:
+    settings:
+      array: 1
+      clientId: ''
+      clientSecret: ''
+      auth_client:
+        authClientId: ''
+        authClientSecret: ''
+      redirectUri: "https://www.aakb.dk/adgangsplatformen/callback"
+      urlAuthorize: "https://login.bib.dk/oauth/authorize"
+      urlAccessToken: "https://login.bib.dk/oauth/token/"
+      urlResourceOwnerDetails: "https://login.bib.dk/userinfo/"
+      urlLogout: "https://login.bib.dk/logout/"
+      singleLogout: 1
+      automaticallyAgency: 1
+      singleLogoutOrigin: "https://login.bib.dk/"
+      revoke: "https://login.bib.dk/oauth/revoke"
+
+ding_adgangsplatformen_token:
+  client:
+    id: 'xxxx'
+    secret: 'yyyy'
+
+modules:
+  enable:
+    - ding_user_form
+  disable:
+    - ding_adgangsplatformen
+    - ding_registration

--- a/modules/ding_libs/ding_libs.module
+++ b/modules/ding_libs/ding_libs.module
@@ -263,8 +263,8 @@ function ding_libs_libraries_info() {
     'yaml' => array(
       'name' => 'Symfony YAML',
       'vendor url' => 'https://symfony.com/doc/current/components/yaml.html',
-      'download url' => 'https://github.com/symfony/yaml/archive/v5.2.0.tar.gz',
-      'version' => '5.2',
+      'download url' => 'https://github.com/symfony/yaml/archive/v3.4.47.tar.gz',
+      'version' => '3.4',
       'xautoload' => function ($adapter) {
         $adapter->composerJson('composer.json');
       },

--- a/modules/ding_libs/ding_libs.module
+++ b/modules/ding_libs/ding_libs.module
@@ -260,5 +260,14 @@ function ding_libs_libraries_info() {
         'js' => array('fabric.js'),
       ),
     ),
+    'yaml' => array(
+      'name' => 'Symfony YAML',
+      'vendor url' => 'https://symfony.com/doc/current/components/yaml.html',
+      'download url' => 'https://github.com/symfony/yaml/archive/v5.2.0.tar.gz',
+      'version' => '5.2',
+      'xautoload' => function ($adapter) {
+        $adapter->composerJson('composer.json');
+      },
+    ),
   );
 }

--- a/project.make
+++ b/project.make
@@ -674,3 +674,9 @@ libraries[fabric][download][type] = "get"
 libraries[fabric][download][url] = https://cdnjs.cloudflare.com/ajax/libs/fabric.js/3.3.2/fabric.js
 libraries[fabric][directory_name] = "fabric"
 libraries[fabric][destination] = "libraries"
+
+; Library used by Configuration import (older version to be able to run on PHP 5.6).
+libraries[yaml][download][type] = "get"
+libraries[yaml][download][url] = https://github.com/symfony/yaml/archive/v3.4.47.tar.gz
+libraries[yaml][directory_name] = "yaml"
+libraries[yaml][destination] = "libraries"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4925

#### Description

Import configuration via YAML file upload (with/without flattening the arrays, mostly for readability for PL's). The modules comes with an YAML example file and readme about the modules usage.

#### Screenshot of the result

![Screenshot 2020-12-08 at 12 30 04](https://user-images.githubusercontent.com/111397/101478533-202ebc00-3951-11eb-80b2-0cf8ce73daa4.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
