### PR TITLE
5123: removed text-decoration none in standardscss

### DIFF
--- a/themes/ddbasic/sass/base/standard.scss
+++ b/themes/ddbasic/sass/base/standard.scss
@@ -210,7 +210,6 @@ img.file-icon {
 
 a {
   @include transition(color $speed $ease);
-  text-decoration: none;
   color: $color-text-link;
   &:hover {
     color: $charcoal;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5123

#### Description

I have removed `text-decoration:none `from links in standard.scss. 

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/15377965/125033631-db5a3780-e08f-11eb-8631-37bf44a79988.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions
Failed behat test is not related to changed styling