### PR TITLE
5193: Fix section panels template being overriden

### DIFF
--- a/modules/ding_sections/ding_sections.install
+++ b/modules/ding_sections/ding_sections.install
@@ -326,7 +326,7 @@ function _ding_sections_create_teaser_field() {
     'description' => 'Tekst shown in teasers.',
     'display' => [
       'default' => [
-        'label' => 'above',
+        'label' => 'hidden',
         'type' => 'text_default',
         'weight' => -5,
         'settings' => [],
@@ -416,3 +416,15 @@ function ding_sections_update_7103() {
 
   field_bundle_settings($entity_type, $bundle, $bundle_settings);
 }
+
+/**
+ * Hide section teaser label
+ */
+function ding_sections_update_7105() {
+  $instance = field_read_instance('taxonomy_term', 'field_ding_sections_teaser', 'section');
+  if ($instance) {
+    $instance['display']['default']['label'] = 'hidden';
+    field_update_instance($instance);
+  }
+}
+

--- a/modules/ding_sections/ding_sections.install
+++ b/modules/ding_sections/ding_sections.install
@@ -27,6 +27,16 @@ function ding_sections_install() {
     'ding_sections_term_panel',
   );
   module_enable($submodules);
+
+  field_bundle_settings('taxonomy_term', 'section', [
+    'extra_fields' => [
+      'form' => [
+        'name' => ['weight' => -6],
+        'description' => ['weight' => -4],
+        'path' => ['weight' => -1],
+      ],
+    ],
+  ]);
 }
 
 /**
@@ -241,7 +251,7 @@ function _ding_sections_create_image_field() {
         'manualcrop_require_cropping' => [],
       ],
       'type' => 'media_generic',
-      'weight' => 3,
+      'weight' => -3,
     ],
   ];
 
@@ -318,7 +328,7 @@ function _ding_sections_create_teaser_field() {
       'default' => [
         'label' => 'above',
         'type' => 'text_default',
-        'weight' => -1,
+        'weight' => -5,
         'settings' => [],
         'module' => 'text',
       ],
@@ -364,4 +374,45 @@ function _ding_sections_purge_teaser_field() {
  */
 function ding_sections_update_7102() {
   _ding_sections_create_teaser_field();
+}
+
+/**
+ * Configure form field order for sections.
+ */
+function ding_sections_update_7103() {
+  $entity_type = 'taxonomy_term';
+  $bundle = 'section';
+
+  $extra_fields = ['name', 'description', 'path'];
+
+  $field_instance_order = [
+    'name',
+    'field_ding_sections_teaser',
+    'description',
+    'field_ding_sections_image',
+    'field_ding_sections_custom_css',
+    'path',
+  ];
+
+  // Bundle settings contain settings for extra fields and their weights.
+  // They are loaded and saved together.
+  $bundle_settings = field_bundle_settings($entity_type, $bundle);
+
+  // Update field weights.
+  $num_fields = count($field_instance_order);
+  foreach ($field_instance_order as $order => $field_name) {
+    $weight = $order - $num_fields;
+    if (in_array($field_name, $extra_fields)) {
+      $bundle_settings['extra_fields']['form'][$field_name]['weight'] = $weight;
+    }
+    else {
+      $instance = field_read_instance($entity_type, $field_name, $bundle);
+      if ($instance) {
+        $instance['widget']['weight'] = $weight;
+        field_update_instance($instance);
+      }
+    }
+  }
+
+  field_bundle_settings($entity_type, $bundle, $bundle_settings);
 }

--- a/modules/ding_sections/ding_sections.module
+++ b/modules/ding_sections/ding_sections.module
@@ -447,3 +447,38 @@ function ding_sections_preprocess_views_view_fields(&$vars) {
     }
   }
 }
