### PR TITLE
4801: Update material list button

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -1079,3 +1079,10 @@ function ding2_update_7092() {
 function ding2_update_7093() {
   ding2_translation_update();
 }
+
+/**
+ * Update translations.
+ */
+function ding2_update_7094() {
+  ding2_translation_update();
+}

--- a/modules/ding_react/ding_react.module
+++ b/modules/ding_react/ding_react.module
@@ -101,13 +101,16 @@ function ding_react_ding_entity_buttons($type, $entity, $view_mode = 'default', 
     $data = [
       'material-list-url' => ding_react_material_list_url(),
       'id' => $entity->ding_entity_id,
-      'text' => t('Add to checklist'),
-      'error-text' => t('An error occurred'),
-      'success-text' => t('Added to checklist'),
+      'add-text' => t('Add to checklist'),
+      'add-error-text' => t('An error occurred'),
+      'add-success-text' => t('Added to checklist'),
+      'remove-text' => t('Remove from checklist'),
+      'remove-error-text' => t('An error occurred'),
+      'remove-success-text' => t('Removed from checklist'),
       'login-url' => ding_react_login_url(),
     ];
 
-    $return[] = ding_react_app('add-to-checklist', $data);
+    $return[] = ding_react_app('checklist-material-button', $data);
 
     return $return;
   }

--- a/translations/da.po
+++ b/translations/da.po
@@ -66643,7 +66643,7 @@ msgstr "Andre materialetyper"
 
 #: /search/ting/findus
 msgid "Add to list"
-msgstr "Tilføj til liste"
+msgstr "Tilføj til huskeliste"
 
 #: /
 msgid "Login with"
@@ -67591,14 +67591,14 @@ msgstr "I fokus"
 
 #: /ting/object/870970-basis%3A53704638
 msgid "Add to checklist"
-msgstr "Tilføj til liste"
+msgstr "Tilføj til huskeliste"
 
 msgid "An error occurred"
 msgstr "Der opstod en fejl"
 
 #: /ting/object/870970-basis%3A53704638
 msgid "Added to checklist"
-msgstr "Tilføjet til liste"
+msgstr "Tilføjet til huskeliste"
 
 #: /search/ting/harry%20potter?
 msgid "Add to followed searches"
@@ -67645,7 +67645,7 @@ msgstr "DDB React komponenter"
 
 #: /lazy-pane/ajax
 msgid "My checklist"
-msgstr "Min liste"
+msgstr "Huskeliste"
 
 #: /user/me/checklist
 msgid "List is empty."


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4801

#### Description

This PR updates the button which allow users to add a material to their checklist:

1. The current button has been replaced with a new one which reflects state. This means that the button will check whether the current material in already on the users checklist. If that is the case then the button will allow the user to remove the material. Otherwise the button looks the same as the existing button. (see danskernesdigitalebibliotek/ddb-react#129)
2. Update wording related to the users checklist. By using "huskelistr" instead of "min liste" we are consistent with the app.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

New strings related to removal has to be translated by the business.