### PR TITLE
5026: Update default text on cookie page

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -1002,24 +1002,7 @@ function ding2_update_7086() {
  * Remove Webtrends specific info from cookie page.
  */
 function ding2_update_7087() {
-  // If we can find the old cookie information page make a backup, so we don't
-  // lose any information added by administrative users.
-  if ($nid = ding2_get_cookie_node_nid()) {
-    $node = node_load($nid);
-    $node->title .= ' (BACKUP)';
-    node_save($node);
-    // Delete "cookies" alias.
-    $path = path_load([
-      'source' => 'node/' . $node->nid,
-      'alias' => 'cookies',
-    ]);
-    if ($path) {
-      path_delete($path['pid']);
-    }
-  }
-  // Set a new generic cookie information page. This time without any specific
-  // information about which analytics tool we use.
-  ding2_set_cookie_page();
+  ding2_update_cookie_page();
 }
 
 /**
@@ -1084,21 +1067,5 @@ function ding2_update_7093() {
  * Update default text on cookie page. A backup of existing will be created.
  */
 function ding2_update_7094() {
-  // If we can find the old cookie information page make a backup, so we don't
-  // lose any information added by administrative users.
-  if ($nid = ding2_get_cookie_node_nid()) {
-    $node = node_load($nid);
-    $node->title .= ' (BACKUP)';
-    node_save($node);
-    // Delete "cookies" alias.
-    $path = path_load([
-      'source' => 'node/' . $node->nid,
-      'alias' => 'cookies',
-    ]);
-    if ($path) {
-      path_delete($path['pid']);
-    }
-  }
-  // Set the new cookie page.
-  ding2_set_cookie_page();
+  ding2_update_cookie_page();
 }

--- a/ding2.install
+++ b/ding2.install
@@ -1079,3 +1079,26 @@ function ding2_update_7092() {
 function ding2_update_7093() {
   ding2_translation_update();
 }
+
+/**
+ * Update default text on cookie page. A backup of existing will be created.
+ */
+function ding2_update_7094() {
+  // If we can find the old cookie information page make a backup, so we don't
+  // lose any information added by administrative users.
+  if ($nid = ding2_get_cookie_node_nid()) {
+    $node = node_load($nid);
+    $node->title .= ' (BACKUP)';
+    node_save($node);
+    // Delete "cookies" alias.
+    $path = path_load([
+      'source' => 'node/' . $node->nid,
+      'alias' => 'cookies',
+    ]);
+    if ($path) {
+      path_delete($path['pid']);
+    }
+  }
+  // Set the new cookie page.
+  ding2_set_cookie_page();
+}

--- a/ding2.profile
+++ b/ding2.profile
@@ -788,6 +788,29 @@ function ding2_set_cookie_page() {
 }
 
 /**
+ * Updates cookie page and make backup of existing.
+ */
+function ding2_update_cookie_page() {
+  // If we can find the old cookie information page make a backup, so we don't
+  // lose any information added by administrative users.
+  if ($nid = ding2_get_cookie_node_nid()) {
+    $node = node_load($nid);
+    $node->title .= ' (BACKUP)';
+    node_save($node);
+    // Delete "cookies" alias.
+    $path = path_load([
+      'source' => 'node/' . $node->nid,
+      'alias' => 'cookies',
+    ]);
+    if ($path) {
+      path_delete($path['pid']);
+    }
+  }
+  // Set the new cookie page.
+  ding2_set_cookie_page();
+}
+
+/**
  * Get the nid of the current node used as cookie page.
  *
  * @return mixed

--- a/ding2.profile
+++ b/ding2.profile
@@ -747,7 +747,7 @@ function ding2_set_cookie_page() {
     <p><strong>Funktionelle cookies</strong></p>
     <p>Visse stedet bruger vi cookies til at forbedre funktionalitet som f.eks. at huske dine valg, så du ikke skal trykke på samme knap om og om igen. Når du afviser cookies vil disse ikke blive indstillet, og det kan dermed betyde foringelse af brugeroplevelsen.</p>
     <p><strong>Statistik cookies</strong></p>
-    <p>Vi bruger cookies til at føre statistik over trafikken på hjemmesiden. Al indsamlet statistik gemmes anonymiseret. Vi bruger dette statistik til at undersøge brugsadfærd med det formål at forbedre kvaliteten af indhold og brugeroplevelsen på hjemmesiden. Afviser du cookies vil denne tracking blive blokeret.</p>';
+    <p>Vi bruger cookies til at forbedre den statistik, vi fører over trafikken på hjemmesiden. Al indsamlet statistik gemmes anonymiseret. Vi bruger denne statistik til at undersøge brugsadfærd med det formål at forbedre kvaliteten af indhold og brugeroplevelsen på hjemmesiden.</p>';
 
   $page_lead = 'Vi vil gerne tilbyde vores brugere en overskuelig og brugervenlig hjemmeside. For at sikre os, at indholdet på siden er relevant og til at finde rundt i, benytter vi os af cookies. Cookies giver os vigtige informationer om, hvordan vores side bliver brugt, hvilke sider der bliver set mest, hvor længe vores brugere bliver på siderne osv.';
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5026

#### Description

Again we make a backup of existing cookie page to avoid deleting anything added by administrators.

Also add new Add `ding2_update_cookie_page()` function.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
