### PR TITLE
5068: Fix bibdk subsearch

### DIFF
--- a/modules/ting_subsearch/ting_subsearch_bibdk/ting_subsearch_bibdk.module
+++ b/modules/ting_subsearch/ting_subsearch_bibdk/ting_subsearch_bibdk.module
@@ -132,10 +132,10 @@ function ting_subsearch_bibdk_is_bibdk_subsearch($new_value = NULL) {
  * Get the query of the last bibdk subsearch performed in the request.
  *
  * @param string $new_value
- *  Used internally to control the static variable.
+ *   Used internally to control the static variable.
  *
  * @return mixed
- *  Returns NULL if no bibdk subearch has been performed in the request.
+ *   Returns NULL if no bibdk subearch has been performed in the request.
  */
 function ting_subsearch_bibdk_get_bibdk_subsearch_query($new_value = NULL) {
   $bibdk_subsearch_query = &drupal_static(__FUNCTION__);

--- a/modules/ting_subsearch/ting_subsearch_bibdk/ting_subsearch_bibdk.module
+++ b/modules/ting_subsearch/ting_subsearch_bibdk/ting_subsearch_bibdk.module
@@ -88,7 +88,7 @@ function ting_subsearch_bibdk_opensearch_pre_execute($request) {
     // Store the final query used in the bibliotek.dk search for use when
     // generating search links. Various modules might apply additional search
     // keys based on query parameters that are not supported on bibliotek.dk.
-    ting_subsearch_bibdk_get_bibdk_subsearch_query($request->getQuery());
+    ting_subsearch_bibdk_subsearch_query($request->getQuery());
   }
 
   // Ensure that facet genreCategory is returned from the well, since we need
@@ -137,7 +137,7 @@ function ting_subsearch_bibdk_is_bibdk_subsearch($new_value = NULL) {
  * @return mixed
  *   Returns NULL if no bibdk subearch has been performed in the request.
  */
-function ting_subsearch_bibdk_get_bibdk_subsearch_query($new_value = NULL) {
+function ting_subsearch_bibdk_subsearch_query($new_value = NULL) {
   $bibdk_subsearch_query = &drupal_static(__FUNCTION__);
   if (isset($new_value)) {
     $bibdk_subsearch_query = $new_value;
@@ -205,7 +205,7 @@ function ting_subsearch_bibdk_ting_subsearch_ajax_placeholder_content(TingSearch
 
   // Get the final query used in bibliotek.dk search. See comment in
   // ting_subsearch_bibdk_opensearch_pre_execute().
-  $bibdk_query = ting_subsearch_bibdk_get_bibdk_subsearch_query();
+  $bibdk_query = ting_subsearch_bibdk_subsearch_query();
 
   $bibdk_num_results = $bibdk_result->getNumTotalObjects();
   $bibdk_result_min = variable_get('ting_subsearch_bibdk_result_min', 4);

--- a/modules/ting_subsearch/ting_subsearch_bibdk/ting_subsearch_bibdk.module
+++ b/modules/ting_subsearch/ting_subsearch_bibdk/ting_subsearch_bibdk.module
@@ -81,16 +81,14 @@ function ting_subsearch_bibdk_opensearch_pre_execute($request) {
     return;
   }
 
-  $bibdk_subsearch = drupal_static('ting_subsearch_bibdk_subsearch');
-  if ($bibdk_subsearch === TRUE) {
+  if (ting_subsearch_bibdk_is_bibdk_subsearch()) {
     $request->setProfile(TING_SUBSEARCH_BIBDK_PROFILE);
     $request->setAgency(TING_SUBSEARCH_BIBDK_AGENCY);
 
     // Store the final query used in the bibliotek.dk search for use when
     // generating search links. Various modules might apply additional search
     // keys based on query parameters that are not supported on bibliotek.dk.
-    $bibdk_query = &drupal_static('ting_subsearch_bibdk_query');
-    $bibdk_query = $request->getQuery();
+    ting_subsearch_bibdk_get_bibdk_subsearch_query($request->getQuery());
   }
 
   // Ensure that facet genreCategory is returned from the well, since we need
@@ -102,6 +100,49 @@ function ting_subsearch_bibdk_opensearch_pre_execute($request) {
     $facets[] = 'facet.genreCategory';
     $request->setFacets($facets);
   }
+}
+
+/**
+ * Implements hook_opensearch_cache_key_alter().
+ */
+function ting_subsearch_bibdk_opensearch_cache_key_alter(&$cid, $request) {
+  if (ting_subsearch_bibdk_is_bibdk_subsearch()) {
+    $cid .= ':ting_subsearch_bibdk';
+  }
+}
+
+/**
+ * Whether a bibdk subsearch is currently being performed.
+ *
+ * @param bool $new_value
+ *   Used internally to control the static variable.
+ *
+ * @return bool
+ *   TRUE if bibdk subsearch is currently being performed. FALSE otherwise.
+ */
+function ting_subsearch_bibdk_is_bibdk_subsearch($new_value = NULL) {
+  $is_bibdk_subsearch = &drupal_static(__FUNCTION__, FALSE);
+  if (isset($new_value)) {
+    $is_bibdk_subsearch = $new_value;
+  }
+  return $is_bibdk_subsearch;
+}
+
+/**
+ * Get the query of the last bibdk subsearch performed in the request.
+ *
+ * @param string $new_value
+ *  Used internally to control the static variable.
+ *
+ * @return mixed
+ *  Returns NULL if no bibdk subearch has been performed in the request.
+ */
+function ting_subsearch_bibdk_get_bibdk_subsearch_query($new_value = NULL) {
+  $bibdk_subsearch_query = &drupal_static(__FUNCTION__);
+  if (isset($new_value)) {
+    $bibdk_subsearch_query = $new_value;
+  }
+  return $bibdk_subsearch_query;
 }
 
 /**
@@ -156,18 +197,15 @@ function ting_subsearch_bibdk_ting_subsearch_ajax_placeholder_content(TingSearch
 
   $search_request = $search_result->getSearchRequest();
 
-  // Mark the subsearch we're about to perform is a bibliotek.dk subsearch,
-  // which should have bibliotek.dk agency and profil set in our implementation
-  // of hook_opensearch_pre_execute().
-  $bibdk_subsearch = &drupal_static('ting_subsearch_bibdk_subsearch');
-  $bibdk_subsearch = TRUE;
+  // Mark the subsearch we're about to perform is a bibliotek.dk subsearch. We
+  // turn off it later after we have fetched collections, since we need these
+  // to be fetched with biddk agency and profile also.
+  ting_subsearch_bibdk_is_bibdk_subsearch(TRUE);
   $bibdk_result = ting_subseach_do_subsearch($search_request);
-  drupal_static_reset('ting_subsearch_bibdk_subsearch');
 
   // Get the final query used in bibliotek.dk search. See comment in
   // ting_subsearch_bibdk_opensearch_pre_execute().
-  $bibdk_query = drupal_static('ting_subsearch_bibdk_query');
-  drupal_static_reset('ting_subsearch_bibdk_query');
+  $bibdk_query = ting_subsearch_bibdk_get_bibdk_subsearch_query();
 
   $bibdk_num_results = $bibdk_result->getNumTotalObjects();
   $bibdk_result_min = variable_get('ting_subsearch_bibdk_result_min', 4);
@@ -240,6 +278,8 @@ function ting_subsearch_bibdk_ting_subsearch_ajax_placeholder_content(TingSearch
       ];
     }
   }
+
+  ting_subsearch_bibdk_is_bibdk_subsearch(FALSE);
 
   return $content;
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5068

#### Description

This PR fixes two issues with the bibdk subsearch mechanism:

1. Since opensearch tries to predict cache by putting collections
from the search result in cache, the bibdk subsearch would result
in full bibdk collections later being shown to the user. As a
solution we implement hook_opensearch_cache_key_alter() and alter
the cache key if bibdk subsearch is currently being performed.

2. We currently turn off bibdk subsearch immediatly after the
subsearch is performed. This means that collections will be
fetched without bibdk agency and profile. This actually relied
on bug 1. to work, but when it's fixed the bug manifests by
displaying empty collections. The solution is turn off bibdk
subsearch after we have fetched collections.

Also refector the code that controls the static variables into
functions to make it cleaner.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
