### PR TITLE
5225: Revert "4877: Check dcterms:URI before fetching relations"

### DIFF
--- a/modules/opensearch/src/OpenSearchTingObject.php
+++ b/modules/opensearch/src/OpenSearchTingObject.php
@@ -218,31 +218,27 @@ class OpenSearchTingObject implements TingObjectInterface {
    */
   public function getOnlineUrl() {
     $url = '';
-
-    // First check dcterms:URI to try to get online URL without having to fetch
-    // relations.
-    if (!empty($this->getRecordEntry('dc:identifier', 'dcterms:URI'))) {
-      $url = $this->firstEntry($this->getRecordEntry('dc:identifier', 'dcterms:URI'));
-      // Give ting_proxy a change to rewrite the url.
-      drupal_alter('ting_online_url', $url, $this);
-    }
-
     // Try to find the online url from relation data, which requires us to get
     // relations. First check if relations are set; if not do another request
     // to get relations.
-    if (empty($url)) {
-      $relations = $this->getRelations();
+    $relations = $this->getRelations();
 
-      foreach ($relations as $relation) {
-        if ($relation->getType() === 'dbcaddi:hasOnlineAccess') {
-          $url = preg_replace('/^\[URL\]/', '', $relation->getURI());
-          // Check for correct url or leading token - some uri is only an id.
-          if (stripos($url, 'http') === 0 || strpos($url, '[') === 0) {
-            // Give other modules a chance to rewrite the url.
-            drupal_alter('ting_online_url', $url, $this);
-          }
+    foreach ($relations as $relation) {
+      if ($relation->getType() === 'dbcaddi:hasOnlineAccess') {
+        $url = preg_replace('/^\[URL\]/', '', $relation->getURI());
+        // Check for correct url or leading token - some uri is only an id.
+        if (stripos($url, 'http') === 0 || strpos($url, '[') === 0) {
+          // Give other modules a chance to rewrite the url.
+          drupal_alter('ting_online_url', $url, $this);
         }
       }
+    }
+
+    // No hasOnlineAccess found so fallback to dc:identifier.
+    if (empty($url) && !empty($this->getRecordEntry('dc:identifier', 'dcterms:URI'))) {
+      $url = $this->firstEntry($this->getRecordEntry('dc:identifier', 'dcterms:URI'));
+      // Give ting_proxy a change to rewrite the url.
+      drupal_alter('ting_online_url', $url, $this);
     }
 
     return $url;


### PR DESCRIPTION
This reverts commit 5fb344f7db1f4e0145f79c822a8d6310a2b3c77e.

#### Link to issue

https://platform.dandigbib.org/issues/5225

#### Description

Check relations before dcterms:URI.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
