### PR TITLE
5698: Moved external debts into own theme function

### DIFF
--- a/modules/ding_debt/ding_debt.module
+++ b/modules/ding_debt/ding_debt.module
@@ -59,6 +59,26 @@ function ding_debt_menu() {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function ding_debt_theme($existing, $type, $theme, $path) {
+  return array(
+    'ding_debt_external' => array(
+      'variables' => array(
+        'title' => NULL,
+        'debts' => [],
+        'total' => 0,
+        'extra_information' => '',
+        'button' => [],
+        'has_internal' => FALSE,
+      ),
+      'template' => 'ding_debt_external',
+      'path' => $path . '/templates',
+    ),
+  );
+}
+
+/**
  * Get the total amount of debts the user has.
  */
 function ding_debt_count($account = NULL) {

--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -23,14 +23,38 @@ function ding_debt_debts_content_type_render($subtype, $conf, $panel_args, $cont
   $block->module = 'ding_debt';
   $block->delta  = 'debts';
   $block->title = t('My debts');
+  $block->content = '';
 
   $debts = ding_provider_invoke('debt', 'list', $account);
 
   if ($debts) {
     $internal_debts = array_filter($debts, '_ding_debt_filter_payable');
     $external_debts = array_filter($debts, '_ding_debt_filter_nonpayable');
-    $build = ding_provider_get_form('ding_debt_debts_form', $internal_debts, $external_debts);
-    $block->content = render($build);
+
+    $has_internal = !empty($internal_debts) && variable_get('ding_debt_enable_internal', TRUE);
+    if ($has_internal) {
+      $build = ding_provider_get_form('ding_debt_debts_form', $internal_debts, $external_debts);
+      $block->content .= render($build);
+    }
+
+    if (!empty($external_debts) && variable_get('ding_debt_enable_external', FALSE)) {
+      $externals = array(
+        '#theme' => 'ding_debt_external',
+        '#title' => check_plain(variable_get('ding_debt_external_title', '')),
+        '#debts' => ding_debt_list_items($external_debts),
+        '#total' => array_reduce($external_debts, function ($total, $debt) {
+          return $total + $debt->amount - $debt->amount_paid;
+        }, 0),
+        '#extra_information' => variable_get('ding_debt_external_extra_information', _ding_debt_external_extra_information_default()),
+        '#button' => array(
+          'enabled' => variable_get('ding_debt_enable_external_button', FALSE),
+          'text' => variable_get('ding_debt_external_button_text', ''),
+          'url' => variable_get('ding_debt_external_button_url', ''),
+        ),
+        '#has_internal' => $has_internal,
+    );
+      $block->content .= render($externals);
+    }
   }
   else {
     $block->content = t('No debts');
@@ -171,63 +195,6 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
           ),
         );
       }
-    }
-  }
-
-  if ($has_external) {
-    if ($has_internal && variable_get('ding_debt_external_title', '')) {
-      $form['external_title'] = [
-        '#prefix' => '<h2>',
-        '#suffix' => '</h2>',
-        '#markup' => check_plain(variable_get('ding_debt_external_title', '')),
-      ];
-    }
-
-    $form['external_debts'] = ding_debt_list_items($external_debts);
-
-    $total = array_reduce($external_debts, function ($total, $debt) {
-      return $total + $debt->amount - $debt->amount_paid;
-    }, 0);
-
-    $form['external_total'] = array(
-      '#type' => 'item',
-      '#prefix' => '<div class="total-amount">',
-      '#suffix' => '</div>',
-      '#markup' => t('Total') . ': <span class="amount">' . number_format($total, 2, ',', ' ') . ' ' . t('Kr') . '</span>',
-    );
-
-    if (variable_get('ding_debt_external_show_extra_information', TRUE)) {
-      $ding_debt_external_extra_information = variable_get('ding_debt_external_extra_information', _ding_debt_external_extra_information_default());
-
-      $form['external_extra_information'] = [
-        '#prefix' => '<div class="debt-body">',
-        '#suffix' => '</div>',
-        '#markup' => check_markup($ding_debt_external_extra_information['value'], $ding_debt_external_extra_information['format']),
-      ];
-    }
-
-    if (variable_get('ding_debt_enable_external_button', FALSE)) {
-      $text = variable_get('ding_debt_external_button_text', '');
-      $url = variable_get('ding_debt_external_button_url', '');
-
-      $form['external_buttons'] = [
-        '#type' => 'container',
-        '#attributes' => [
-          'class' => ['pay-buttons'],
-        ],
-        '#tree' => FALSE,
-      ];
-
-      $options = [
-        'attributes' => [
-          'role' => 'button',
-          'class' => 'external-payment',
-          'target' => '_blank',
-        ],
-      ];
-      $form['external_buttons']['external_link'] = [
-        '#markup' => l($text, $url, $options),
-      ];
     }
   }
 

--- a/modules/ding_debt/templates/ding_debt_external.tpl.php
+++ b/modules/ding_debt/templates/ding_debt_external.tpl.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * @file
+ * Default template for external debts.
+ */
+?>
+<div id="ding-debt-debts-form">
+  <?php if ($has_internal && !empty($title)): ?>
+  <h2><?php print $title ?></h2>
+  <?php endif; ?>
+  <?php
+    print render($debts)
+  ?>
+  <div class="total-amount">
+    <div id="edit-external-total" class="form-item form-type-item">
+      <?php print t('Total') ?>: <span class="amount"><?php print number_format($total, 2, ',', ' ') ?> <?php print t('Kr') ?></span>
+    </div>
+  </div>
+
+  <?php if (!empty($extra_information['value'])): ?>
+  <div class="debt-body">
+    <?php print check_markup($extra_information['value'], $extra_information['format']) ?>
+  </div>
+  <?php endif; ?>
+
+  <?php if ($button['enabled']): ?>
+  <div class="pay-buttons form-wrapper" id="edit-external-buttons">
+    <?php print l($button['text'], $button['url'], $options = array(
+      'attributes' => [
+        'role' => 'button',
+        'class' => 'external-payment',
+        'target' => '_blank',
+      ],
+    )) ?>
+  </div>
+  <?php endif; ?>
+</div>
+


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5139

#### Description

The issues exists when you only have external debts payments and the first part of the form is empty. Then the form do not have any submit buttons.

Fixed by not rendering external inside the form, but in it's own theme function.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
