### PR TITLE
4101: Add translatable FBS on hold field description

### DIFF
--- a/modules/fbs/fbs.features.field_instance.inc
+++ b/modules/fbs/fbs.features.field_instance.inc
@@ -174,7 +174,7 @@ function fbs_field_default_field_instances() {
     'bundle' => 'provider_fbs',
     'default_value' => NULL,
     'deleted' => 0,
-    'description' => '',
+    'description' => 'If you pick a start date earlier than 5 days from now some of your current reservations might still go through.',
     'display' => array(
       'default' => array(
         'label' => 'above',

--- a/project.make
+++ b/project.make
@@ -417,7 +417,7 @@ projects[tipsy][subdir] = "contrib"
 projects[tipsy][version] = "1.0-rc1"
 
 projects[token][subdir] = "contrib"
-projects[token][version] = "1.6"
+projects[token][version] = "1.8"
 
 projects[transliteration][subdir] = "contrib"
 projects[transliteration][version] = "3.2"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4101

#### Description

Add english source for on hold description

This will make it translatable via the field translate module.

Note that we also need to update Token module for this to work.
Version 1.7 contains a fix to the following issue:

https://www.drupal.org/node/2474403

Since 1.8 contains additional bug fixes we might as well upgrade
to the newest version.

#### Screenshot of the result

![4101-on-hold-description](https://user-images.githubusercontent.com/5011234/115035371-ce80da00-9ecc-11eb-909f-f4565055d3da.png)

![4101-on-hold-description-translation-with-link](https://user-images.githubusercontent.com/5011234/115035378-d0e33400-9ecc-11eb-96f1-f258c827a972.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
