### PR TITLE
5129: Use h1 for debt pane headline to improve accessibility

### DIFF
--- a/modules/ding_user_frontend/ding_user_frontend.pages_default.inc
+++ b/modules/ding_user_frontend/ding_user_frontend.pages_default.inc
@@ -1146,8 +1146,9 @@ function ding_user_frontend_default_page_manager_pages() {
     $pane->access = array();
     $pane->configuration = array(
       'context' => 'argument_entity_id:user_1',
-      'override_title' => 0,
-      'override_title_text' => '',
+      'override_title' => 1,
+      'override_title_text' => '%title',
+      'override_title_heading' => 'h1',
     );
     $pane->cache = array();
     $pane->style = array(

--- a/themes/ddbasic/templates/panel/panels-pane--debts.tpl.php
+++ b/themes/ddbasic/templates/panel/panels-pane--debts.tpl.php
@@ -32,7 +32,10 @@
     <?php print render($title_prefix); ?>
     <?php if (!empty($title)): ?>
       <div class="title-container">
-        <h2<?php print $title_attributes; ?>><?php print t($title); ?></h2>
+        <?php $heading_tag_name = isset($pane->configuration['override_title_heading']) ? $pane->configuration['override_title_heading'] : 'h2'; ?>
+        <<?php print $heading_tag_name ?> <?php print $title_attributes; ?>>
+          <?php print t($title); ?>
+        </<?php print $heading_tag_name ?>>
       </div>
     <?php endif; ?>
     <?php print render($title_suffix); ?>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5129

#### Description

Update the panel pane configuration to use H1 for the title.

For this to work we also have to update the template to respect the 
selected title tag.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.