### PR TITLE
5013: Fix overriding title

### DIFF
--- a/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
+++ b/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
@@ -401,7 +401,9 @@ function _ding_nodelist_content_type_form_save(&$form_state, $rebuild = FALSE) {
 
   $form_state['conf']['limit'] = $form_state['values']['limit'];
   $form_state['conf']['more_links'] = !empty($form_state['values']['more_links']) ? $form_state['values']['more_links'] : array();
+  $form_state['conf']['override_title'] = $form_state['values']['override_title'];
   $form_state['conf']['override_title_text'] = $form_state['values']['override_title_text'];
+  $form_state['conf']['override_title_heading'] = $form_state['values']['override_title_heading'];
   $form_state['conf']['selected_nodes'] = !empty($form_state['values']['selected_nodes']) && $form_state['conf']['nodes_switch'] ? $form_state['values']['selected_nodes'] : array();
   $form_state['conf']['sort_field'] = $form_state['values']['sort_field'];
   $form_state['conf']['sort_order'] = $form_state['values']['sort_order'];


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5013

#### Description

Shouldn't be necessary, ctools should handle the override_title
elements, but apparently there's so much mucking about in the nodelist
form that it get's confused.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
