### PR TITLE
5290: Change link hover color to inherit

### DIFF
--- a/themes/ddbasic/sass/components/cookie.scss
+++ b/themes/ddbasic/sass/components/cookie.scss
@@ -29,15 +29,16 @@
       color: $white;
       font-size: inherit;
       text-decoration: underline;
-      transition: color .2s ease-in-out;
+      transition: opacity .2s ease-in-out;
       @media (prefers-reduced-motion) {
-        transition: color .0s ease-in-out;
+        transition: opacity .0s ease-in-out;
       }
       &:hover {
-        color: $color-secondary !important;
-        transition: color .2s ease-in-out;
+        color: inherit;
+        opacity: 0.85;
+        transition: opacity .2s ease-in-out;
         @media (prefers-reduced-motion) {
-          transition: color .0s ease-in-out;
+          transition: opacity .0s ease-in-out;
         }
       }
     }
@@ -80,7 +81,7 @@
         // Mobile
         @include media($mobile) {
           height: 280px;
-      }      
+      }
     }
     #popup-text {
       max-width: calc(100% - 40px);

--- a/themes/ddbasic/sass/components/cookie.scss
+++ b/themes/ddbasic/sass/components/cookie.scss
@@ -35,7 +35,7 @@
       }
       &:hover {
         color: inherit;
-        opacity: 0.85;
+        opacity: 0.75;
         transition: opacity .2s ease-in-out;
         @media (prefers-reduced-motion) {
           transition: opacity .0s ease-in-out;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5290#change-55324

#### Description

Change link hover color to inherit the text color, and use opacity to distinguish the state.
Based on case where secondary color was dark, and therefore unreadable on a also dark background.

#### Screenshot of the result

Resting:
![Screenshot 2021-11-25 at 09 49 00](https://user-images.githubusercontent.com/332915/143409340-2ae2a47a-1cac-452c-b455-7a1867563124.png)

Hover:
![Screenshot 2021-11-25 at 09 55 31](https://user-images.githubusercontent.com/332915/143410320-cab5c216-43cd-4892-840c-8db44bd8dd27.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
