### PR TITLE
4931: Add aria-labelledby to news list article elements

### DIFF
--- a/themes/ddbasic/templates/node/node--ding-news--view-mode--teaser.tpl.php
+++ b/themes/ddbasic/templates/node/node--ding-news--view-mode--teaser.tpl.php
@@ -86,12 +86,12 @@
  * @see template_process()
  */
 ?>
-<article class="<?php print $classes; ?>"<?php print $attributes; ?>>
+<article class="<?php print $classes; ?>" aria-labelledby="news-article-<?php print $node->nid; ?>" <?php print $attributes; ?>>
   <a href="<?php print $node_url; ?>">
     <div class="inner">
       <?php print $news_teaser_image; ?>
       <div class="news-text">
-        <h3 class="title"><?php print $title; ?></h3>
+        <h3 class="title" id="news-article-<?php print $node->nid; ?>"><?php print $title; ?></h3>
         <div class="category-and-submitted">
           <?php print render($content['field_ding_news_category']); ?>
           <div class="info-dash">-</div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4931

#### Description

For better accessibility we add aria-labelledby to news list article elements, pointing to the title of the element.

#### Screenshot of the result

Screenshot of code and enabled Wave extension.
![Screenshot 2021-02-08 at 14 09 32](https://user-images.githubusercontent.com/332915/107224185-6539a200-6a17-11eb-88f4-3662c7762044.png)


#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
