### PR TITLE
4927: Set top-level heading on section titles

### DIFF
--- a/themes/ddbasic/template.php
+++ b/themes/ddbasic/template.php
@@ -141,6 +141,13 @@ function ddbasic_preprocess_panels_pane(&$vars) {
   if ($vars['pane']->subtype == 'menu_block-main_menu_second_level') {
     ddbasic_body_class('has-second-level-menu');
   }
+
+  // Check if we're displaying a taxonomy terms, i.e. a section.
+  // @todo can we make a better check for this?
+  if ($vars['pane']->panel == 'primary' && $vars['pane']->type == 'term_description') {
+    // Tell the template to render a top-level heading.
+    $vars['pane']->configuration['override_title_heading'] = 'h1';
+  }
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4927

#### Description

Changes section titles to always be displayed as `h1` elements.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

This may be considered a hack, but doing it in the template is even more hackish …