### PR TITLE
5137: Add underline to links in WYSIWYG text on debts page

### DIFF
--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -67,6 +67,8 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     $ding_debt_introtext = variable_get('ding_debt_introtext', _ding_debt_introtext_default());
 
     $form['introtext'] = [
+      '#prefix' => '<div class="debt-body">',
+      '#suffix' => '</div>',
       '#markup' => check_markup($ding_debt_introtext['value'], $ding_debt_introtext['format']),
     ];
   }
@@ -198,6 +200,8 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
       $ding_debt_external_extra_information = variable_get('ding_debt_external_extra_information', _ding_debt_external_extra_information_default());
 
       $form['external_extra_information'] = [
+        '#prefix' => '<div class="debt-body">',
+        '#suffix' => '</div>',
         '#markup' => check_markup($ding_debt_external_extra_information['value'], $ding_debt_external_extra_information['format']),
       ];
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5137

#### Description

Add underline to links in WYSIWYG text on debts page to improve accessibility.

For ancient reasons the default display of links is without
decoration. Consequently we have to add it on a per-case basis.

By adding a class ending with -body we get the decoration we want.
It is not pretty but it works.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.