### PR TITLE
5092: Added user exists exception when status 409 is returned

### DIFF
--- a/modules/fbs/includes/fbs.user.inc
+++ b/modules/fbs/includes/fbs.user.inc
@@ -153,6 +153,15 @@ function fbs_user_create($cpr, $pin_code, $name, $mail, $branch_id) {
     // Re-throw other errors.
     throw $exception;
   }
+  catch (\Reload\Prancer\SwaggerApiError $exception) {
+    // When trying to registry use that exists FBS returns status 409.
+    if ($exception->getCode() === 409) {
+      throw new DingProviderUserExistsError('User account already exists');
+    }
+
+    // Re-throw other errors.
+    throw $exception;
+  }
 }
 
 /**

--- a/modules/fbs/includes/fbs.user.inc
+++ b/modules/fbs/includes/fbs.user.inc
@@ -154,7 +154,7 @@ function fbs_user_create($cpr, $pin_code, $name, $mail, $branch_id) {
     throw $exception;
   }
   catch (\Reload\Prancer\SwaggerApiError $exception) {
-    // When trying to registry use that exists FBS returns status 409.
+    // When trying to register a user that exists, FBS returns status 409.
     if ($exception->getCode() === 409) {
       throw new DingProviderUserExistsError('User account already exists');
     }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5092

#### Description

Throw `DingProviderUserExistsError` exception when FBS returns statusCode 409 at user create request.

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Scrutinizer error exists because I followed the used convention in the file.
