### PR TITLE
5133: Map readable FBS dept type to Ding dept type

### DIFF
--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -57,6 +57,7 @@ function fbs_debt_list($account, $reset = FALSE) {
       }
 
       foreach ($res as $fee) {
+        /* @var \FBS\Model\Fee $fee */
         $id = $fee->feeId;
 
         $data = array(
@@ -68,7 +69,7 @@ function fbs_debt_list($account, $reset = FALSE) {
           // And the only thing we can do here is set it to zero, as the original
           // amount isn't available.
           'amount_paid' => 0,
-          'type' => $fee->reasonMessage,
+          'type' => fbs_debt_translate_debt_type($fee->type),
           'payable' => $fee->payableByClient,
         );
 
@@ -121,6 +122,32 @@ function fbs_debt_list($account, $reset = FALSE) {
   }
 
   return $results;
+}
+
+/**
+ * Translate FBS debt types into a human readable string in english.
+ *
+ * @param string $debt_type
+ *   The FBS debt type.
+ *
+ * @return string
+ *   English translation of the debt type if found.
+ */
+function fbs_debt_translate_debt_type($debt_type) {
+  switch ($debt_type) {
+    case 'compensation':
+      $str = t('Compensation', [], ['context' => 'fbs']);
+      break;
+
+    case 'fee':
+      $str = t('Fee', [], ['context' => 'fbs']);
+      break;
+
+    default:
+      $str = t('Other', [], ['context' => 'fbs']);
+  }
+
+  return $str;
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5133

#### Description

Reason message is a free text field where library employees can enter
whatever. This does not go well with the design. Instead use the type
field.

We expect the type field to be restricted regarding allowed values
but official documentation of actual values is nowhere to be found.
Consequently we reference types which can be found in examples like
https://platform.dandigbib.org/issues/5059 and fall back to a generic
“other” for the rest.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.