### PR TITLE
5035: Rebuild permissions when deploying to PR environments

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -111,6 +111,7 @@ hooks:
     set -e
     cd public
     drush -y updatedb
+    drush secure-permissions-rebuild
     drush css-generate
     drush cc all
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5035

#### Description

This ensures that permissions in the environment always reflect what
is defined in the codebase.

The procedure should match the deployment procedure in production
environments.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.