### PR TITLE
5139: Ensure debt form always has a button

### DIFF
--- a/modules/ding_debt/ding_debt.admin.inc
+++ b/modules/ding_debt/ding_debt.admin.inc
@@ -208,4 +208,9 @@ function ding_debt_settings_form_validate($form, $form_state) {
       form_error($form['external']['button']['ding_debt_external_button_url'], t('Button link is required.'));
     }
   }
+
+  if (empty($form_state['values']['ding_debt_enable_internal_button'])
+    && empty($form_state['values']['ding_debt_enable_external_button'])) {
+    form_error($form, t('Please enable either internal or external payment'));
+  }
 }

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -216,6 +216,7 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
 
       $options = [
         'attributes' => [
+          'role' => 'button',
           'class' => 'external-payment',
           'target' => '_blank',
         ],


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5139

#### Description

Ensure debt form always has a button. This is required to ensure accessibility.

Adding the button role to the external payment url should be
sufficient for assistive technologies to determine its relevance.

We also have to ensure that either form of payment button is enabled.
Otherwise there will actually be no buttons. Restructuring the form
to handle such a setup will be quite tedious and probably not a
relevant usage scenario. Consequently we do not accept such a
configuration.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
