### PR TITLE
4895: Set top-level heading on registration page title

### DIFF
--- a/modules/ding_registration/templates/ding-registration.tpl.php
+++ b/modules/ding_registration/templates/ding-registration.tpl.php
@@ -20,7 +20,7 @@
   <div class="layout-wrapper">
     <div class="pane-content">
       <div class="primary-content ding-auth">
-        <h2 class="pane-title"><?php print render($title); ?></h2>
+        <h1 class="pane-title"><?php print render($title); ?></h1>
         <div class="ding-auth--registration-information">
           <?php print render($content); ?>
         </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4895

#### Description

Changes registration page title be displayed as an h1 element.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.