### PR TITLE
4276: Prevent overlap between teaser and button in nodelist + blocks

### DIFF
--- a/modules/ding_nodelist/js/node_blocks.js
+++ b/modules/ding_nodelist/js/node_blocks.js
@@ -53,7 +53,7 @@
       $('.node-ding-news.nb-item', context).mouseenter(function() {
         var title_and_lead_height;
         // Set height for title and lead text.
-        title_and_lead_height = $(this).find('.title').outerHeight(true) + $(this).find('.field-name-field-ding-news-lead').outerHeight(true) + 50;
+        title_and_lead_height = $(this).find('.title').outerHeight(true) + $(this).find('.field-name-field-ding-news-lead').outerHeight(true) + 75;
 
         $(this).find('.title-and-lead').css('min-height', title_and_lead_height);
       });

--- a/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
+++ b/modules/ding_nodelist/templates/ding_nodelist.ding_eresource.node_blocks.tpl.php
@@ -22,8 +22,7 @@
         </div>
         <div class="title-and-lead">
           <h3 class="title" id="<?php print 'link-id-' . $item->nid; ?>"><?php print $item->title; ?></h3>
-          <div
-            class="field field-name-field-ding-eresource-lead field-type-text-long field-label-hidden">
+          <div class="field field-name-field-ding-eresource-lead field-type-text-long field-label-hidden element-hidden">
             <div class="field-items">
               <div class="field-item">
                 <?php print $item->teaser_lead; ?>

--- a/themes/ddbasic/ddbasic.info
+++ b/themes/ddbasic/ddbasic.info
@@ -75,6 +75,7 @@
   stylesheets[all][] = sass_css/add-ons/frontpage-header.css
   stylesheets[all][] = sass_css/add-ons/genre-list.css
   stylesheets[all][] = sass_css/add-ons/material-list.css
+  stylesheets[all][] = sass_css/add-ons/nodelist.css
   stylesheets[all][] = sass_css/add-ons/panel-pane-ding-node.css
   stylesheets[all][] = sass_css/add-ons/related-content.css
   stylesheets[all][] = sass_css/add-ons/servicemeddelelse-list.css

--- a/themes/ddbasic/sass/add-ons/nodelist.scss
+++ b/themes/ddbasic/sass/add-ons/nodelist.scss
@@ -1,0 +1,4 @@
+.ding_nodelist-node_blocks .nb-item.node-ding-page:hover .inner,
+.ding_nodelist-node_blocks .nb-item.node-ding-eresource:hover .inner{
+  padding-bottom: 50px;
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4276

#### Description

You can use nodelist to display nodes in blocks. Each node has a
teaser text and read more link in the form of a button. This is shown
when the user hovers node. 

However when the truncated teaser spans the entire last line then the
read more button will overlap with the teaser text.

To prevent this we increase the size of the teaser when hovered. This
provides more space for the button which will no longer overlap with
the text.

#### Screenshot of the result

Before as seen on https://upgrade-fbs.ddbcms.dk/section/sektion:

https://user-images.githubusercontent.com/73966/112604923-04272b80-8e17-11eb-9b41-869fc1416445.mp4

After:

https://user-images.githubusercontent.com/73966/112604948-0c7f6680-8e17-11eb-8a16-65a76f4d6dd1.mp4

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.