### PR TITLE
5109: Styling popup find-more-button

### DIFF
--- a/themes/ddbasic/sass/components/cookie.scss
+++ b/themes/ddbasic/sass/components/cookie.scss
@@ -25,9 +25,25 @@
       position: relative;
     }
 
+    .find-more-button {
+      color: $white;
+      font-size: inherit;
+      text-decoration: underline;
+      transition: color .2s ease-in-out;
+      @media (prefers-reduced-motion) {
+        transition: color .0s ease-in-out;
+      }
+      &:hover {
+        color: $color-secondary !important;
+        transition: color .2s ease-in-out;
+        @media (prefers-reduced-motion) {
+          transition: color .0s ease-in-out;
+        }
+      }
+    }
+
     #popup-buttons {
       .agree-button,
-      .find-more-button,
       .hide-popup-button,
       .decline-button,
       .eu-cookie-withdraw-button {
@@ -77,7 +93,6 @@
       max-width: none;
       float: left;
       .agree-button,
-      .find-more-button,
       .hide-popup-button,
       .decline-button {
         float: left;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5109

#### Description

In some installations the button is not visible due to a fallback to a black text color.
This pull request addresses that by adding styling to the `.find-more-button`. Also that element is not a child of `#popup-buttons` hence we have moved the styling of it.

#### Screenshot of the result

Default:
<img width="352" alt="Screenshot 2021-06-15 at 12 34 20" src="https://user-images.githubusercontent.com/332915/122041312-180c7900-cdd9-11eb-8838-efae96ee6c4b.png">

With `:hover`:
<img width="310" alt="Screenshot 2021-06-15 at 12 34 26" src="https://user-images.githubusercontent.com/332915/122041306-16db4c00-cdd9-11eb-8a2a-d22d41494255.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
