### PR TITLE
5257: Inherit white color on 2. level menu items

### DIFF
--- a/themes/ddbasic/sass/components/menu.scss
+++ b/themes/ddbasic/sass/components/menu.scss
@@ -121,6 +121,7 @@ ul {
           padding: 0;
           a {
             display: block;
+            color: inherit;
           }
         }
         > li {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5257#change-55296

#### Description

Preserve white text color on 2. level menu items when black on primary is configured.

#### Screenshot of the result

<img width="413" alt="Screenshot 2021-11-19 at 08 47 00" src="https://user-images.githubusercontent.com/332915/142585089-682fb23b-7c0b-4edb-99db-ce80088b71dd.png">
<img width="307" alt="Screenshot 2021-11-19 at 08 45 56" src="https://user-images.githubusercontent.com/332915/142585096-10062e64-7472-4ada-891f-c34234c0d759.png">

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
