### PR TITLE
Remove wrong bin argument

### DIFF
--- a/modules/ting_covers/ting_covers.module
+++ b/modules/ting_covers/ting_covers.module
@@ -143,7 +143,7 @@ function ting_covers_get(array $requested_covers) {
     }
 
     // Determine if the local id is a known negative.
-    if (cache_get('ting_covers:' . $id, FALSE)) {
+    if (cache_get('ting_covers:' . $id)) {
       continue;
     }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5054

#### Description

Cache bin was set to false, which is just wrong.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
