### PR TITLE
5080: Fix bibdk button background color

### DIFF
--- a/themes/ddbasic/sass/components/ting-subsearch.scss
+++ b/themes/ddbasic/sass/components/ting-subsearch.scss
@@ -107,9 +107,11 @@
       border-radius: 5px;
       color: $color-text-on-secondary;
       background-color: $color-secondary;
+      transition: background-color .3s cubic-bezier(.165,.84,.44,1),color .3s cubic-bezier(.165,.84,.44,1);
 
       &:hover {
-        color: $color-text-on-secondary;
+        background-color: $grey-dark;
+        color: $white;
       }
     }
   }

--- a/themes/ddbasic/sass/components/ting-subsearch.scss
+++ b/themes/ddbasic/sass/components/ting-subsearch.scss
@@ -104,9 +104,9 @@
       text-align: center;
       margin-top: 15px;
       padding: 12px 25px 7px 25px;
-      background-color: #000;
       border-radius: 5px;
       color: $color-text-on-secondary;
+      background-color: $color-secondary;
 
       &:hover {
         color: $color-text-on-secondary;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5080

#### Description

Since we use "text on secondary" for bibdk external search button color, we also have to use secondary color as background.

Also add better hover effect.

#### Screenshot of the result
New background color (notice default visual is changed):
![5080-secondary-background-on-button](https://user-images.githubusercontent.com/5011234/115029501-56171a80-9ec6-11eb-8b8d-216e84a326a5.png)

Hover effect:
![5080-added-hover-effect](https://user-images.githubusercontent.com/5011234/115029514-58797480-9ec6-11eb-9b8d-8686dead3e7e.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
