### PR TITLE
5138: use darker gray on information-label

### DIFF
--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -1,7 +1,7 @@
 //
 // Styling of Material item
 
-@import "../../base.scss";
+@import '../../base.scss';
 
 // ==========================================================================
 // User material item
@@ -184,7 +184,7 @@
       margin: 0 0;
       list-style: none;
 
-      &:nth-child(1 + 3n) {
+      &:nth-child(1+3n) {
         clear: left;
       }
 
@@ -216,7 +216,7 @@
       }
     }
     .item-information-label {
-      @include font("base-bold");
+      @include font('base-bold');
       color: $grey-darker;
     }
     #ding-loan-loans-form & {
@@ -227,14 +227,14 @@
         width: 100%;
       }
       .item-information-label {
-        @include font("base");
+        @include font('base');
         color: $color-standard-text;
       }
       &.loan-date,
       &.expire-date,
       &.material-number {
         .item-information-label {
-          @include font("base-bold");
+          @include font('base-bold');
           color: $grey-darker;
         }
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5138#change-54958

#### Description

Fix information label contrast issue

#### Screenshot of the result

![Screenshot 2021-10-12 at 15 02 32](https://user-images.githubusercontent.com/332915/136961493-df3ef8a8-5884-45d1-99f9-ed1b3b29a065.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions


