### PR TITLE
5073: Enforce h2 and panel titles when using IPE

### DIFF
--- a/modules/ding_content/ding_content.info
+++ b/modules/ding_content/ding_content.info
@@ -6,6 +6,7 @@ project = ding_content
 dependencies[] = clone
 dependencies[] = ctools
 dependencies[] = ctools_custom_content
+dependencies[] = ding_ipe_filter
 dependencies[] = ding_page
 dependencies[] = entity
 dependencies[] = features

--- a/modules/ding_content/ding_content.module
+++ b/modules/ding_content/ding_content.module
@@ -90,3 +90,41 @@ function ding_content_wysiwyg_editor_settings_alter(&$settings, $context) {
     $settings['customConfig'] = '/' . $path . '/js/ding_content.editor_config.js';
   }
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function ding_content_form_alter(&$form, &$form_state, $form_id) {
+  // Make some modifications for all panel pane configure forms rendered with
+  // Panels IPE and Ding IPE filter.
+  // See: ctools_content_form() and ctools_content_configure_form_defaults().
+  if (strpos($form['#action'], '/panels/ajax/ipe/') !== FALSE && $form_state['modal'] == TRUE) {
+    // Ensure override title element is present. Some panel's content types may
+    // have 'no title override' in plugin definition causing it to not be
+    // present and always use the default title.
+    if (!empty($form['override_title'])) {
+      // Enforce h2 header tag for the panel title.
+      $form['override_title_heading']['#default_value'] = 'h2';
+      $form['override_title_heading']['#access'] = FALSE;
+
+      // Simplify and improve title configuration:
+      //
+      //   1. Remove override title option.
+      //   2. Enable title override and show title field as default.
+      //   3. Use '%title' as default value to keep current behavior where the
+      //      panels default title (if any) is used as default.
+      //   4. Insert label above title field.
+      //   5. Insert better decsription below title field that only mentions the
+      //      %title keyword and recommends updating.
+      //
+      // The goal is the make it more likely that the administrators sees and
+      // updates and title field.
+      $conf = $form_state['conf'];
+      $form['override_title']['#access'] = FALSE;
+      $form['override_title']['#default_value'] = TRUE;
+      $form['override_title_text']['#default_value'] = isset($conf['override_title_text']) ? $conf['override_title_text'] : '%title';
+      $form['override_title_text']['#title'] = t('Title');
+      $form['override_title_markup']['#markup'] = t("The default value %title uses the panel's default title. For better accesibility it's recommended to change it and use a title more specific to the context.");
+    }
+  }
+}

