### PR TITLE
5151: Ensure optOut cookies are removed from users browsers 

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.install
+++ b/modules/ding_webtrekk/ding_webtrekk.install
@@ -9,7 +9,14 @@
  * Whitelist webtrekk opt-out cookie in EU cookie compliance settings.
  */
 function ding_webtrekk_update_7001() {
-  ding_webtrekk_whitelist_opt_out_cookie();
+  // This function previously whitelisted a webtrekk opt-out cookie.
+  //
+  // The contents of this function has been removed after switching to
+  // cookieless tracking. Read more about this issue in
+  // https://platform.dandigbib.org/issues/5151.
+  //
+  // The function has been left empty, since some distrubitons have
+  // already had this update_hook() ran - but older sites have not.
 }
 
 /**
@@ -28,22 +35,3 @@ function ding_webtrekk_update_7002() {
   }
 }
 
-/**
- * Whitelist webtrekk opt-out cookie in EU cookie compliance settings.
- */
-function ding_webtrekk_whitelist_opt_out_cookie() {
-  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
-  $cookie_name = 'webtrekkOptOut';
-  // Depending on whether this is run from an update, a normal install of the
-  // module after ding2 install OR installed DURING ding2 installation via
-  // module selection form, we might run before or after ding2 calls
-  // ding2_set_eu_cookie_compliance_settings(), so we need to be able to handle
-  // both cases here. Hence this check and no hook_update_dependencies().
-  if (!empty($ecc_settings['whitelisted_cookies'])) {
-    $ecc_settings['whitelisted_cookies'] .= "\r\n" . $cookie_name;
-  }
-  else {
-    $ecc_settings['whitelisted_cookies'] = $cookie_name;
-  }
-  i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
-}

--- a/modules/ding_webtrekk/ding_webtrekk.install
+++ b/modules/ding_webtrekk/ding_webtrekk.install
@@ -6,17 +6,26 @@
  */
 
 /**
- * Implements hook_install().
- */
-function ding_webtrekk_install() {
-  ding_webtrekk_whitelist_opt_out_cookie();
-}
-
-/**
  * Whitelist webtrekk opt-out cookie in EU cookie compliance settings.
  */
 function ding_webtrekk_update_7001() {
   ding_webtrekk_whitelist_opt_out_cookie();
+}
+
+/**
+ * Remove webtrekk opt-out cookie from EU cookie compliance whitelist.
+ */
+function ding_webtrekk_update_7002() {
+  $ecc_settings = i18n_variable_get('eu_cookie_compliance', 'da', []);
+  if (!empty($ecc_settings['whitelisted_cookies'])) {
+    $whitelisted_cookies = explode("\r\n", $ecc_settings['whitelisted_cookies']);
+    if (($key = array_search('webtrekkOptOut', $whitelisted_cookies)) !== false) {
+      unset($whitelisted_cookies[$key]);
+      $whitelisted_cookies = implode("\r\n", $whitelisted_cookies);
+      $ecc_settings['whitelisted_cookies'] = $whitelisted_cookies;
+      i18n_variable_set('eu_cookie_compliance', $ecc_settings, 'da');
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5151

#### Description

Removing the cookie from ECC whitelist is the most convenient of achieving this without writing any frontend code to handle this ourselves.

It was left there to keep support of opt-in/out with cookie-based tracking, but in current situation it's preffered to just remove
it.

This is the successor of #1776 with a bit more cleanup of obsolete functions. This would normally happen in a review but I have taken over work on the issue.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/73966/117095960-21c9a800-ad68-11eb-9aa0-7e463d365052.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
