### PR TITLE
5134: Fix material item information floating on mobile

### DIFF
--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -191,6 +191,10 @@
         box-sizing: border-box;
         padding-right: 10px;
         margin: 0 0 20px;
+
+        &:nth-child(odd) {
+          clear: left;
+        }
       }
 
       &.loan-date {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5134

#### Description

Fix material item information floating on mobile.

Without clearing and with sufficiently long dates as the first entry
then the third entry may creep up to the right underneath the second
one on mobile.

With the clearing odd numbered items should stay to the left.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.