### PR TITLE
Core: Revert features when deploying on Platform.sh

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -111,6 +111,7 @@ hooks:
     set -e
     cd public
     drush -y updatedb
+    drush -y features-revert-all
     drush secure-permissions-rebuild
     drush css-generate
     drush pm-enable ding_config_import


### PR DESCRIPTION
#### Description

Without this it can be difficult to know whether a configuration
change has been implemented properly as it is up to the tester to
revert features using admin access.

This way features are reverted automatically which also matches the
deployment procedure on staging and production environments.

This problem has been identified during the test of #1804.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.