### PR TITLE
5064 teaser not showing first

### DIFF
--- a/themes/ddbasic/sass/components/node/news.scss
+++ b/themes/ddbasic/sass/components/node/news.scss
@@ -260,7 +260,6 @@
     }
     .field-name-field-ding-news-lead {
       @include span-columns(6 of 8);
-      @include font('display-small');
       @include transition(
         height $speed $ease,
         opacity $speed $ease
@@ -334,6 +333,14 @@
         .ding-news-list-image {
           &::after {
             background-color: $black-overlay;
+          }
+        }
+        .field-name-field-ding-news-lead {
+          height: auto;
+          padding: 25px 15px;
+           // Mobile
+           @include media($mobile) {
+             display: none;
           }
         }
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5064?

#### Description

Teaser not showing on the first highligted news item on hover. Teaser is not shown on mobile devices so it is removed there.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/73946470/131136852-c508b1e6-8000-445a-af42-f01e1986255e.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
