### PR TITLE
5092: Log in existing users trying to register

### DIFF
--- a/modules/ding_registration/includes/ding_registration.acceptance.inc
+++ b/modules/ding_registration/includes/ding_registration.acceptance.inc
@@ -115,8 +115,13 @@ function ding_registration_acceptance_form_submit($form, $form_state) {
 
   // Try to create the user at the provider.
   try {
-    // Create user as the provider.
-    ding_provider_invoke('user', 'create', $user_info['attributes']['userId'], $values['pin'], $values['name'], $values['mail'], $values['branch']);
+    try {
+      // Create user at the provider.
+      ding_provider_invoke('user', 'create', $user_info['attributes']['userId'], $values['pin'], $values['name'], $values['mail'], $values['branch']);
+    }
+    catch (DingProviderUserExistsError $e) {
+      // If they exists, just carry on trying logging them in.
+    }
 
     // Set redirect and try logging in the user.
     if (_ding_adgangsplatformen_provider_login($user_info)) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5092

#### Description

Simply catch the `DingProviderUserExistsError` exception and carry on.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
