### PR TITLE
4744: Improve display of status page buttons

### DIFF
--- a/themes/ddbasic/sass/base/standard.scss
+++ b/themes/ddbasic/sass/base/standard.scss
@@ -76,8 +76,7 @@ body {
 
       // If there are too many links, we need to add even more padding.
       &#{$_selector}.has-second-level-menu.secondary-menu-below-main,
-      &#{$_selector}.has-second-level-menu.has-multiline-main-menu,
-      &#{$_selector}.secondary-menu-below-main {
+      &#{$_selector}.has-second-level-menu.has-multiline-main-menu {
         padding-top: $_value + $second-level-menu-height + $search-form-extended-height;
       }
     }

--- a/themes/ddbasic/sass/components/panel/account.scss
+++ b/themes/ddbasic/sass/components/panel/account.scss
@@ -42,7 +42,6 @@
     position: absolute;
     top: 0;
     z-index: $z-above;
-    padding: 10px;
     background-color: $grey-dark;
 
     &.is-bottom {
@@ -81,6 +80,7 @@
 
     .action-buttons {
       width: 100%;
+      margin-top: 10px;
       padding-left: 180px;
 
       // Tablet
@@ -91,32 +91,30 @@
       // Mobile
       @include media($mobile) {
         width: 100%;
-        padding-left: 0;
+        padding: 10px;
       }
       .action-button {
-        margin-right: getGutter(8);
+        margin-right: 10px;
+        margin-bottom: 10px;
         padding: 0;
         float: left;
+        input[type="submit"] {
+          margin-bottom: 0;
+        }
         &:nth-child(2) {
           margin-right: 0;
         }
-        &:nth-child(3) {
-          margin-top: 10px;
+
+        input[type="submit"], a {
+          padding: 10px;
+          height: auto;
         }
 
-        @include media($mobile) {
-          margin-bottom: 10px;
-          &:nth-child(3) {
-            margin-top: 0;
-          }
-        }
         &.action-all {
           a {
             @include font('base');
             @include transition(background-color $speed $ease, color $speed $ease);
             display: block;
-            height: $element-height;
-            padding: 23px 15px 18px;
             border: none;
             border-radius: $round-corner;
             color: $charcoal-opacity-dark;
@@ -143,6 +141,9 @@
           }
         }
         &.delete-all {
+          // Ensure delete button on new row or else the padding-top calculation
+          // from account.js will be wrong.
+          clear: both;
           a {
             color: white;
             background-color: $red;
@@ -152,6 +153,10 @@
               }
             }
           }
+        }
+
+        @include media($mobile) {
+          clear: both;
         }
       }
     }

--- a/themes/ddbasic/sass/configuration/_grid-settings.scss
+++ b/themes/ddbasic/sass/configuration/_grid-settings.scss
@@ -9,7 +9,7 @@ $gutter: 28px;
 $grid-columns: 12;
 $max-width: 1124px;
 
-$notebook: new-breakpoint(max-width 1100px 12);
-$tablet-min-width: new-breakpoint(min-width 950px 12);
-$tablet: new-breakpoint(max-width 950px 12);
+$notebook: new-breakpoint(max-width 1124px 12);
+$tablet-min-width: new-breakpoint(min-width 1050px 12);
+$tablet: new-breakpoint(max-width 1050px 12);
 $mobile: new-breakpoint(max-width 600px 12);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4744

#### Description

Improve display of the status page buttons on reservations and loans. Prevent them from taking up to much screen space.

Also includes some fixes and adjustments to improve screen space when secondary menu is pushed below main menu.

#### Screenshot of the result

![4744-new-reservation-tools-layout-1](https://user-images.githubusercontent.com/5011234/106498907-32942480-64c0-11eb-8aa1-c824be34a34f.png)

![4744-new-reservation-tools-layout-2](https://user-images.githubusercontent.com/5011234/106498923-3758d880-64c0-11eb-8ee6-15eaa782bdab.png)

![4744-unwanted-gap](https://user-images.githubusercontent.com/5011234/106498929-3aec5f80-64c0-11eb-93b3-e415709e821f.png)

![4744-unwanted-gap-2](https://user-images.githubusercontent.com/5011234/106498935-3cb62300-64c0-11eb-869a-6b424f025df5.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