+
+/**
+ * Implements hook_ctools_plugin_pre_alter().
+ */
+function ding_sections_ctools_plugin_pre_alter(&$plugin, &$info) {
+  if ($plugin['name'] !== 'term_description') {
+    return;
+  }
+
+  // Set a render callback to replace the default content of the term
+  // description pane.
+  $plugin['render callback'] = "ding_sections_render_term";
+}
+
+/**
+ * Custom render function for section terms
+ *
+ * This is an alternate implementation of
+ * ctools_term_description_content_type_render(). It replaces the
+ * content of the original with a default taxonomy term view. The
+ * original function will only output the description. This allows us
+ * to output other fields without replacing the pane already being
+ * used.
+ */
+function ding_sections_render_term($subtype, $conf, $panel_args, $context) {
+  $block = ctools_term_description_content_type_render($subtype, $conf, $panel_args, $context);
+
+  $term = $context->data;
+  $vocabulary = taxonomy_vocabulary_load($term->vid);
+  if ($vocabulary->machine_name == "section") {
+    $block->content =  taxonomy_term_view($context->data);
+  }
+
+  return $block;
+}

--- a/modules/ding_sections/ding_sections.module
+++ b/modules/ding_sections/ding_sections.module
@@ -116,7 +116,6 @@ function ding_sections_form_taxonomy_form_term_alter(&$form, &$form_state) {
 
   $form['section_tabs'] = array(
     '#type' => 'vertical_tabs',
-    '#weight' => 100,
   );
   $form['relations']['#access'] = FALSE;
 

--- a/modules/ding_sections/modules/ding_sections_custom_css/ding_sections_custom_css.features.field_base.inc
+++ b/modules/ding_sections/modules/ding_sections_custom_css/ding_sections_custom_css.features.field_base.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * ding_sections_custom_css.features.field_base.inc
@@ -18,14 +17,6 @@ function ding_sections_custom_css_field_default_field_bases() {
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_ding_sections_custom_css',
-    'foreign keys' => array(
-      'format' => array(
-        'columns' => array(
-          'format' => 'format',
-        ),
-        'table' => 'filter_format',
-      ),
-    ),
     'indexes' => array(
       'format' => array(
         0 => 'format',

--- a/modules/ding_sections/modules/ding_sections_custom_css/ding_sections_custom_css.features.field_instance.inc
+++ b/modules/ding_sections/modules/ding_sections_custom_css/ding_sections_custom_css.features.field_instance.inc
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * @file
  * ding_sections_custom_css.features.field_instance.inc
@@ -11,7 +10,8 @@
 function ding_sections_custom_css_field_default_field_instances() {
   $field_instances = array();
 
-  // Exported field_instance: 'taxonomy_term-section-field_ding_sections_custom_css'.
+  // Exported field_instance:
+  // 'taxonomy_term-section-field_ding_sections_custom_css'.
   $field_instances['taxonomy_term-section-field_ding_sections_custom_css'] = array(
     'bundle' => 'section',
     'default_value' => NULL,
@@ -41,7 +41,7 @@ function ding_sections_custom_css_field_default_field_instances() {
         'rows' => 5,
       ),
       'type' => 'text_textarea',
-      'weight' => 3,
+      'weight' => -2,
     ),
   );
 

--- a/modules/ding_sections/modules/ding_sections_term_menu/ding_sections_term_menu.module
+++ b/modules/ding_sections/modules/ding_sections_term_menu/ding_sections_term_menu.module
@@ -149,6 +149,9 @@ function ding_sections_term_menu_form_taxonomy_form_term_alter(&$form, &$form_st
  */
 function ding_sections_term_validate($form, &$form_state) {
   if ($form_state['values']['section']['enabled'] == 1) {
+    // Automatically transfer title from name to menu.
+    $form_state['values']['menu']['link_title'] = $form_state['values']['name'];
+
     $menu_parameters = array(
       'parent' => 'Parent item',
     );

--- a/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
+++ b/modules/ding_sections/modules/ding_sections_term_panel/ding_sections_term_panel.install
@@ -132,3 +132,16 @@ function ding_sections_term_panel_update_7001(&$sandbox) {
   $handler = ding_sections_term_panel_get_handler();
   page_manager_save_task_handler($handler);
 }
+
+/**
+ * Restore base panel page to default settings.
+ */
+function ding_sections_term_panel_update_7002(&$sandbox) {
+  $handler = page_manager_load_task_handler('term_view', '', 'term_section_panel_context');
+  if ($handler) {
+    page_manager_delete_task_handler($handler);
+  }
+
+  $handler = ding_sections_term_panel_get_handler();
+  page_manager_save_task_handler($handler);
+}

--- a/themes/ddbasic/sass/components/ding-sections.scss
+++ b/themes/ddbasic/sass/components/ding-sections.scss
@@ -1,5 +1,14 @@
 @import '../base.scss';
 
+.pane-term-description .vocabulary-section {
+
+  .field-name-field-ding-sections-teaser {
+    @include font('base-bold');
+    margin: 20px 0;
+  }
+
+}
+
 .pane-ding-sections {
   padding-bottom: 30px;
 

--- a/themes/ddbasic/templates/taxonomy/taxonomy-term--section.tpl.php
+++ b/themes/ddbasic/templates/taxonomy/taxonomy-term--section.tpl.php
@@ -1,0 +1,18 @@
+<?php
+
+hide($content['field_ding_sections_custom_css']);
+hide($content['field_ding_sections_image']);
+hide($content['field_term_page']);
+
+?>
+<div id="taxonomy-term-<?php print $term->tid; ?>" class="<?php print $classes; ?>">
+
+  <?php if (!$page): ?>
+    <h2><a href="<?php print $term_url; ?>"><?php print $term_name; ?></a></h2>
+  <?php endif; ?>
+
+  <div class="content">
+    <?php print render($content); ?>
+  </div>
+
+</div>

--- a/themes/ddbasic/templates/view/views-view-fields--ding-sections--ding-sections-groups.tpl.php
+++ b/themes/ddbasic/templates/view/views-view-fields--ding-sections--ding-sections-groups.tpl.php
@@ -29,7 +29,7 @@
   <a href="<?php print url('taxonomy/term/' . $row->tid); ?>" aria-labelledby="<?php print 'link-id-' . $row->tid; ?>"<?php print drupal_attributes($link_attributes); ?>>
     <div class="group-text">
       <h3 id="<?php print 'link-id-' . $row->tid; ?>" class="title"><?php print $row->taxonomy_term_data_name; ?></h3>
-      <?php if (!empty($row->taxonomy_term_data_description)) : ?>
+      <?php if (!empty($row->field_field_ding_sections_teaser[0]['rendered'])) : ?>
       <div class="section-description">
         <?php print drupal_render($row->field_field_ding_sections_teaser[0]['rendered']); ?>
       </div>


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5193

#### Description

Ding Sections are supports to create a new panels variant for each
section page where editors can decide what panes to use for the
specific term/page. This is controlled by the term page field which
is set by default.
 
In #1756 the weight for the section tab which places
the field in the vertical tabs section was set in order to move the
section to the bottom of the section form.

Unfortunately for some reason this did not result in moving the
section down. Instead the term page field is removed from the form
entirely. This means that is does not have a value. Due to the way
the module is constructed this will instead result in editing the
general panels variant for sections.

![Sections | Københavns Biblioteker | Logget ind 2021-06-19 22-05-06](https://user-images.githubusercontent.com/73966/122654245-6f4c7980-d14a-11eb-8562-f3797d437475.png)

This makes it seem as if new sections copy the old ones instead of
starting from scratch. Working with new sections will also affect
other sections which also accidentally use the general variant.

![Skabelon for taksonomitermer | Københavns Biblioteker | Logget ind 2021-06-19 22-04-04](https://user-images.githubusercontent.com/73966/122654236-5b087c80-d14a-11eb-8065-c3e5471598d2.png)

To address this this commits introduces the following changes:

1. Remove the #weight setting causing problems,
2. Set field order for current sites. Since the ding_sections do not
use features we have to do this manually using an update hook
combining field instances and bundle settings,
3. Set field order for new sites mirroring the changes in 2
4. Revert the ding sections general panels variant to the default
setup.

#### Screenshot of the result

![Sections | Ding2 | Logget ind 2021-06-19 22-06-12](https://user-images.githubusercontent.com/73966/122654268-9a36cd80-d14a-11eb-95a2-fb90de8df467.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.