### PR TITLE
5061: Added support for wildcard session cache clear

### DIFF
--- a/modules/ding_loan/plugins/content_types/loans.inc
+++ b/modules/ding_loan/plugins/content_types/loans.inc
@@ -447,10 +447,10 @@ function ding_loan_loans_form_submit($form, &$form_state) {
     }
   }
 
-  // If any loans was succesfully renewed; clear session cache and remember
+  // If any loans was successfully renewed; clear session cache and remember
   // these loans throughout the session.
   if ($clear_cache && module_exists('ding_session_cache')) {
-    ding_session_cache_clear('ding_loan', 'list');
+    ding_session_cache_clear('ding_loan', 'list-', TRUE);
     ding_session_cache_set('ding_loan', 'renewed_ids', $renewed_ids);
   }
 }

--- a/modules/ding_session_cache/ding_session_cache.module
+++ b/modules/ding_session_cache/ding_session_cache.module
@@ -112,8 +112,7 @@ function ding_session_cache_get($module, $cid, $default = FALSE) {
  * @param string $cid
  *   Index data is stored under.
  * @param bool $wildcard
- *   If TRUE, the $cid argument must contain a string value and cache IDs
- *   starting with $cid are deleted.
+ *   If TRUE cache IDs starting with $cid are deleted.
  */
 function ding_session_cache_clear($module, $cid, $wildcard = FALSE) {
   cache_clear_all(_ding_session_cache_get_cid($module, $cid), 'cache_ding_session_cache', $wildcard);
@@ -153,8 +152,10 @@ function _ding_session_cache_enabled($module) {
 }
 
 /**
- * Get expire timestamp based on the maximum cache lifetime for the module
- * given as parameter.
+ * Get expire timestamp.
+ *
+ * The timestamp is based on the maximum cache lifetime for the module given
+ * as parameter.
  *
  * @param string $module
  *   Name of the module to get the expire for.

--- a/modules/ding_session_cache/ding_session_cache.module
+++ b/modules/ding_session_cache/ding_session_cache.module
@@ -111,9 +111,12 @@ function ding_session_cache_get($module, $cid, $default = FALSE) {
  *   Name of the module that the date is stored under (prefix).
  * @param string $cid
  *   Index data is stored under.
+ * @param bool $wildcard
+ *   If TRUE, the $cid argument must contain a string value and cache IDs
+ *   starting with $cid are deleted.
  */
-function ding_session_cache_clear($module, $cid) {
-  cache_clear_all(_ding_session_cache_get_cid($module, $cid), 'cache_ding_session_cache', FALSE);
+function ding_session_cache_clear($module, $cid, $wildcard = FALSE) {
+  cache_clear_all(_ding_session_cache_get_cid($module, $cid), 'cache_ding_session_cache', $wildcard);
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5061

#### Description

After changes to the session cache set in loans list (https://github.com/ding2/ding2/pull/1618) so loans are cached. A cache key is used with set that is not available when clearing cache. So wildcard clear is added in this PR.  

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
