### PR TITLE
5082: Add red color for error text

### DIFF
--- a/themes/ddbasic/sass/components/messages.scss
+++ b/themes/ddbasic/sass/components/messages.scss
@@ -60,15 +60,25 @@
     border: none;
     background-image: none;
     background-color: transparent;
-    color: $color-standard-text;
     > ul {
       list-style: none;
       margin: 0;
       > li {
         padding: 5px 0;
         margin: 5px 0;
-        color: $color-standard-text;
       }
     }
+  }
+  &.status {
+    color: $color-standard-text;
+  }
+  &.error {
+    color: $red-error;
+  }
+}
+
+.pane-user-login {
+  .form-required {
+    color: $red-error;
   }
 }

--- a/themes/ddbasic/sass/configuration/_variables.scss
+++ b/themes/ddbasic/sass/configuration/_variables.scss
@@ -28,6 +28,7 @@ $green: #24d273;
 $green-text: darken($green, 10);
 $red: #e22045;
 $red-text: $red;
+$red-error: darken($red, 15%);
 $yellow: #ffca5f;
 $yellow-text: darken($yellow, 15);
 


### PR DESCRIPTION
#### Link to issue



#### Description

Change red color for error messages shown as text or symbols to have a better contrast.

New contrast ratio is like this: https://webaim.org/resources/contrastchecker/?fcolor=A11515&bcolor=F1F1F2

#### Screenshot of the result

Changes text like this:
![Screenshot 2021-06-18 at 14 13 27](https://user-images.githubusercontent.com/332915/122559307-73d83b80-d03f-11eb-9f4b-193a236f9f14.png)

To this:
![Screenshot 2021-06-18 at 14 13 33](https://user-images.githubusercontent.com/332915/122559325-79ce1c80-d03f-11eb-8fd0-d35456595a3d.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
