### PR TITLE
4510: Changed styling for event labels

### DIFF
--- a/themes/ddbasic/sass/components/node/event.scss
+++ b/themes/ddbasic/sass/components/node/event.scss
@@ -317,29 +317,11 @@
       margin-bottom: 30px;
     }
     .field-label-inline {
-      position: relative;
+      display: flex;
       width: 100%;
-      float: left;
       .field-label {
-        position: absolute;
-        top: 0;
-        left: 0;
+        overflow-wrap: break-word;
         width: 100px;
-
-        // Tablet
-        @include media($tablet) {
-          @include span-columns(2 of 5);
-        }
-      }
-
-      .field-item {
-        width: 100%;
-        padding-left: 100px;
-
-        // Tablet
-        @include media($tablet) {
-          padding-left: getColumn(2 of 5);
-        }
       }
     }
     .field-name-field-ding-event-files {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4510

#### Description

Removes text overflow on event labels.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ x ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ x ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ x ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
