### PR TITLE
5106: Remove duplicate translation of string to "Gem"

### DIFF
--- a/translations/da.po
+++ b/translations/da.po
@@ -67608,9 +67608,6 @@ msgstr "Tilføjet til gemte søgninger"
 msgid "Title for followed search"
 msgstr "Titel på gemt søgning"
 
-msgid "Add"
-msgstr "Gem"
-
 #: /search/ting/harry%20potter?
 msgid "See your followed searches."
 msgstr "Se mine gemte søgninger"


### PR DESCRIPTION
### Link to issue

https://platform.dandigbib.org/issues/5106

### Description

Drupal uses button texts to determine which button was clicked.
This leads to problems when multiple buttons have the same text.
Drupal cannot figure out which button was clicked and will choose 
whatever.

This leads to problems which can be experienced on the Webform
components page. Here you cannot add more components than one as it
contains both an Add and a Save button. Both are translated to Gem.
Consequently Drupal always acts as if the Save button was clicked.

Actually the translation of Add is a duplicate so we just remove it.

The problem only seems to occur for newly installed sites so there
is no reason to run an update hook.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
