### PR TITLE
1370: Improve periodical sorting

### DIFF
--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -415,22 +415,15 @@ function theme_ding_holdings_periodical($variables) {
   // Remember if this periodical was reservable in any of the issues.
   $reservable = FALSE;
 
-  // The provider is expected to return issues as arrays of volumes, where each
-  // volume can contain several issues. We can't know how the provider choose to
-  // key and order these arrays, but we would like them to appear with latest
-  // volumes and issues first.
-  // So we reverse key sort both the volumes array and the nested issues arrays,
-  // and since we can't know wether we're dealing with strings, numbers or a
-  // hybrid of both, we use PHP's natural sort to ensure that the periodical
-  // issues is presented in a correct order.
-  krsort($variables['issues'], SORT_NATURAL);
+  // Sort the top level volume of issues by key.
+  ding_availability_sort_periodical_issues($variables['issues']);
 
   foreach ($variables['issues'] as $volume => $issues) {
     $iss = array();
     $i = 0;
 
-    // Sort these volume issues in natural order. See comment above.
-    krsort($issues, SORT_NATURAL);
+    // Sort the issues in this volume by key.
+    ding_availability_sort_periodical_issues($issues);
 
     foreach ($issues as $key => $availability) {
       $issue = $key;
@@ -520,6 +513,54 @@ function theme_ding_holdings_periodical($variables) {
   }
 
   return $prefix . theme('item_list', array('items' => $items, 'attributes' => array('class' => 'ding-periodical-issues')));
+}
+
+/**
+ * Sort an array of issues (or volume of issues) by their key.
+ *
+ * The provider is expected to return issues as arrays of volumes, where each
+ * volume can contain several issues. We can't know how the provider choose to
+ * key and order these arrays, but we would like them to appear with latest
+ * volumes and issues first.
+ *
+ * @param array $issues
+ *   Array of issues/volumes of issues that needs to be sorted by key.
+ */
+function ding_availability_sort_periodical_issues(&$issues) {
+  $month_names = array_map('drupal_strtolower', [
+    t('January'), t('Jan'), 'January', 'Jan',
+    t('February'), t('Feb'), 'February', 'Feb',
+    t('March'), t('Mar'), 'March', 'Mar',
+    t('April'), t('Apr'), 'April', 'Apr',
+    t('May'), 'May',
+    t('June'), t('Jun'), 'June', 'Jun',
+    t('July'), t('Jul'), 'July', 'Jul',
+    t('August'), t('Aug'), 'August', 'Aug',
+    t('September'), t('Sep'), 'September', 'Sep',
+    t('October'), t('Oct'), 'October', 'Oct',
+    t('November'), t('November'), 'November', 'Nov',
+    t('December'), t('Dec'), 'December', 'Dec',
+  ]);
+  $issues_keyed_by_month_name = array_filter($issues, function ($issue_key) use ($month_names) {
+    return in_array(drupal_strtolower($issue_key), $month_names);
+  }, ARRAY_FILTER_USE_KEY);
+
+  // Only if every issue/volume is keyed by month name do we sort by it.
+  if (count($issues_keyed_by_month_name) === count($issues)) {
+    // Flip it now to get easier access to month names' ordinal values.
+    $month_names = array_flip($month_names);
+    uksort($issues, function($a, $b) use ($month_names) {
+      // Notice we reverse comparison since we want later months to come first.
+      return $month_names[drupal_strtolower($b)] - $month_names[drupal_strtolower($a)];
+    });
+  }
+  else {
+    // Otherwise just use reverse key sort. Since we can't know wether we're
+    // dealing with strings, numbers or a hybrid of both, we use PHP's natural
+    // sort to ensure that the periodical issues is presented in a meaningful
+    // order regardless of key type.
+    krsort($issues, SORT_NATURAL);
+  }
 }
 
 /**

--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -294,7 +294,6 @@ function ding_availability_holdings(array $provider_ids) {
     }
     elseif (!empty($item['issues'])) {
       $issues = $item['issues'];
-      krsort($issues);
 
       // Try to load the entity, so we can make reserve buttons if the
       // periodical issues is reservable.
@@ -416,9 +415,22 @@ function theme_ding_holdings_periodical($variables) {
   // Remember if this periodical was reservable in any of the issues.
   $reservable = FALSE;
 
+  // The provider is expected to return issues as arrays of volumes, where each
+  // volume can contain several issues. We can't know how the provider choose to
+  // key and order these arrays, but we would like them to appear with latest
+  // volumes and issues first.
+  // So we reverse key sort both the volumes array and the nested issues arrays,
+  // and since we can't know wether we're dealing with strings, numbers or a
+  // hybrid of both, we use PHP's natural sort to ensure that the periodical
+  // issues is presented in a correct order.
+  krsort($variables['issues'], SORT_NATURAL);
+
   foreach ($variables['issues'] as $volume => $issues) {
     $iss = array();
     $i = 0;
+
+    // Sort these volume issues in natural order. See comment above.
+    krsort($issues, SORT_NATURAL);
 
     foreach ($issues as $key => $availability) {
       $issue = $key;

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -253,8 +253,18 @@ function fbs_availability_holdings($provider_ids) {
             $tmp_issues[$key]['total'] += 1;
           }
           else {
+            // Generate "vol key". Both volume and volumeNumber can be empty so
+            // if one is empty just use the other or if both are present we use
+            // "volume-volumeNumber".
+            $separator = '';
+            $volume = $material->periodical->volume;
+            $volume_number = $material->periodical->volumeNumber;
+            if (!empty($volume) && !empty($volume_number)) {
+              $separator = '-';
+            }
+
             $tmp_issues[$key] = array(
-              'vol' => $material->periodical->volume . (!empty($material->periodical->volumeNumber) ? '-' . $material->periodical->volumeNumber : ''),
+              'vol' => $volume . $separator . $volume_number,
               'year' => $material->periodical->volumeYear,
               'available' => $material->available ? 1 : 0,
               'total' => 1,

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -256,15 +256,12 @@ function fbs_availability_holdings($provider_ids) {
             // Generate "vol key". Both volume and volumeNumber can be empty so
             // if one is empty just use the other or if both are present we use
             // "volume-volumeNumber".
-            $separator = '';
-            $volume = $material->periodical->volume;
-            $volume_number = $material->periodical->volumeNumber;
-            if (!empty($volume) && !empty($volume_number)) {
-              $separator = '-';
-            }
-
+            $volume_string = implode('-', array_filter([
+              $material->periodical->volume,
+              $material->periodical->volumeNumber,
+            ]));
             $tmp_issues[$key] = array(
-              'vol' => $volume . $separator . $volume_number,
+              'vol' => $volume_string,
               'year' => $material->periodical->volumeYear,
               'available' => $material->available ? 1 : 0,
               'total' => 1,


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/1370

#### Description

We are currently sorting each periodical "volume", but not the issues in each volume. This PR fixes that.

Additionally we swicth to using PHP's natural sort in both cases, since we can't know how the provider keys the periodical arrays. For example FBS uses both the volume and volume-number returned by the API to form a string as key for each issue. Ding availability also makes no assumptions about what the provider uses as keys for each volume. FBS uses years but it could be anything. Since we don't know if we can sort numerically, natural sort is a good solution since it will order the numbers correct in the string: http://sourcefrog.net/projects/natsort/.

If we determine that every issue (or volume of issue) is keyed by month name, we instead sort by month name chronologically.

Also removes the unneeded hyphen prefix in the periodical holdings display when only using volume number in FBS. See screenshots below.

NOTICE: There's some mismatch between the terminology in Ding availability and FBS. Ding availability expects the provider to return an array of volumes each with a nested array of issues. But FBS module gets year, volume and volumeNumber from the API and uses year for key in the returned volumes array and volume+volumeNumber for keys in the issues array. I think it best just to leave it at that and not change anything in Ding availability API at this point.

#### Screenshot of the result

![1370-fixed](https://user-images.githubusercontent.com/5011234/106636902-8b2bf600-6582-11eb-85ab-50174ed62ee9.png)

![1370-volume-number-prefix-fixed](https://user-images.githubusercontent.com/5011234/106636959-8f581380-6582-11eb-85d8-27aa8a544f5d.png)

**Sort by month name**:

![1370-periodical-sort-by-month-name](https://user-images.githubusercontent.com/5011234/115744462-e0fa8800-a392-11eb-87da-bc5015dbbb8b.png)

**BEFORE THE FIX ABOVE (Notice the prefix hyphens):**

![1370-unwanted-volume-number-prefix](https://user-images.githubusercontent.com/5011234/106637141-a0a12000-6582-11eb-8aab-fe474d065057.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
