### PR TITLE
Core: Disable test of sorting search results by publication date

### DIFF
--- a/tests/behat/features/searching/01-searching.feature
+++ b/tests/behat/features/searching/01-searching.feature
@@ -89,7 +89,7 @@ Feature: SEEK redroute 01
     When I sort the search result on "title_descending"
     Then paging allows to get all the results
 
-  @api @seek013 @seekNologin @regression
+  @api @seek013 @seekNologin @regression @no_ci
   Scenario: S013 Check sorting for published date descending
     Given I have searched for "phrase.titleSeries=B*"
     And I set control mode for "searchMaxPages" to be "2"


### PR DESCRIPTION
This start failing as search results containing works are sorted by
objects which are not immediately visible from the search result
page. The current implementation of the test checks on years on the
search page and thus fail.

Temporarily disable the test while we figure out whether the current
behavior is intentional.