### PR TITLE
5155: Hide checklist button from teasers

### DIFF
--- a/themes/ddbasic/sass/components/ting-object/ting-object.scss
+++ b/themes/ddbasic/sass/components/ting-object/ting-object.scss
@@ -156,8 +156,8 @@
           opacity: 1;
         }
       }
-      // Hide ding react add to list button in teaser views.
-      [data-ddb-app="add-to-checklist"] {
+      // Hide ding react checklist button in teaser views.
+      [data-ddb-app="checklist-material-button"] {
         display: none;
       }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5155

#### Description

After replacing the checklist button we have to update the CSS rule 
which hides it on teaser views. This was missing when implementing
#1766.

Currently the styling does not support displaying the button in a
good way here. Consequently we hide it.

When implementing this I have searched through the codebase and I cannot find any other references to the `add-to-checklist` button.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.