### PR TITLE
5059: off-site payments

### DIFF
--- a/modules/ding_debt/ding_debt.admin.inc
+++ b/modules/ding_debt/ding_debt.admin.inc
@@ -9,6 +9,45 @@
  * Settings form.
  */
 function ding_debt_settings_form($form, $form_state) {
+  $form['introtext'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Introtext'),
+    '#tree' => FALSE,
+    '#description' => t('Text displayed at the top of the page, useful for explaining the move to a new system.'),
+  ];
+
+  $form['introtext']['ding_debt_show_introtext'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show introtext'),
+    '#default_value' => variable_get('ding_debt_show_introtext', TRUE),
+  ];
+
+  $ding_debt_introtext = variable_get('ding_debt_introtext', _ding_debt_introtext_default());
+
+  // We have to apply states to a wrapper, else it will only apply it to the
+  // text field and not the text format selector. As suggested here:
+  // https://www.drupal.org/project/drupal/issues/997826#comment-9119483
+  $form['introtext']['wrapper'] = [
+    '#type' => 'container',
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_show_introtext"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['introtext']['wrapper']['ding_debt_introtext'] = [
+    '#type' => 'text_format',
+    '#title' => t('Introtext'),
+    '#default_value' => $ding_debt_introtext['value'],
+    '#format' => $ding_debt_introtext['format'],
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_show_introtext"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
   $form['internal'] = [
     '#type' => 'fieldset',
     '#title' => t('Payable on site'),
@@ -110,50 +149,6 @@ function ding_debt_settings_form($form, $form_state) {
     '#title' => t('Payment button url'),
     '#description' => t('URL for the payment button.'),
     '#default_value' => variable_get('ding_debt_external_button_url', ''),
-  ];
-
-  $form['external']['introtext'] = [
-    '#type' => 'fieldset',
-    '#title' => t('Introtext'),
-    '#tree' => FALSE,
-    '#description' => t('Text displayed at the top of the page, useful for explaining the move to a new system.'),
-    '#states' => [
-      'visible' => [
-        ':input[name="ding_debt_enable_external"]' => ['checked' => TRUE],
-      ],
-    ],
-  ];
-
-  $form['external']['introtext']['ding_debt_external_show_introtext'] = [
-    '#type' => 'checkbox',
-    '#title' => t('Show introtext'),
-    '#default_value' => variable_get('ding_debt_external_show_introtext', TRUE),
-  ];
-
-  $ding_debt_external_introtext = variable_get('ding_debt_external_introtext', _ding_debt_external_introtext_default());
-
-  // We have to apply states to a wrapper, else it will only apply it to the
-  // text field and not the text format selector. As suggested here:
-  // https://www.drupal.org/project/drupal/issues/997826#comment-9119483
-  $form['external']['introtext']['wrapper'] = [
-    '#type' => 'container',
-    '#states' => [
-      'visible' => [
-        ':input[name="ding_debt_external_show_introtext"]' => ['checked' => TRUE],
-      ],
-    ],
-  ];
-
-  $form['external']['introtext']['wrapper']['ding_debt_external_introtext'] = [
-    '#type' => 'text_format',
-    '#title' => t('Introtext'),
-    '#default_value' => $ding_debt_external_introtext['value'],
-    '#format' => $ding_debt_external_introtext['format'],
-    '#states' => [
-      'visible' => [
-        ':input[name="ding_debt_external_show_introtext"]' => ['checked' => TRUE],
-      ],
-    ],
   ];
 
   $form['external']['extra_information'] = [

--- a/modules/ding_debt/ding_debt.admin.inc
+++ b/modules/ding_debt/ding_debt.admin.inc
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * @file
+ * Administration for ding_debts.
+ */
+
+/**
+ * Settings form.
+ */
+function ding_debt_settings_form($form, $form_state) {
+  $form['internal'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Payable on site'),
+    '#description' => t('Settings for debts that can be payed on site using DIBS.'),
+    '#tree' => FALSE,
+  ];
+
+  $form['internal']['ding_debt_enable_internal'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show list'),
+    '#description' => t('Shows list of debts payable on site.'),
+    '#default_value' => variable_get('ding_debt_enable_internal', TRUE),
+  ];
+
+  $form['internal']['ding_debt_internal_title'] = [
+    '#type' => 'textfield',
+    '#title' => t('Title'),
+    '#description' => t('Title for section, only shown if off-site debts is also shown.'),
+    '#default_value' => variable_get('ding_debt_internal_title', ''),
+    '#states' => [
+      'enabled' => [
+        ':input[name="ding_debt_enable_internal"]' => ['checked' => TRUE],
+        ':input[name="ding_debt_enable_external"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['internal']['ding_debt_enable_internal_button'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show payment button'),
+    '#description' => t('Shows payment button for debts payable on site.'),
+    '#default_value' => variable_get('ding_debt_enable_internal_button', TRUE),
+    '#states' => [
+      'enabled' => [
+        ':input[name="ding_debt_enable_internal"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Payable off-site'),
+    '#description' => t('Settings for debts that can be payed on an external site.'),
+    '#tree' => FALSE,
+  ];
+
+  $form['external']['ding_debt_enable_external'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show list'),
+    '#description' => t('Shows list of debts payable off-site.'),
+    '#default_value' => variable_get('ding_debt_enable_external', FALSE),
+  ];
+
+  $form['external']['ding_debt_external_title'] = [
+    '#type' => 'textfield',
+    '#title' => t('Title'),
+    '#description' => t('Title for section, only shown if on site debts is also shown.'),
+    '#default_value' => variable_get('ding_debt_external_title', ''),
+    '#states' => [
+      'enabled' => [
+        ':input[name="ding_debt_enable_external"]' => ['checked' => TRUE],
+        ':input[name="ding_debt_enable_internal"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['ding_debt_enable_external_button'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show payment button'),
+    '#description' => t('Shows payment button for debts payable off-site.'),
+    '#default_value' => variable_get('ding_debt_enable_external_button', FALSE),
+    '#states' => [
+      'enabled' => [
+        ':input[name="ding_debt_enable_external"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['button'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Payment button'),
+    '#tree' => FALSE,
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_enable_external_button"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['button']['ding_debt_external_button_text'] = [
+    '#type' => 'textfield',
+    '#title' => t('Payment button text'),
+    '#description' => t('Label for the payment button.'),
+    '#default_value' => variable_get('ding_debt_external_button_text', ''),
+  ];
+
+  $form['external']['button']['ding_debt_external_button_url'] = [
+    '#type' => 'textfield',
+    '#title' => t('Payment button url'),
+    '#description' => t('URL for the payment button.'),
+    '#default_value' => variable_get('ding_debt_external_button_url', ''),
+  ];
+
+  $form['external']['introtext'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Introtext'),
+    '#tree' => FALSE,
+    '#description' => t('Text displayed at the top of the page, useful for explaining the move to a new system.'),
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_enable_external"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['introtext']['ding_debt_external_show_introtext'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show introtext'),
+    '#default_value' => variable_get('ding_debt_external_show_introtext', TRUE),
+  ];
+
+  $ding_debt_external_introtext = variable_get('ding_debt_external_introtext', _ding_debt_external_introtext_default());
+
+  // We have to apply states to a wrapper, else it will only apply it to the
+  // text field and not the text format selector. As suggested here:
+  // https://www.drupal.org/project/drupal/issues/997826#comment-9119483
+  $form['external']['introtext']['wrapper'] = [
+    '#type' => 'container',
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_external_show_introtext"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['introtext']['wrapper']['ding_debt_external_introtext'] = [
+    '#type' => 'text_format',
+    '#title' => t('Introtext'),
+    '#default_value' => $ding_debt_external_introtext['value'],
+    '#format' => $ding_debt_external_introtext['format'],
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_external_show_introtext"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['extra_information'] = [
+    '#type' => 'fieldset',
+    '#title' => t('Extra information'),
+    '#description' => t('Extra information displayed after the list. Useful for terms, information about delays in processing, etc.'),
+    '#tree' => FALSE,
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_enable_external"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['extra_information']['ding_debt_external_show_extra_information'] = [
+    '#type' => 'checkbox',
+    '#title' => t('Show extra information'),
+    '#default_value' => variable_get('ding_debt_external_show_extra_information', TRUE),
+  ];
+
+  $ding_debt_external_extra_information = variable_get('ding_debt_external_extra_information', _ding_debt_external_extra_information_default());
+
+  $form['external']['extra_information']['wrapper'] = [
+    '#type' => 'container',
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_external_show_extra_information"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  $form['external']['extra_information']['wrapper']['ding_debt_external_extra_information'] = [
+    '#type' => 'text_format',
+    '#title' => t('Extra information'),
+    '#default_value' => $ding_debt_external_extra_information['value'],
+    '#format' => $ding_debt_external_extra_information['format'],
+    '#states' => [
+      'visible' => [
+        ':input[name="ding_debt_external_show_extra_information"]' => ['checked' => TRUE],
+      ],
+    ],
+  ];
+
+  return system_settings_form($form);
+}
+
+/**
+ * Form validate function.
+ */
+function ding_debt_settings_form_validate($form, $form_state) {
+  if ($form_state['values']['ding_debt_enable_external_button']) {
+    if (empty($form_state['values']['ding_debt_external_button_text'])) {
+      form_error($form['external']['button']['ding_debt_external_button_text'], t('Button text is required.'));
+    }
+
+    if (empty($form_state['values']['ding_debt_external_button_url'])) {
+      form_error($form['external']['button']['ding_debt_external_button_url'], t('Button link is required.'));
+    }
+  }
+}

--- a/modules/ding_debt/ding_debt.admin.inc
+++ b/modules/ding_debt/ding_debt.admin.inc
@@ -19,7 +19,7 @@ function ding_debt_settings_form($form, $form_state) {
   $form['introtext']['ding_debt_show_introtext'] = [
     '#type' => 'checkbox',
     '#title' => t('Show introtext'),
-    '#default_value' => variable_get('ding_debt_show_introtext', TRUE),
+    '#default_value' => variable_get('ding_debt_show_introtext', FALSE),
   ];
 
   $ding_debt_introtext = variable_get('ding_debt_introtext', _ding_debt_introtext_default());
@@ -166,7 +166,7 @@ function ding_debt_settings_form($form, $form_state) {
   $form['external']['extra_information']['ding_debt_external_show_extra_information'] = [
     '#type' => 'checkbox',
     '#title' => t('Show extra information'),
-    '#default_value' => variable_get('ding_debt_external_show_extra_information', TRUE),
+    '#default_value' => variable_get('ding_debt_external_show_extra_information', FALSE),
   ];
 
   $ding_debt_external_extra_information = variable_get('ding_debt_external_extra_information', _ding_debt_external_extra_information_default());

--- a/modules/ding_debt/ding_debt.install
+++ b/modules/ding_debt/ding_debt.install
@@ -9,6 +9,8 @@
  * Implements hook_uninstall().
  */
 function ding_debt_uninstall() {
+  variable_del('ding_debt_show_introtext');
+  variable_del('ding_debt_introtext');
   variable_del('ding_debt_enable_internal');
   variable_del('ding_debt_internal_title');
   variable_del('ding_debt_enable_internal_button');
@@ -17,8 +19,6 @@ function ding_debt_uninstall() {
   variable_del('ding_debt_enable_external_button');
   variable_del('ding_debt_external_button_text');
   variable_del('ding_debt_external_button_url');
-  variable_del('ding_debt_external_show_introtext');
-  variable_del('ding_debt_external_introtext');
   variable_del('ding_debt_external_show_extra_information');
   variable_del('ding_debt_external_extra_information');
 }

--- a/modules/ding_debt/ding_debt.install
+++ b/modules/ding_debt/ding_debt.install
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Install, update and uninstall functions for the ding_debt module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function ding_debt_uninstall() {
+  variable_del('ding_debt_enable_internal');
+  variable_del('ding_debt_internal_title');
+  variable_del('ding_debt_enable_internal_button');
+  variable_del('ding_debt_enable_external');
+  variable_del('ding_debt_external_title');
+  variable_del('ding_debt_enable_external_button');
+  variable_del('ding_debt_external_button_text');
+  variable_del('ding_debt_external_button_url');
+  variable_del('ding_debt_external_show_introtext');
+  variable_del('ding_debt_external_introtext');
+  variable_del('ding_debt_external_show_extra_information');
+  variable_del('ding_debt_external_extra_information');
+}

--- a/modules/ding_debt/ding_debt.module
+++ b/modules/ding_debt/ding_debt.module
@@ -83,9 +83,9 @@ function ding_debt_payment_callback($transaction) {
 }
 
 /**
- * Default value for external payment introtext.
+ * Default value for payment introtext.
  */
-function _ding_debt_external_introtext_default() {
+function _ding_debt_introtext_default() {
   return [
     'value' => '<p>Gebyrer og erstatninger overgår til et nyt system, hvor betalingen sker gennem løsningen Mit betalingsoverblik.</p>',
     'format' => 'ding_wysiwyg',

--- a/modules/ding_debt/ding_debt.module
+++ b/modules/ding_debt/ding_debt.module
@@ -32,9 +32,87 @@ function ding_debt_ding_provider_user() {
 }
 
 /**
+ * Implements hook_permission().
+ */
+function ding_debt_permission() {
+  return [
+    'administer debts settings' => [
+      'title' => t('administer debts settings'),
+    ],
+  ];
+}
+
+/**
+ * Implements hook_menu().
+ */
+function ding_debt_menu() {
+  $items['admin/config/ding/payment'] = [
+    'title' => 'Payment',
+    'description' => 'Configure the payment options.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => ['ding_debt_settings_form'],
+    'access arguments' => ['administer debts settings'],
+    'file' => 'ding_debt.admin.inc',
+  ];
+
+  return $items;
+}
+
+/**
+ * Get the total amount of debts the user has.
+ */
+function ding_debt_count($account = NULL) {
+  $debts = ding_provider_invoke('debt', 'list', $account);
+
+  if (variable_get('ding_debt_enable_internal', TRUE) && variable_get('ding_debt_enable_external', TRUE)) {
+    return count($debts);
+  }
+
+  if (variable_get('ding_debt_enable_internal', TRUE)) {
+    return count(array_filter($debts, '_ding_debt_filter_payable'));
+  }
+
+  return count(array_filter($debts, '_ding_debt_filter_nonpayable'));
+}
+
+/**
  * Callback for successful payment transaction.
  */
 function ding_debt_payment_callback($transaction) {
   return ding_provider_invoke('debt', 'payment_received', $transaction['payment_price'], $transaction['params']['debt_ids'], $transaction['payment_order_id']);
 }
 
+/**
+ * Default value for external payment introtext.
+ */
+function _ding_debt_external_introtext_default() {
+  return [
+    'value' => '<p>Gebyrer og erstatninger overgår til et nyt system, hvor betalingen sker gennem løsningen Mit betalingsoverblik.</p>',
+    'format' => 'ding_wysiwyg',
+  ];
+}
+
+/**
+ * Default value for external payment extra_information.
+ */
+function _ding_debt_external_extra_information_default() {
+  return [
+    'value' => '<p><strong>Bemærk</strong>: Betalte gebyrer registreres først op til 24 timer efter din indbetaling.</p>
+    <p>På Mit Betalingsoverblik kan du altid se en opdateret status på dine betalinger.</p>',
+    'format' => 'ding_wysiwyg',
+  ];
+}
+
+/**
+ * Filter callback function.
+ */
+function _ding_debt_filter_payable($debt) {
+  return $debt->payable;
+}
+
+/**
+ * Filter callback function.
+ */
+function _ding_debt_filter_nonpayable($debt) {
+  return !$debt->payable;
+}

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -18,8 +18,6 @@ $plugin = array(
  */
 function ding_debt_debts_content_type_render($subtype, $conf, $panel_args, $context) {
   $account = isset($context->data) ? $context->data : NULL;
-  $total_amount = 0;
-  $has_invoiced_fees = FALSE;
 
   $block = new stdClass();
   $block->module = 'ding_debt';
@@ -28,20 +26,10 @@ function ding_debt_debts_content_type_render($subtype, $conf, $panel_args, $cont
 
   $debts = ding_provider_invoke('debt', 'list', $account);
 
-  if (count($debts) == TRUE) {
-    foreach ($debts as $debt) {
-      // Invoiced fees can't be paid online.
-      if (!$debt->invoice_number) {
-        $total_amount += $debt->amount;
-        $total_amount -= $debt->amount_paid;
-        $debt->is_invoice = FALSE;
-      }
-      else {
-        $debt->is_invoice = TRUE;
-        $has_invoiced_fees = TRUE;
-      }
-    }
-    $build = ding_provider_get_form('ding_debt_debts_form', $debts, $has_invoiced_fees, $total_amount);
+  if ($debts) {
+    $internal_debts = array_filter($debts, '_ding_debt_filter_payable');
+    $external_debts = array_filter($debts, '_ding_debt_filter_nonpayable');
+    $build = ding_provider_get_form('ding_debt_debts_form', $internal_debts, $external_debts);
     $block->content = render($build);
   }
   else {
@@ -62,53 +50,167 @@ function ding_debt_debts_content_type_edit_form($form, &$form_state) {
 /**
  * Implements a drupal form, which implements a pay button and debts data.
  */
-function ding_debt_debts_form($form, &$form_state, $debts, $has_invoiced_fees, $total_amount) {
-  ding_debt_form_details($form, $debts, $has_invoiced_fees, $total_amount);
+function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_debts) {
+  if (variable_get('ding_debt_external_show_introtext', TRUE)) {
+    $ding_debt_external_introtext = variable_get('ding_debt_external_introtext', _ding_debt_external_introtext_default());
 
-  if ($total_amount) {
-    // Init debts.
-    if (!isset($debts)) {
-      $debts = array();
+    $form['external_introtext'] = [
+      '#markup' => check_markup($ding_debt_external_introtext['value'], $ding_debt_external_introtext['format']),
+    ];
+  }
+
+  if (variable_get('ding_debt_enable_internal', TRUE)) {
+    if (variable_get('ding_debt_enable_external', TRUE) && variable_get('ding_debt_internal_title', '')) {
+      $form['internal_title'] = [
+        '#prefix' => '<h2>',
+        '#suffix' => '</h2>',
+        '#markup' => check_plain(variable_get('ding_debt_internal_title', '')),
+      ];
     }
 
+    $form['internal_debts'] = ding_debt_list_items($internal_debts);
+
+    $total = array_reduce($internal_debts, function ($total, $debt) {
+      return $total + $debt->amount - $debt->amount_paid;
+    }, 0);
+
+    $form['internal_total'] = array(
+      '#type' => 'item',
+      '#prefix' => '<div class="total-amount">',
+      '#suffix' => '</div>',
+      '#markup' => t('Total') . ': <span class="amount">' . number_format($total, 2, ',', ' ') . ' ' . t('Kr') . '</span>',
+    );
+
+    // Pass debts to submit handler.
     $form['debt_data'] = array(
       '#type' => 'value',
-      '#value' => $debts,
+      '#value' => $internal_debts,
     );
 
-    $form['accept_terms'] = array(
-      '#type' => 'checkbox',
-      '#title' => t('I accept the terms of service'),
-      '#required' => TRUE,
+    if (variable_get('ding_debt_enable_internal_button', TRUE)) {
+      $provider = ding_provider_get_provider_module_name('payment');
+      if (!empty($provider)) {
+        // Yeah, this is extremely hacky, but DIBS payments are being phased out,
+        // so refactoring ding_dibs so we can include the contents of these blocks
+        // isn't worth the efford.
+        if ($provider === 'ding_dibs') {
+          $block = ding_dibs_block_view('dibs-cards-supported');
+          $form['cards_header'] = [
+            '#prefix' => '<h3>',
+            '#suffix' => '</h3>',
+            '#markup' => check_plain($block['subject']),
+          ];
+
+          $form['cards_body'] = [
+            '#markup' => $block['content'],
+          ];
+
+          $block = ding_dibs_block_view('dibs-terms-of-sale');
+          $form['terms_header'] = [
+            '#prefix' => '<h3>',
+            '#suffix' => '</h3>',
+            '#markup' => check_plain($block['subject']),
+          ];
+
+          $form['terms_body'] = [
+            '#markup' => $block['content'],
+          ];
+        }
+
+        $form['accept_terms'] = array(
+          '#type' => 'checkbox',
+          '#title' => t('I accept the terms of service'),
+          '#required' => TRUE,
+        );
+
+        $form['internal_buttons'] = [
+          '#type' => 'container',
+          '#attributes' => [
+            'class' => ['pay-buttons'],
+          ],
+          '#tree' => FALSE,
+        ];
+
+        $form['internal_buttons']['pay_selected'] = array(
+          '#type' => 'submit',
+          '#prefix' => '<div class="pay-button">',
+          '#value' => t('Pay selected debts'),
+          '#suffix' => '</div>',
+          '#submit' => array('ding_debt_debts_form_submit_pay_selected'),
+          '#states' => array(
+            'disabled' => array(
+              ':input[name="accept_terms"]' => array('checked' => FALSE),
+            ),
+          ),
+        );
+
+        $form['internal_buttons']['pay_all'] = array(
+          '#type' => 'submit',
+          '#prefix' => '<div class="pay-button">',
+          '#value' => t('Pay all debts'),
+          '#suffix' => '</div>',
+          '#submit' => array('ding_debt_debts_form_submit_pay_all'),
+          '#states' => array(
+            'disabled' => array(
+              ':input[name="accept_terms"]' => array('checked' => FALSE),
+            ),
+          ),
+        );
+      }
+    }
+  }
+
+  if (variable_get('ding_debt_enable_external', FALSE)) {
+    if (variable_get('ding_debt_enable_internal', TRUE) && variable_get('ding_debt_external_title', '')) {
+      $form['external_title'] = [
+        '#prefix' => '<h2>',
+        '#suffix' => '</h2>',
+        '#markup' => check_plain(variable_get('ding_debt_external_title', '')),
+      ];
+    }
+
+    $form['external_debts'] = ding_debt_list_items($external_debts);
+
+    $total = array_reduce($external_debts, function ($total, $debt) {
+      return $total + $debt->amount - $debt->amount_paid;
+    }, 0);
+
+    $form['external_total'] = array(
+      '#type' => 'item',
+      '#prefix' => '<div class="total-amount">',
+      '#suffix' => '</div>',
+      '#markup' => t('Total') . ': <span class="amount">' . number_format($total, 2, ',', ' ') . ' ' . t('Kr') . '</span>',
     );
 
-    $provider = ding_provider_get_provider_module_name('payment');
-    if (!empty($provider)) {
-      $form['pay_selected'] = array(
-        '#type' => 'submit',
-        '#prefix' => '<div class="pay-button">',
-        '#value' => t('Pay selected debts'),
-        '#suffix' => '</div>',
-        '#submit' => array('ding_debt_debts_form_submit_pay_selected'),
-        '#states' => array(
-          'disabled' => array(
-            ':input[name="accept_terms"]' => array('checked' => FALSE),
-          ),
-        ),
-      );
+    if (variable_get('ding_debt_external_show_extra_information', TRUE)) {
+      $ding_debt_external_extra_information = variable_get('ding_debt_external_extra_information', _ding_debt_external_extra_information_default());
 
-      $form['pay_all'] = array(
-        '#type' => 'submit',
-        '#prefix' => '<div class="pay-button">',
-        '#value' => t('Pay all debts'),
-        '#suffix' => '</div>',
-        '#submit' => array('ding_debt_debts_form_submit_pay_all'),
-        '#states' => array(
-          'disabled' => array(
-            ':input[name="accept_terms"]' => array('checked' => FALSE),
-          ),
-        ),
-      );
+      $form['external_extra_information'] = [
+        '#markup' => check_markup($ding_debt_external_extra_information['value'], $ding_debt_external_extra_information['format']),
+      ];
+    }
+
+    if (variable_get('ding_debt_enable_external_button', FALSE)) {
+      $text = variable_get('ding_debt_external_button_text', '');
+      $url = variable_get('ding_debt_external_button_url', '');
+
+      $form['external_buttons'] = [
+        '#type' => 'container',
+        '#attributes' => [
+          'class' => ['pay-buttons'],
+        ],
+        '#tree' => FALSE,
+      ];
+
+      $options = [
+        'attributes' => [
+          'class' => 'external-payment',
+          'target' => '_blank',
+        ],
+      ];
+      $form['external_buttons']['external_link'] = [
+        '#markup' => l($text, $url, $options),
+      ];
     }
   }
 
@@ -118,7 +220,9 @@ function ding_debt_debts_form($form, &$form_state, $debts, $has_invoiced_fees, $
 /**
  * Helper function to render the details of the debt form.
  */
-function ding_debt_form_details(&$form, $debts, $has_invoiced_fees, $total_amount) {
+function ding_debt_list_items($debts) {
+  $items = [];
+
   foreach ($debts as $debt) {
     $item = array(
       '#type' => 'material_item',
@@ -140,12 +244,12 @@ function ding_debt_form_details(&$form, $debts, $has_invoiced_fees, $total_amoun
         ),
         'amount' => array(
           'label' => t('Amount'),
-          'data' => $debt->is_invoice ? number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('Kr') . ' <span class="note">*</span>' : number_format(($debt->amount - $debt->amount_paid), 2, ',', ' ') . ' ' . t('Kr'),
+          'data' => number_format($debt->amount - $debt->amount_paid, 2, ',', ' ') . ' ' . t('Kr'),
           'class' => 'fee_amount',
           '#weight' => 8,
         ),
       ),
-      '#disabled' => (bool) $debt->invoice_number,
+      '#disabled' => !$debt->payable,
     );
 
     // Add material number if available.
@@ -159,25 +263,10 @@ function ding_debt_form_details(&$form, $debts, $has_invoiced_fees, $total_amoun
     }
 
     // Add the debt to the form.
-    $form['debts'][$debt->id] = $item;
+    $items[] = $item;
   }
 
-  // Add item with the total amount.
-  $form['total'] = array(
-    '#type' => 'item',
-    '#prefix' => '<div class="total-amount">',
-    '#suffix' => '</div>',
-    '#markup' => t('Total') . ': <span class="amount">' . number_format($total_amount, 2, ',', ' ') . ' ' . t('Kr') . '</span>',
-  );
-
-  if ($has_invoiced_fees) {
-    $form['notice'] = array(
-      '#type' => 'item',
-      '#prefix' => '<div class="messages warning">',
-      '#suffix' => '</div>',
-      '#markup' => t("* Invoiced fees can't be paid online."),
-    );
-  }
+  return $items;
 }
 
 /**
@@ -187,13 +276,8 @@ function ding_debt_debts_form_submit_pay_all($form, &$form_state) {
   $amount = 0;
   $debts = $form_state['values']['debt_data'];
   foreach ($debts as $debt_id => $debt_data) {
-    if (!$form_state['values']['debt_data'][$debt_id]->invoice_number) {
-      $amount += $form_state['values']['debt_data'][$debt_id]->amount;
-      $amount -= $form_state['values']['debt_data'][$debt_id]->amount_paid;
-    }
-    else {
-      unset($debts[$debt_id]);
-    }
+    $amount += $form_state['values']['debt_data'][$debt_id]->amount;
+    $amount -= $form_state['values']['debt_data'][$debt_id]->amount_paid;
   }
   ding_debt_debts_perform_payment($debts, $amount, $form_state);
 }
@@ -207,11 +291,9 @@ function ding_debt_debts_form_submit_pay_selected($form, &$form_state) {
   $debts = $form_state['values']['debt_data'];
   foreach ($debts as $debt_id => $debt_data) {
     if (!empty($form_state['values'][$debt_id])) {
-      if (!$debt_data->invoice_number) {
-        $amount += $form_state['values']['debt_data'][$debt_id]->amount;
-        $amount -= $form_state['values']['debt_data'][$debt_id]->amount_paid;
-        $payments[$debt_id] = $form_state['values']['debt_data'][$debt_id];
-      }
+      $amount += $form_state['values']['debt_data'][$debt_id]->amount;
+      $amount -= $form_state['values']['debt_data'][$debt_id]->amount_paid;
+      $payments[$debt_id] = $form_state['values']['debt_data'][$debt_id];
     }
   }
   ding_debt_debts_perform_payment($payments, $amount, $form_state);

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -51,8 +51,8 @@ function ding_debt_debts_content_type_edit_form($form, &$form_state) {
  * Implements a drupal form, which implements a pay button and debts data.
  */
 function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_debts) {
-  $has_internal = !empty($internal_debts);
-  $has_external = !empty($external_debts);
+  $has_internal = !empty($internal_debts) && variable_get('ding_debt_enable_internal', TRUE);
+  $has_external = !empty($external_debts) && variable_get('ding_debt_enable_external', FALSE);
 
   // Cop out early if there's no debts.
   if (!$has_internal && !$has_external) {
@@ -71,8 +71,8 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     ];
   }
 
-  if (variable_get('ding_debt_enable_internal', TRUE) && $has_internal) {
-    if (variable_get('ding_debt_enable_external', TRUE) && variable_get('ding_debt_internal_title', '')) {
+  if ($has_internal) {
+    if ($has_external && variable_get('ding_debt_internal_title', '')) {
       $form['internal_title'] = [
         '#prefix' => '<h2>',
         '#suffix' => '</h2>',
@@ -172,8 +172,8 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     }
   }
 
-  if (variable_get('ding_debt_enable_external', FALSE) && $has_external) {
-    if (variable_get('ding_debt_enable_internal', TRUE) && variable_get('ding_debt_external_title', '')) {
+  if ($has_external) {
+    if ($has_internal && variable_get('ding_debt_external_title', '')) {
       $form['external_title'] = [
         '#prefix' => '<h2>',
         '#suffix' => '</h2>',

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -59,7 +59,7 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     ];
   }
 
-  if (variable_get('ding_debt_enable_internal', TRUE)) {
+  if (variable_get('ding_debt_enable_internal', TRUE) && !empty($internal_debts)) {
     if (variable_get('ding_debt_enable_external', TRUE) && variable_get('ding_debt_internal_title', '')) {
       $form['internal_title'] = [
         '#prefix' => '<h2>',
@@ -160,7 +160,7 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     }
   }
 
-  if (variable_get('ding_debt_enable_external', FALSE)) {
+  if (variable_get('ding_debt_enable_external', FALSE) && !empty($external_debts)) {
     if (variable_get('ding_debt_enable_internal', TRUE) && variable_get('ding_debt_external_title', '')) {
       $form['external_title'] = [
         '#prefix' => '<h2>',

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -51,6 +51,18 @@ function ding_debt_debts_content_type_edit_form($form, &$form_state) {
  * Implements a drupal form, which implements a pay button and debts data.
  */
 function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_debts) {
+  $has_internal = !empty($internal_debts);
+  $has_external = !empty($external_debts);
+
+  // Cop out early if there's no debts.
+  if (!$has_internal && !$has_external) {
+    $form['no_debts'] = [
+      '#markup' => t("There's no unpaid debts."),
+    ];
+
+    return $form;
+  }
+
   if (variable_get('ding_debt_external_show_introtext', TRUE)) {
     $ding_debt_external_introtext = variable_get('ding_debt_external_introtext', _ding_debt_external_introtext_default());
 
@@ -59,7 +71,7 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     ];
   }
 
-  if (variable_get('ding_debt_enable_internal', TRUE) && !empty($internal_debts)) {
+  if (variable_get('ding_debt_enable_internal', TRUE) && $has_internal) {
     if (variable_get('ding_debt_enable_external', TRUE) && variable_get('ding_debt_internal_title', '')) {
       $form['internal_title'] = [
         '#prefix' => '<h2>',
@@ -160,7 +172,7 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     }
   }
 
-  if (variable_get('ding_debt_enable_external', FALSE) && !empty($external_debts)) {
+  if (variable_get('ding_debt_enable_external', FALSE) && $has_external) {
     if (variable_get('ding_debt_enable_internal', TRUE) && variable_get('ding_debt_external_title', '')) {
       $form['external_title'] = [
         '#prefix' => '<h2>',

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -63,11 +63,11 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     return $form;
   }
 
-  if (variable_get('ding_debt_external_show_introtext', TRUE)) {
-    $ding_debt_external_introtext = variable_get('ding_debt_external_introtext', _ding_debt_external_introtext_default());
+  if (variable_get('ding_debt_show_introtext', TRUE)) {
+    $ding_debt_introtext = variable_get('ding_debt_introtext', _ding_debt_introtext_default());
 
-    $form['external_introtext'] = [
-      '#markup' => check_markup($ding_debt_external_introtext['value'], $ding_debt_external_introtext['format']),
+    $form['introtext'] = [
+      '#markup' => check_markup($ding_debt_introtext['value'], $ding_debt_introtext['format']),
     ];
   }
 

--- a/modules/ding_provider/ding_provider.debt.inc
+++ b/modules/ding_provider/ding_provider.debt.inc
@@ -56,6 +56,11 @@ class DingProviderDebt extends DingEntityBase {
   protected $material_type = DingEntityBase::NULL;
 
   /**
+   * Whether this debt is payable using Ding payment provider.
+   */
+  protected $payable = DingEntityBase::NULL;
+
+  /**
    * Default constructor for this class.
    *
    * @param string $id
@@ -69,7 +74,6 @@ class DingProviderDebt extends DingEntityBase {
     // Default display name.
     $this->properties['display_name'] = t('Title not available');
     $this->properties['amount_paid'] = 0;
-    $this->properties['invoice_number'] = FALSE;
     $properties = array(
       'material_number',
       'display_name',
@@ -77,7 +81,7 @@ class DingProviderDebt extends DingEntityBase {
       'date',
       'amount',
       'amount_paid',
-      'invoice_number',
+      'payable',
       'type',
       'note',
       'material_type',

--- a/modules/ding_user_frontend/ding_user_frontend.pages_default.inc
+++ b/modules/ding_user_frontend/ding_user_frontend.pages_default.inc
@@ -866,6 +866,8 @@ function ding_user_frontend_default_page_manager_pages() {
       ),
     ),
     'logic' => 'and',
+    'type' => 'none',
+    'settings' => NULL,
   );
   $page->menu = array(
     'type' => 'tab',
@@ -1104,6 +1106,7 @@ function ding_user_frontend_default_page_manager_pages() {
       'attachment_2_1' => NULL,
       'attachment_2_2' => NULL,
       'attachment_1_1' => NULL,
+      'top_banner' => NULL,
     ),
   );
   $display->cache = array();
@@ -1160,50 +1163,6 @@ function ding_user_frontend_default_page_manager_pages() {
     $pane->uuid = 'e2022ee9-76c6-459f-a099-31e801455557';
     $display->content['new-e2022ee9-76c6-459f-a099-31e801455557'] = $pane;
     $display->panels['main_content'][0] = 'new-e2022ee9-76c6-459f-a099-31e801455557';
-    $pane = new stdClass();
-    $pane->pid = 'new-a02ec119-af14-4c5c-bdf3-f742b32486a7';
-    $pane->panel = 'main_content';
-    $pane->type = 'block';
-    $pane->subtype = 'ding_dibs-dibs-terms-of-sale';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'override_title' => 0,
-      'override_title_text' => '',
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 1;
-    $pane->locks = '';
-    $pane->uuid = 'a02ec119-af14-4c5c-bdf3-f742b32486a7';
-    $display->content['new-a02ec119-af14-4c5c-bdf3-f742b32486a7'] = $pane;
-    $display->panels['main_content'][1] = 'new-a02ec119-af14-4c5c-bdf3-f742b32486a7';
-    $pane = new stdClass();
-    $pane->pid = 'new-6de0581e-da74-4598-8800-395eee76efdd';
-    $pane->panel = 'main_content';
-    $pane->type = 'block';
-    $pane->subtype = 'ding_dibs-dibs-cards-supported';
-    $pane->shown = TRUE;
-    $pane->access = array();
-    $pane->configuration = array(
-      'override_title' => 0,
-      'override_title_text' => '',
-    );
-    $pane->cache = array();
-    $pane->style = array(
-      'settings' => NULL,
-    );
-    $pane->css = array();
-    $pane->extras = array();
-    $pane->position = 2;
-    $pane->locks = '';
-    $pane->uuid = '6de0581e-da74-4598-8800-395eee76efdd';
-    $display->content['new-6de0581e-da74-4598-8800-395eee76efdd'] = $pane;
-    $display->panels['main_content'][2] = 'new-6de0581e-da74-4598-8800-395eee76efdd';
   $display->hide_title = PANELS_TITLE_NONE;
   $display->title_pane = 'new-e2022ee9-76c6-459f-a099-31e801455557';
   $handler->conf['display'] = $display;
@@ -1233,6 +1192,8 @@ function ding_user_frontend_default_page_manager_pages() {
       ),
     ),
     'logic' => 'and',
+    'type' => 'none',
+    'settings' => NULL,
   );
   $page->menu = array(
     'type' => 'tab',

--- a/modules/fbs/includes/classes/FBSFakeHttpClient.php
+++ b/modules/fbs/includes/classes/FBSFakeHttpClient.php
@@ -170,7 +170,7 @@ class FBSFakeHttpClient implements HttpClient {
   private function getFees($request, $vars) {
     // No fees.
     $response = new Response(new Stream('php://memory', 'w'));
-    $response->getBody()->write(json_encode(array()));
+    $response->getBody()->write(file_get_contents(__DIR__ . '/FeesResponse.json'));
     return $response;
   }
 

--- a/modules/fbs/includes/classes/FeesResponse.json
+++ b/modules/fbs/includes/classes/FeesResponse.json
@@ -1,0 +1,221 @@
+[
+  {
+    "feeId": 159786,
+    "type": "fee",
+    "reasonMessage": "Gebyr (For sent)",
+    "amount": 0.5,
+    "dueDate": "2028-11-17",
+    "creationDate": "2017-12-07",
+    "paidDate": null,
+    "payableByClient": true,
+    "materials": [
+      {
+        "materialItemNumber": "5160562503",
+        "recordId": "53161480",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      }
+    ]
+  },
+  {
+    "feeId": 159837,
+    "type": "fee",
+    "reasonMessage": "Gebyr (For sent)",
+    "amount": 10.0,
+    "dueDate": "2028-11-17",
+    "creationDate": "2017-12-07",
+    "paidDate": null,
+    "payableByClient": false,
+    "materials": [
+      {
+        "materialItemNumber": "3843952681",
+        "recordId": "27365817",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "5056745892",
+        "recordId": "51590961",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      }
+    ]
+  },
+  {
+    "feeId": 172464,
+    "type": "fee",
+    "reasonMessage": "Gebyr (For sent)",
+    "amount": 55.0,
+    "dueDate": "2028-11-17",
+    "creationDate": "2018-01-31",
+    "paidDate": null,
+    "payableByClient": true,
+    "materials": [
+      {
+        "materialItemNumber": "4931754209",
+        "recordId": "29367477",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "3843071766",
+        "recordId": "24929604",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "3845598176",
+        "recordId": "27437087",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "4934838462",
+        "recordId": "29570221",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      }
+    ]
+  },
+  {
+    "feeId": 172470,
+    "type": "fee",
+    "reasonMessage": "Gebyr (For sent)",
+    "amount": 55.0,
+    "dueDate": "2028-11-17",
+    "creationDate": "2018-01-31",
+    "paidDate": null,
+    "payableByClient": true,
+    "materials": [
+      {
+        "materialItemNumber": "3847293836",
+        "recordId": "27618553",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      }
+    ]
+  },
+  {
+    "feeId": 172473,
+    "type": "fee",
+    "reasonMessage": "Gebyr (For sent)",
+    "amount": 55.0,
+    "dueDate": "2028-11-17",
+    "creationDate": "2018-01-31",
+    "paidDate": null,
+    "payableByClient": true,
+    "materials": [
+      {
+        "materialItemNumber": "5056745892",
+        "recordId": "51590961",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      }
+    ]
+  },
+  {
+    "feeId": 185099,
+    "type": "fee",
+    "reasonMessage": "Gebyr (For sent)",
+    "amount": 230.0,
+    "dueDate": "2028-11-17",
+    "creationDate": "2018-04-04",
+    "paidDate": null,
+    "payableByClient": false,
+    "materials": [
+      {
+        "materialItemNumber": "4931754209",
+        "recordId": "29367477",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "4934838462",
+        "recordId": "29570221",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "3843071766",
+        "recordId": "24929604",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "3845598176",
+        "recordId": "27437087",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      },
+      {
+        "materialItemNumber": "5056745892",
+        "recordId": "51590961",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      }
+    ]
+  },
+  {
+    "feeId": 185105,
+    "type": "fee",
+    "reasonMessage": "Gebyr (For sent)",
+    "amount": 230.0,
+    "dueDate": "2028-11-17",
+    "creationDate": "2018-04-04",
+    "paidDate": null,
+    "payableByClient": true,
+    "materials": [
+      {
+        "materialItemNumber": "3847293836",
+        "recordId": "27618553",
+        "periodical": null,
+        "materialGroup": {
+          "name": "standard",
+          "description": "31 dages lånetid til alm lånere"
+        }
+      }
+    ]
+  }
+]

--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -32,7 +32,7 @@ function fbs_debt_list($account, $reset = FALSE) {
       $res = array();
 
       try {
-        $res = fbs_service()->Payment->getFees(fbs_service()->agencyId, fbs_patron_id($account), FALSE, FALSE);
+        $res = fbs_service()->Payment->getFees(fbs_service()->agencyId, fbs_patron_id($account), 'false', 'true');
       }
       catch (Exception $e) {
         watchdog_exception('fbs', $e);
@@ -68,8 +68,8 @@ function fbs_debt_list($account, $reset = FALSE) {
           // And the only thing we can do here is set it to zero, as the original
           // amount isn't available.
           'amount_paid' => 0,
-          'invoice_number' => NULL,
           'type' => $fee->reasonMessage,
+          'payable' => $fee->payableByClient,
         );
 
         // If the has associated materials; collect some information about them and

--- a/modules/fbs/tests/DebtProviderTest.php
+++ b/modules/fbs/tests/DebtProviderTest.php
@@ -116,7 +116,6 @@ class ProviderTest extends ProviderTestCase {
         'display_name' => 'For sent afleveret',
         'amount' => 100.0,
         'amount_paid' => 0,
-        'invoice_number' => NULL,
         'type' => 'fee',
       )),
       57 => new DingProviderDebt(57, array(
@@ -124,7 +123,6 @@ class ProviderTest extends ProviderTestCase {
         'display_name' => 'Erstatning',
         'amount' => 150.0,
         'amount_paid' => 0,
-        'invoice_number' => NULL,
         'type' => 'compensation',
       )),
       58 => new DingProviderDebt(58, array(
@@ -132,7 +130,6 @@ class ProviderTest extends ProviderTestCase {
         'display_name' => 'bestillingsgebyr',
         'amount' => 200.0,
         'amount_paid' => 0,
-        'invoice_number' => NULL,
         'type' => 'fee',
         'material_number' => '3829213434'
       ))

--- a/themes/ddbasic/sass/components/form/form-class.scss
+++ b/themes/ddbasic/sass/components/form/form-class.scss
@@ -95,12 +95,6 @@
   }
 }
 
-// Fix for TOS accept checkbox in ding_debts form. The materials above the
-// checkbox is floated so we need to clear for it to appear correctly.
-.pane-debts .form-item-accept-terms label {
-  clear: both;
-}
-
 .node-ding-event {
   .webform-client-form {
     margin-bottom: 30px;

--- a/themes/ddbasic/sass/components/form/form-status.scss
+++ b/themes/ddbasic/sass/components/form/form-status.scss
@@ -47,4 +47,40 @@
     margin: 10px 0;
     white-space: normal;
   }
+
+  h2 {
+    margin-top: 2em;
+  }
+
+  h3 {
+    margin: 20px auto;
+  }
+
+  .pay-buttons a {
+    // Apparently there's no class or mixin for creating a button that
+    // looks like a submit button, so we'll have to do it ourselves.
+    @include appearance(none);
+    @include font('base');
+    @include transition(background-color $speed $ease);
+
+    display: block;
+    height: $element-height;
+    padding: 20px 15px 14px;
+    border: none;
+    border-radius: $round-corner;
+    color: $white;
+    background-color: $charcoal;
+    line-height: 1em;
+    text-align: left;
+    cursor: pointer;
+
+    &:hover {
+      background-color: $grey-dark;
+    }
+
+    &:focus {
+      outline: none;
+      box-shadow: 0 0 10px $grey-medium;
+    }
+  }
 }

--- a/themes/ddbasic/sass/components/panel/class-panel.scss
+++ b/themes/ddbasic/sass/components/panel/class-panel.scss
@@ -284,23 +284,17 @@
   @include clearfix();
   .total-amount {
     width: 100%;
-    float: left;
     margin: 10px 0;
   }
-  .pay-button {
-    float: left;
-    margin-right: getGutter(8);
 
-    // Mobile
-    @include media($mobile) {
-      margin-bottom: 10px;
-    }
-    input {
-      padding-right: 80px;
-    }
+  .pay-buttons {
+    width: 100%;
+    display: flex;
+    justify-content: flex-end;
   }
-  .pay-button + .pay-button {
-    margin-right: 0;
+
+  .pay-button {
+    margin-left: getGutter(8);
   }
 }
 

--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -9,7 +9,6 @@
 
 .material-item {
   position: relative;
-  float: left;
   min-height: 136px;
   width: 100%;
   padding: 10px 20px;

--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -494,8 +494,8 @@ function ddbasic_preprocess_menu_link(&$variables) {
         break;
 
       case 'status-debts':
-        $debts = ddbasic_account_count_debts();
-        if (!empty($debts)) {
+        $debts = ding_debt_count();
+        if ($debts) {
           $variables['element']['#title'] .= ' <span class="menu-item-count menu-item-count-warning">' . $debts . '</span>';
         }
         break;
@@ -606,8 +606,8 @@ function ddbasic_menu_link__menu_tabs_menu($vars) {
           // Fill the notification icon, in following priority.
           // Debts, overdue, ready reservations, notifications.
           $notification = array();
-          $debts = ddbasic_account_count_debts();
-          if (!empty($debts)) {
+          $debts = ding_debt_count();
+          if ($debts) {
             $notification = array(
               'count' => $debts,
               'type' => 'warning',

--- a/themes/ddbasic/utils.inc
+++ b/themes/ddbasic/utils.inc
@@ -20,26 +20,6 @@ function ddbasic_body_class($class = array()) {
 }
 
 /**
- * Get the total amount of debts the user has.
- */
-function ddbasic_account_count_debts($account = NULL) {
-  // Prepare the static cache.
-  $debts = &drupal_static(__FUNCTION__, array());
-
-  // Default the $account to the currently logged in user.
-  if (empty($account)) {
-    $account = $GLOBALS['user'];
-  }
-
-  // If the user have no hits in the static cache, count the debts.
-  if (!isset($debts[$account->uid])) {
-    $debts[$account->uid] = count(ding_provider_invoke('debt', 'list', $account));
-  }
-
-  return $debts[$account->uid];
-}
-
-/**
  * Get the total amount of loans the user has.
  */
 function ddbasic_account_count_loans($account = NULL) {

--- a/translations/da.po
+++ b/translations/da.po
@@ -40931,7 +40931,7 @@ msgstr "Se hele beskrivelsen"
 
 #: /user/36/status/debts
 msgid "My debts"
-msgstr "Betal gebyrer"
+msgstr "Gebyrer og erstatninger"
 
 #: /user/36/status/debts
 msgid "No debts"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5059

#### Description

Refactors debs to be split in on-site and off-site payments, with a separate section for each type. Much moving about and cleaning up.

#### Screenshot of the result

User page:
![ddb-5059-3](https://user-images.githubusercontent.com/229422/107758987-eea6e800-6d27-11eb-87e9-4c2672afa46a.png)

Admin:
![ddb-5059-admin-2](https://user-images.githubusercontent.com/229422/107758999-f2d30580-6d27-11eb-9e76-da7c5e1b5dc9.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
