### PR TITLE
3437: Fix availability types for collection with online entities

### DIFF
--- a/modules/ding_availability/ding_availability.field.inc
+++ b/modules/ding_availability/ding_availability.field.inc
@@ -96,12 +96,6 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
       ),
     );
 
-    // Extract records' source.
-    if ($field['type'] != 'ting_collection_types') {
-      /* @var \TingEntity $entity */
-      $ac_source = $entity->getAc_source();
-    }
-
     switch ($display['type']) {
       case 'ding_availability_default':
         // Generate an unique id.
@@ -212,9 +206,6 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
 
         // Loop over the different material types.
         foreach ($typed_entities as $type => $entities) {
-          // Extract records' source.
-          $ac_source = $entities[0]->getAc_source();
-
           // Filter out any materials of this type with online access and show
           // them separately.
           $online_entities = array_filter($entities, function ($entity) {
@@ -261,9 +252,6 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
           $entities = array_diff_key($entities, $online_entities);
           if (!empty($entities)) {
             $id = drupal_html_id('availability-' . $entities[0]->id . '-' . $type);
-
-            // Extract records' source.
-            $ac_source = $entities[0]->getAc_source();
 
             // There might be several entities for a type. If that's the case,
             // to avoid displaying many links with the same type, we use a

--- a/modules/ding_availability/ding_availability.field.inc
+++ b/modules/ding_availability/ding_availability.field.inc
@@ -212,27 +212,29 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
 
         // Loop over the different material types.
         foreach ($typed_entities as $type => $entities) {
-          /* @var \TingEntity[] $entities */
-          // Generate an unique id.
-          $id = drupal_html_id('availability-' . $entities[0]->id . '-' . $type);
-
           // Extract records' source.
           $ac_source = $entities[0]->getAc_source();
 
-          // Get link to first element in the collection of the current type.
-          // If more than one exists link to the collection.
-          if (count($entities) == 1) {
-            $url = entity_uri('ting_object', $entities[0]);
-          }
-          else {
-            $url = entity_uri('ting_collection', $entities[0]);
-          }
+          // Filter out any materials of this type with online access and show
+          // them separately.
+          $online_entities = array_filter($entities, function ($entity) {
+            return $entity->is('online');
+          });
 
-          // Mark as available if it is an online resource. As some types are
-          // not always predefined online type we need to check if the entity
-          // has an online URL. Please not tht that this in most cases will
-          // trigger a search request with get all relations.
-          if (in_array(drupal_strtolower($type), $online_types) || $entities[0]->isOnline()) {
+          if (!empty($online_entities)) {
+            $id = drupal_html_id('availability-' . $online_entities[0]->id . '-' . $type);
+
+            // There might be several online entities for a type. If that's the
+            // case, to avoid displaying many links with the same type, we use
+            // a collection url to the first entity and just show one link for
+            // the online type group.
+            if (count($online_entities) == 1) {
+              $url = entity_uri('ting_object', $online_entities[0]);
+            }
+            else {
+              $url = entity_uri('ting_collection', $online_entities[0]);
+            }
+
             if (!isset($output['#types']['online'])) {
               // Add label "online" to output.
               $output['#types']['online'] = array(
@@ -253,7 +255,27 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
               ),
             );
           }
-          else {
+
+          // Check availability for any remaining entities that are not online,
+          // where can possible check availability.
+          $entities = array_diff_key($entities, $online_entities);
+          if (!empty($entities)) {
+            $id = drupal_html_id('availability-' . $entities[0]->id . '-' . $type);
+
+            // Extract records' source.
+            $ac_source = $entities[0]->getAc_source();
+
+            // There might be several entities for a type. If that's the case,
+            // to avoid displaying many links with the same type, we use a
+            // collection url to the first entity and just show one link for
+            // the type group.
+            if (count($entities) == 1) {
+              $url = entity_uri('ting_object', $entities[0]);
+            }
+            else {
+              $url = entity_uri('ting_collection', $entities[0]);
+            }
+
             if (!isset($output['#types']['pending'])) {
               // Add label "Pending" to output as in waiting for information.
               $output['#types']['pending'] = array(
@@ -283,7 +305,6 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
                 ),
               ),
             );
-          }
 
           // If item is of type 'library materials' (where we can lookup
           // availability data), map the HTML id to the list of entity ids.

--- a/modules/ding_availability/ding_availability.field.inc
+++ b/modules/ding_availability/ding_availability.field.inc
@@ -306,12 +306,13 @@ function ding_availability_field_formatter_view($entity_type, $entity, $field, $
               ),
             );
 
-          // If item is of type 'library materials' (where we can lookup
-          // availability data), map the HTML id to the list of entity ids.
-          // This is for the current material type group (book, cd, etc.).
-          if ($entities[0]->is('library_material')) {
-            foreach ($entities as $object_entity) {
-              $id_mapping[$id][] = $object_entity->localId;
+            // Add entities of the type 'library materials' (where we can lookup
+            // availability data), map the HTML id to the list of entity ids.
+            // This is for the current material type group (book, cd, etc.).
+            foreach ($entities as $entity) {
+              if ($entity->is('library_material')) {
+                $id_mapping[$id][] = $entity->localId;
+              }
             }
           }
         }

--- a/modules/ding_availability/js/ding_availability_labels.js
+++ b/modules/ding_availability/js/ding_availability_labels.js
@@ -116,10 +116,7 @@
         var available = status['available'];
 
         var group = null;
-        if ($('.js-online', groups_wrapper).length !== 0) {
-          group = $('.js-online', groups_wrapper);
-        }
-        else if (available) {
+        if (available) {
           group = $('.js-available', groups_wrapper);
 
           if (group.length === 0) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3437

#### Description

Fixes ding availabilty types display. 

When there are online types in the collection all types will currently be displayed as online.

The main problem is in frontend where it will always use the `js-online` container if it's present.

But there was also an incorrect assumption made in backend, where all entities of a type in a collection would be considered online if the first one was.

This PR fixes both issues and also some cleanup.

Check commit and code comments for details.

This PR is closely related to #1750, so we might have som conflicts.

#### Screenshot of the result

**Before fix**

![3437-availability-types-before-fix](https://user-images.githubusercontent.com/5011234/109539883-16d16d80-7ac2-11eb-8ffb-0c7ac6f139e6.png)

**After fix**

![3437-availability-types-after-fix](https://user-images.githubusercontent.com/5011234/109539908-1f29a880-7ac2-11eb-8a4e-2dabe207d3df.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
