### PR TITLE
5136: Debt layout

### DIFF
--- a/themes/ddbasic/sass/components/panel/class-panel.scss
+++ b/themes/ddbasic/sass/components/panel/class-panel.scss
@@ -282,9 +282,26 @@
   margin-bottom: 25px;
 
   @include clearfix();
+
   .total-amount {
-    width: 100%;
-    margin: 10px 0;
+    // This combination of margin and padding corresponds to the size of covers
+    // for material items in the debt list. This makes the total align with
+    // other infos.
+    margin: 10px 0 10px 19%;
+    padding-left: 50px;
+
+    @include media($mobile) {
+      margin: 0;
+      padding: 20px 10px;
+    }
+
+    // Make the total appear as other infos with a label in bold and value
+    // on the next line.
+    font-weight: bold;
+    .amount {
+      display: block;
+      font-weight: normal;
+    }
   }
 
   .pay-buttons {

--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -178,7 +178,16 @@
     }
     > li {
       float: left;
+      width: 33%;
+      box-sizing: border-box;
+      padding-right: 10px;
+      margin: 0 0;
       list-style: none;
+
+      &:nth-child(1+3n) {
+        clear: left;
+      }
+
       > div {
         margin-right: 30px;
         &:last-child {
@@ -188,13 +197,10 @@
       // Mobile
       @include media($mobile) {
         width: 50%;
-        box-sizing: border-box;
-        padding-right: 10px;
-        margin: 0 0 20px;
-      }
 
-      &.loan-date {
-        clear: left;
+        &:nth-child(odd) {
+          clear: left;
+        }
       }
 
       &.url {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5136

#### Description

Improve layout of material item information elements

Currently we rely on dynamic resizing based on content. This results
in an uneven rhythm where you are not guaranteed that the same info
aligns vertically across items in a list.

Introduce a shared grid where each info has the same width - 33% on
desktop and 50% on mobile. Clear accordingly to avoid overlapping
infos.

Note that the original issue deals with debts but this actually
targets all material item lists.

Also make debt totals align with other infos in material list. This goes for both spacing (margin + padding) and fonts.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.