--- a/modules/ding_content/ding_content.module
+++ b/modules/ding_content/ding_content.module
@@ -110,11 +110,16 @@ function ding_content_form_alter(&$form, &$form_state, $form_id) {
       // Simplify and improve title configuration:
       //
       //   1. Remove override title option.
-      //   2. Enable title override and show title field as default.
-      //   3. Use '%title' as default value to keep current behavior where the
-      //      panels default title (if any) is used as default.
-      //   4. Insert label above title field.
-      //   5. Insert better decsription below title field that only mentions the
+      //   2. Enable title override as default. This will make the title field
+      //      appear when the form is renderede initially.
+      //   3. Make title field required.
+      //   4. Use '%title' as default value to keep current behavior where the
+      //      panels default title (if any) is used as default. This also
+      //      minimizes the chance that administrators will leave the title
+      //      empty making the "Add one more" AJAX button fail silenty because
+      //      of required validation error.
+      //   5. Insert label above title field.
+      //   6. Insert better decsription below title field that only mentions the
       //      %title keyword and recommends updating.
       //
       // The goal is the make it more likely that the administrators sees and
@@ -122,6 +127,7 @@ function ding_content_form_alter(&$form, &$form_state, $form_id) {
       $conf = $form_state['conf'];
       $form['override_title']['#access'] = FALSE;
       $form['override_title']['#default_value'] = TRUE;
+      $form['override_title_text']['#required'] = TRUE;
       $form['override_title_text']['#default_value'] = isset($conf['override_title_text']) ? $conf['override_title_text'] : '%title';
       $form['override_title_text']['#title'] = t('Title');
       $form['override_title_markup']['#markup'] = t("The default value %title uses the panel's default title. For better accesibility it's recommended to change it and use a title more specific to the context.");

--- a/modules/ding_frontpage/ding_frontpage.info
+++ b/modules/ding_frontpage/ding_frontpage.info
@@ -7,7 +7,6 @@ dependencies[] = cache_actions
 dependencies[] = ctools
 dependencies[] = ding_event
 dependencies[] = ding_groups
-dependencies[] = ding_ipe_filter
 dependencies[] = ding_news
 dependencies[] = ding_tabroll
 dependencies[] = lazy_pane

--- a/modules/ding_ipe_filter/ding_ipe_filter.module
+++ b/modules/ding_ipe_filter/ding_ipe_filter.module
@@ -227,11 +227,7 @@ function _ding_ipe_filter_selected_panes() {
     'ding-:ding_campaign_plus' => 'ding-:ding_campaign_plus',
     'ding-:ding_sections' => 'ding-:ding_sections',
     'ding-:all_opening_hours' => 'ding-:all_opening_hours',
-    'ding-:popular' => 'ding-:popular',
-    'ding-:interaction_pane' => 'ding-:interaction_pane',
-    'ding-:serendipity_ting_object' => 'ding-:serendipity_ting_object',
     'ding-:ding_tabroll-ding_frontpage_tabroll' => 'ding-:ding_tabroll-ding_frontpage_tabroll',
-    'ding-:campaign' => 'ding-:campaign',
     'ting:carousel' => 'ting:carousel',
   );
 

--- a/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
+++ b/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
@@ -33,7 +33,7 @@ $plugin = array(
 function ding_nodelist_content_type_render($subtype, $conf, $args, $context) {
   $block = new stdClass();
 
-  $block->title = t('Nodelist');
+  $block->title = t('Latest');
 
   // Prepare classes for widget container.
   $classes = array();

--- a/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
+++ b/modules/ding_nodelist/plugins/content_types/ding_nodelist.inc
@@ -33,6 +33,8 @@ $plugin = array(
 function ding_nodelist_content_type_render($subtype, $conf, $args, $context) {
   $block = new stdClass();
 
+  $block->title = t('Nodelist');
+
   // Prepare classes for widget container.
   $classes = array();
   $classes[] = 'ding_nodelist';

--- a/modules/ding_sections/plugins/content_types/ding_sections.inc
+++ b/modules/ding_sections/plugins/content_types/ding_sections.inc
@@ -128,7 +128,7 @@ function ding_sections_content_type_render($subtype, $conf, $args, $context) {
   $result = $view->preview();
 
   $block = new stdClass();
-  $block->title = t('Section Group');
+  $block->title = t('Themes');
   $block->content = $result;
   return $block;
 }

--- a/modules/ding_sections/plugins/content_types/ding_sections.inc
+++ b/modules/ding_sections/plugins/content_types/ding_sections.inc
@@ -128,6 +128,7 @@ function ding_sections_content_type_render($subtype, $conf, $args, $context) {
   $result = $view->preview();
 
   $block = new stdClass();
+  $block->title = t('Section Group');
   $block->content = $result;
   return $block;
 }

--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -24,6 +24,8 @@ function ting_search_carousel_carousel_content_type_render($subtype, $conf, $pan
   $searches = $conf['searches'];
 
   if (!empty($searches)) {
+    $block->title = t('Ting search carousel');
+
     $carousels = array();
     foreach ($searches as $search) {
       $search += array(

--- a/modules/ting_search_carousel/plugins/content_types/carousel.inc
+++ b/modules/ting_search_carousel/plugins/content_types/carousel.inc
@@ -24,7 +24,7 @@ function ting_search_carousel_carousel_content_type_render($subtype, $conf, $pan
   $searches = $conf['searches'];
 
   if (!empty($searches)) {
-    $block->title = t('Ting search carousel');
+    $block->title = t('Inspiration');
 
     $carousels = array();
     foreach ($searches as $search) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5073

#### Description

Add some modification to panels configure forms, when they are added directly in frontend with Panels IPE.

The goal is to promote better accessibility by requiring title and nudging administrators to provide a better more specific one. Also enforce h2 tag for title.

Administrators with access to page manager backend will still have all options to omit title and use different title tag.

There is a minor issue with using required on the title field: if title field is empty the ajax button to add a carousel tab will fail silently. We therefore insert the panel's content type's default title (with ctools %title token) as default value to minimize to chance of this happening. Using the default title when title field is empty is also the current behavior.

Additionally:

- Provide some generic default titles for ting_search_carousel, nodelist and ding_section.
- Cleanup: remove old default selected panel content types in Ding IPE filter.

#### Screenshot of the result

![5073-solution-screenshot](https://user-images.githubusercontent.com/5011234/110553604-8a662100-8139-11eb-8ed2-c386ae180e53.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
