### PR TITLE
5259: Remove space between reservation buttons

### DIFF
--- a/themes/ddbasic/sass/components/panel/account.scss
+++ b/themes/ddbasic/sass/components/panel/account.scss
@@ -97,15 +97,15 @@
         margin-right: getGutter(8);
         padding: 0;
         float: left;
+        margin-bottom: 0;
+
         &:nth-child(2) {
           margin-right: 0;
-        }
-        &:nth-child(3) {
-          margin-top: 10px;
         }
 
         @include media($mobile) {
           margin-bottom: 10px;
+          width: auto;
           &:nth-child(3) {
             margin-top: 0;
           }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5259

#### Description

Remove unwanted space

#### Screenshot of the result

![Screenshot 2021-11-05 at 12 09 53](https://user-images.githubusercontent.com/332915/140505254-778c3b9e-2b2c-42dd-a9dc-18677ae25514.png)
![Screenshot 2021-11-05 at 12 08 24](https://user-images.githubusercontent.com/332915/140505258-1bebff49-8d7b-46fc-bb06-9ae090363723.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
