### PR TITLE
4774: Remove user openlist status check in admin interface

### DIFF
--- a/modules/ding_react/ding_react.admin.inc
+++ b/modules/ding_react/ding_react.admin.inc
@@ -55,46 +55,6 @@ function ding_react_admin_settings_form($form, &$form_state) {
     '#element_validate' => [ 'element_validate_integer_positive' ],
   ];
 
-  $form['migration']['user_status'] = [
-    '#type' => 'fieldset',
-    '#title' => t('User migration status'),
-  ];
-
-  $form['migration']['user_status']['user_id'] = [
-    '#type' => 'textfield',
-    '#title' => t('User id'),
-    '#description' => t('The Drupal id of the user to check. Enter the id and hit TAB to search.'),
-    '#ajax' => [
-      'callback' => 'ding_react_admin_user_callback',
-      'wrapper' => 'ding-react-app-user-data',
-      'method' => 'replace',
-    ],
-  ];
-  $form['migration']['user_status']['user'] = [
-    '#prefix' => '<div id="ding-react-app-user-data">',
-    '#suffix' => '</div>',
-  ];
-  if (!empty($form_state['values']['user_id'])) {
-    $account = user_load($form_state['values']['user_id']);
-    if ($account) {
-      $form['migration']['user_status']['user']['user_account'] = [
-        '#type' => 'value',
-        '#value' => $account,
-      ];
-      $form['migration']['user_status']['user']['openlist_uid'] = [
-        '#type' => 'item',
-        '#title' => t('Openlist user id'),
-        '#markup' => (!empty($account->openlist_uid)) ? $account->openlist_uid : t('No OpenList UID for user'),
-        '#description' => t('User ids beginning with "@prefix" have already been migrated.', ['@prefix' => DING_REACT_MIGRATED_UID_PREFIX]),
-      ];
-      $form['migration']['user_status']['user']['reset'] = [
-        '#type' => 'submit',
-        '#value' => t('Reset migration status'),
-        '#submit' => ['ding_react_user_reset_migration_status'],
-      ];
-    }
-  }
-
   $form['debug'] = [
     '#type' => 'fieldset',
     '#title' => t('Debugging'),
@@ -144,29 +104,4 @@ function ding_react_admin_settings_form_submit($form, &$form_state) {
     variable_set($variable, $form_state['values'][$variable]);
   });
   drupal_set_message(t('The configuration options have been saved.'));
-}
-
-/**
- * AJAX callback for admin user lookup.
- */
-function ding_react_admin_user_callback(array $form, array $form_state) {
-  return $form['migration']['user_status']['user'];
-}
-
-/**
- * Submit handler when resetting user migration status.
- */
-function ding_react_user_reset_migration_status(array $form, array &$form_state) {
-  $account = $form_state['values']['user_account'];
-  if (!$account || empty($account->openlist_uid)) {
-    return;
-  }
-
-  // We mark migrated users by prefixing their OpenList uid. Remove the prefix
-  // to reset status.
-  $account->openlist_uid = preg_replace('/^' . DING_REACT_MIGRATED_UID_PREFIX . '/', '', $account->openlist_uid);
-  user_save($account);
-
-  drupal_set_message(t('Reset migration status for user %uid', ['%uid' => $account->uid]), 'status');
-  ding_react_log('Reset migration status for user %uid', ['%uid' => $account->uid], WATCHDOG_NOTICE);
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4774

#### Description

Remove user openlist status check in admin interface

This is no longer needed as we expect most users to be migrated by
now.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.