### PR TITLE
4953: added visibility hidden to search-is-not-open

### DIFF
--- a/themes/ddbasic/sass/components/header.scss
+++ b/themes/ddbasic/sass/components/header.scss
@@ -728,3 +728,7 @@
     }
   }
 }
+
+.search-form-extended.extended-search-is-not-open .site-header .pane-search-form {
+  visibility: hidden;
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4953

#### Description

Right now, the search bar is hidden by a combination of z-index and absolute positioning. I have added visibility: hidden to the class: extended-search-is-not-open

#### Screenshot of the result

No screenshots

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
