### PR TITLE
5031: Don't disable field_term_page

### DIFF
--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.module
@@ -300,7 +300,6 @@ function ding_sections_term_panel_form_taxonomy_form_term_alter(&$form, &$form_s
       '#title' => t('Term page'),
       '#group' => 'section_tabs',
     );
-    $form['field_term_page']['#disabled'] = TRUE;
 
     $form['ding_sections']['term_panel']['field_term_page'] = $form['field_term_page'];
     unset($form['field_term_page']);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5031

#### Description

Don't disable field_term_page on section forms.

It caused the term page to be disabled on second save. Why one would
want to disable it in the first place is unknown.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
