### PR TITLE
5295: Merge IMS placements into holdings

### DIFF
--- a/ding2.info
+++ b/ding2.info
@@ -4,6 +4,7 @@ description = Install a Ding based library site.
 core = 7.x
 distribution_name = "Ding 2"
 exclusive = TRUE
+version = 7.x-6.3.2
 
 ; Core modules.
 dependencies[] = block

--- a/modules/ding_ims/ding_ims.admin.inc
+++ b/modules/ding_ims/ding_ims.admin.inc
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @file
+ * Administration interface for the ding_ims module.
+ *
+ * Allows configuration of ims end-point and credentials.
+ */
+
+/**
+ * Form builder; Configure IMS settings for this site.
+ *
+ * @ingroup forms
+ *
+ * @see system_settings_form()
+ */
+function ding_ims_admin_settings_form($form, &$form_state) {
+  $form['ims'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('IMS settings'),
+    '#description' => t('When settings are configured DDB CMS will start fetching placement 
+      information about materials from the IMS service. <br>By default the IMS service 
+      exposes no placements at all. Use the IMS Webclient to configure which application types should expose placements.'),
+    '#tree' => FALSE,
+  );
+
+  $form['ims']['ding_ims_wsdl_url'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Service URL'),
+    '#description' => t('URL of the IMS webservice. The url template 
+      looks like this: https://[library-short-name].lyngsoe-imms.com/ImsWs/soap/Ims4Ils?wsdl<br> 
+      E.g. https://bibsdb.lyngsoe-imms.com/ImsWs/soap/Ims4Ils?wsdl'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('ding_ims_wsdl_url', ''),
+  );
+
+  $form['ims']['ding_ims_username'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Username'),
+    '#description' => t('Username of a user created in the IMS webclient. No privileges needs to be granted to the user.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('ding_ims_username', ''),
+  );
+
+  $form['ims']['ding_ims_password'] = array(
+    '#type' => 'textfield',
+    '#title' => t('Password'),
+    '#description' => t('Password of the user.'),
+    '#required' => TRUE,
+    '#default_value' => variable_get('ding_ims_password', ''),
+  );
+
+  $form['ims']['ding_ims_enable_logging'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable logging'),
+    '#default_value' => variable_get('ding_ims_enable_logging', FALSE),
+  );
+
+  return system_settings_form($form);
+}

--- a/modules/ding_ims/ding_ims.info
+++ b/modules/ding_ims/ding_ims.info
@@ -1,0 +1,12 @@
+name = Ting Ims Placement Information
+description = Module implementing getting material placements from Ims
+package = Ding!
+version = "7.x-1.0"
+core = "7.x"
+dependencies[] = ting
+dependencies[] = fbs
+configure = admin/config/ting/ims
+files[] = lib/ims-client/ImsPlacement.php
+files[] = lib/ims-client/ImsException.php
+files[] = lib/ims-client/ImsService.php
+

--- a/modules/ding_ims/ding_ims.module
+++ b/modules/ding_ims/ding_ims.module
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @file
+ * Provide placement information from the IMS service.
+ */
+
+/**
+ * Implements hook_menu().
+ */
+function ding_ims_menu() {
+  $items = array();
+
+  $items['admin/config/ting/ims'] = array(
+    'title' => 'IMS service settings',
+    'description' => 'Settings for the IMS service.',
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('ding_ims_admin_settings_form'),
+    'access arguments' => array('administer site configuration'),
+    'file' => 'ding_ims.admin.inc',
+    'type' => MENU_LOCAL_TASK,
+  );
+
+  return $items;
+}
+
+/**
+ * Fetch placement information from IMS service.
+ * 
+ * @param array $provider_ids
+ *   Array of ting object ids (faust).
+ *
+ * @return array
+ *   Placements info.
+ */
+function ding_ims_placements($provider_ids) {
+  
+  // @todo Call the IMS Webservice. 
+  /*
+  try {
+    $service = new ImsService(variable_get('ding_ims_wsdl_url'), variable_get('ding_ims_username'), variable_get('ding_ims_password'));
+
+    // Retrieve covers by PID.
+    $retrieved = $service->getByFaustNumber($provider_ids);
+  }
+  catch (Exception $e) {
+    watchdog('ting_covers_ims', 'Unable to retrieve placements from IMS: %message', array('%message' => $e->getMessage()), WATCHDOG_ERROR);
+
+    // Error in fetching, return no covers.
+    return array();
+  }
+  */
+
+  // @todo Remove example 
+  // This is an example of what could be returned by the webservice.
+  // Faust 52673542 - Kvinderne fra Thy. 
+  // We pretend that two of 30 matrials are on display
+
+  $retrieved = array(
+    "52673542" => array(
+      "5133663391" => array(
+          0 => "Biblioteket Sønderborg",
+          1 => "Niveau 2",
+          2 => "Voksenbibliotek",
+          3 => "Gallerivæggen ved fiktion"
+      ),
+      "5131171783" => array(
+        0 => "Biblioteket Sønderborg",
+        1 => "Niveau 2",
+        2 => "Voksenbibliotek",
+        3 => "Gallerivæggen ved fiktion"
+    ),
+    )
+  );
+ 
+  return $retrieved;
+}
+

--- a/modules/ding_ims/lib/ims-client/ImsException.php
+++ b/modules/ding_ims/lib/ims-client/ImsException.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @file
+ * ImsServiceException class.
+ */
+
+class ImsServiceException extends Exception {}

--- a/modules/ding_ims/lib/ims-client/ImsPlacement.php
+++ b/modules/ding_ims/lib/ims-client/ImsPlacement.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @file
+ * ImsPlacement class.
+ */
+
+class ImsPlacement {
+
+  public $materialId;
+  public $placement;
+
+  /**
+   * ImsPlacement constructor.
+   */
+  public function __construct($material_id, array $placement) {
+    $this->materialId = $material_id;
+    $this->placement = $placement;
+  }
+}

--- a/modules/ding_ims/lib/ims-client/ImsService.php
+++ b/modules/ding_ims/lib/ims-client/ImsService.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * @file
+ * ImsService class.
+ */
+
+class ImsService {
+  protected $wsdlUrl;
+  protected $username;
+  protected $password;
+
+  /**
+   * Instantiate the ims client.
+   */
+  public function __construct($wsdl_url, $username, $password) {
+    $this->wsdlUrl = $wsdl_url;
+    $this->username = $username;
+    $this->password = $password;
+  }
+
+  /**
+   * Get information by FAUST number.
+   *
+   * @param mixed $faust_numbers
+   *   Expects either a single FAUST number, or an array of them, for looking
+   *   up multiple titles at a time.
+   *
+   * @return array
+   *   Array of placements.
+   */
+  public function getByFaustNumber($faust_numbers) {
+    // Cast to array to ensure the variable is an array and not a string
+    $faust_numbers = (array) $faust_numbers;
+
+    // Loop the faust numbers since the ims service only accepts one faust 
+    // pr. request 
+    $placements = array();
+    foreach($faust_numbers as $faust_number) {
+      $response = $this->sendRequest($faust_number);
+      $placements[] = $this->extractPlacements($response);
+    }
+
+    return $placements;
+  }
+
+  /**
+   * Send request to the ims server, returning the data response.
+   */
+  protected function sendRequest($faust_number) {
+    $auth_info = array(
+      'Username' => $this->username,
+      'Password' => $this->password,
+    );
+
+    // New ims service.
+    $client = new SoapClient($this->wsdlUrl);
+
+    // Record the start time, so we can calculate the difference, once
+    // the ims service responds.
+    $start_time = explode(' ', microtime());
+
+    // Start on the responds object.
+    $response = new stdClass();
+    $response->identifierInformation = array();
+
+    // Try to get covers 40 at the time as the service has a limit.
+    try {    
+      $data = $client->Ping(array(
+        'Credentials' => $auth_info,
+        'BibliographicRecordId' => $faust_number,
+      ));
+
+      // Check if the request went through.
+      if ($data->requestStatus->statusEnum != 'ok') {
+        throw new ImsServiceException($data->requestStatus->statusEnum . ': ' . $data->requestStatus->errorText);
+      }
+    }
+    catch (Exception $e) {
+      // Re-throw Ims specific exception.
+      throw new ImsServiceException($e->getMessage());
+    }
+
+    $stop_time = explode(' ', microtime());
+    $time = floatval(($stop_time[1] + $stop_time[0]) - ($start_time[1] + $start_time[0]));
+
+    // Drupal specific code - consider moving this elsewhere.
+    if (variable_get('ims_enable_logging', FALSE)) {
+      watchdog('ims', 'Completed request', WATCHDOG_DEBUG, '(' . round($time, 3) . 's): Ids: %ids', array('%ids' => implode(', ', $ids)) . ' http://' . $_SERVER["HTTP_HOST"] . $_SERVER["REQUEST_URI"]);
+    }
+
+    if (!is_array($response->identifierInformation)) {
+      $response->identifierInformation = array($response->identifierInformation);
+    }
+
+    return $response;
+  }
+}

--- a/modules/ding_ims/translations/da.po
+++ b/modules/ding_ims/translations/da.po
@@ -1,0 +1,97 @@
+# $Id$
+#
+# Danish translation of Drupal (general)
+# Generated from files:
+#  ding_ims.admin.inc: n/a
+#  ding_ims.module: n/a
+#  ding_ims.info: n/a
+#  lib/ims-client/ImsService.php: n/a
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2021-10-05 10:59+0200\n"
+"PO-Revision-Date: 2021-10-05 10:59+0200\n"
+"Last-Translator: Agnete Moos <agms@sonderborg.dk>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n!=1);\n"
+
+#: ding_ims.admin.inc:19
+msgid "IMS settings"
+msgstr "IMS indstillinger"
+
+#: ding_ims.admin.inc:20
+msgid "When settings are configured the IMS service will start fetching IMS placement information about materials. The IMS placement will replace the FBS placement when holdings are displayed. Be aware that the default setting of IMS is to expose no placements at all. Use the IMS Webclient to configure which application types should expose placements.. <a href=\"https://lyngsoe-imms.com/docs/webservices\">IMS Web Service Reference</a>"
+msgstr ""
+
+#: ding_ims.admin.inc:26
+msgid "Service URL"
+msgstr ""
+
+#: ding_ims.admin.inc:27
+msgid "URL to the IMS webservice. The url template looks like this: https://<library-short-name>.lyngsoe-imms.com/ImsWs/soap/Ims4Ils?wsdl"
+msgstr ""
+
+#: ding_ims.admin.inc:34
+msgid "Username"
+msgstr ""
+
+#: ding_ims.admin.inc:35
+msgid "Username of a user created in IMS webclient. No privileges needs to be granted to the user in IMS"
+msgstr ""
+
+#: ding_ims.admin.inc:42
+msgid "Password"
+msgstr ""
+
+#: ding_ims.admin.inc:43
+msgid "Password of a user created in IMS webclient"
+msgstr ""
+
+#: ding_ims.admin.inc:50
+msgid "Enable logging"
+msgstr ""
+
+#: ding_ims.admin.inc:56
+msgid "Save"
+msgstr ""
+
+#: ding_ims.module:45
+msgid "ting_covers_ims"
+msgstr ""
+
+#: ding_ims.module:45
+msgid "Unable to retrieve placements from IMS: %message"
+msgstr ""
+
+#: ding_ims.module:14
+msgid "IMS service settings"
+msgstr ""
+
+#: ding_ims.module:15
+msgid "Settings for the IMS service."
+msgstr ""
+
+#: ding_ims.info:0
+msgid "Ting Ims Placement Information"
+msgstr ""
+
+#: ding_ims.info:0
+msgid "Module implementing getting material placements from Ims"
+msgstr ""
+
+#: ding_ims.info:0
+msgid "Ding!"
+msgstr ""
+
+#: lib/ims-client/ImsService.php:88
+msgid "ims"
+msgstr ""
+
+#: lib/ims-client/ImsService.php:88
+msgid "Completed request"
+msgstr ""
+

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -101,6 +101,7 @@ function fbs_availability_holdings($provider_ids) {
         // We have no idea about this either.
         'reference_count' => 0,
         'placement' => array(),
+        'materials' => array(),
       );
 
       // Add in placement.
@@ -108,6 +109,11 @@ function fbs_availability_holdings($provider_ids) {
         if (!empty($item_holding->{$part}->title)) {
           $result_holding['placement'][] = $item_holding->{$part}->title;
         }
+      }
+
+      // Add material numbers and availability
+      foreach ($item_holding->materials as $material) {
+        $result_holding['materials'][] = array('material_id' => $material->itemNumber, 'available' => $material->available);
       }
 
       // Add material description.
@@ -306,6 +312,29 @@ function fbs_availability_holdings($provider_ids) {
     }
   }
 
+  // Fetch IMS placement info
+  if (module_exists('ding_ims')) {
+    try {
+      $ims_result = ding_ims_placements($provider_ids);
+    }
+    catch (Exception $e) {
+      watchdog_exception('ims', $e);
+    }
+
+    // @todo: Does it work for periodicals?
+
+    // Loop each faust-number
+    foreach ($result as $faust => $faust_result) {
+      // Ims placements for current faust
+      $ims_placements = $ims_result[$faust];
+      // Fbs holdings for current faust
+      $fbs_holdings = $faust_result['holdings'];
+      // Create and ajust holdings to acommodate ims_placements
+      $adjusted_holdings = _fbs_merge_ims_placements($fbs_holdings, $ims_placements, $shelf_mark);
+      $result[$faust]['holdings'] = $adjusted_holdings;
+    }
+  }
+
   // Sort holdings alphabetically based on library name.
   foreach ($result as &$item) {
     usort($item['holdings'], 'fbs_holdings_sort_compare');
@@ -447,4 +476,97 @@ function _fbs_get_marc_039b_translations() {
     'ÅT' => 'Tibet',
     'ÅY' => 'Sydamerika',
   );
+}
+
+/**
+ *  Merge ims placements into the holdingsdata from FBS.
+ */
+function _fbs_merge_ims_placements(array $holdings, array $ims_placements, $shelf_mark) {
+
+  // Fbs holdings arrays and ims holdings arrays are identical in structure.
+  $holding_structure = array(
+    'available_count' => 0,
+    'total_count' => 0,
+    // We have no idea about this either.
+    'reference_count' => 0,
+    'placement' => array(),
+    'materials' => array(),
+  );
+
+  // Create an array to store the decremented fbs holdings
+  $adjusted_holdings = $holdings;
+
+  // Create array to store new holdings items created based on ims placement
+  $ims_holdings = array();
+  // Loop fbs holdings for current faust
+  foreach ($holdings as $holding_key => $holding) {
+
+    // Loop materials
+    $materials = $holding['materials'];
+    foreach ($materials as $material) {
+      // Check if material_id is present in ims result, meaning that
+      // this material should have it's ims placement displayed.
+      if (isset($ims_placements[$material['material_id']])) {
+
+        $ims_placement = $ims_placements[$material['material_id']];
+        // Check if an ims holding with a matching placement array, 
+        // was created earlier. If so increment holding.
+        // Note that if the ims location tree is build in a way so 
+        // that the ims placement array competely matches the 
+        // fbs placement array then two identical placementstrings 
+        // are displayed. There is lttle chance of that though, and 
+        // the outcome is acceptable in these rare cases.
+        $found = false;
+        foreach ($ims_holdings as $ims_holding) {
+          $placement_without_shelf_mark = array_slice($ims_holding['placement'], 0, -1);
+          if ($placement_without_shelf_mark == $ims_placement) {
+            $found = true;
+            // Increment total_count
+            $ims_holding['total_count']++;
+            // Increment available count if material is available
+            if ($material['available']) {
+              $ims_holding['available_count']++;
+            }
+            // Add material
+            $ims_holding['materials'][] = $material; 
+            break;
+          }
+        }
+        
+        // There is no holding with matching placement.
+        // We have to create one from scratch.
+        if (!$found) {
+          $ims_holding = $holding_structure;
+          $ims_holding['total_count']++;
+          // Increment available count if material is available
+          if ($material['available']) {
+            $ims_holding['available_count']++;
+          }
+          // Add material
+          $ims_holding['materials'][] = $material; 
+          // Add placement
+          $ims_holding['placement'] = $ims_placement;
+          // Add shelf mark as the last element
+          $ims_holding['placement'][] = $shelf_mark;
+          $ims_holdings[] = $ims_holding;
+        }
+
+        // Adjust available and total of the fbs holding the material belongs to
+        $adjusted_holdings[$holding_key]['total_count']--;
+        // Decrease available count in holding if material is available
+        if ($material['available']) {
+          $adjusted_holdings[$holding_key]['available_count']--;
+        }
+        // Remove material
+        $adjusted_holdings[$holding_key]['materials'] = array_udiff($materials, [$material], '_fbs_compare_materials');
+      }
+    }
+  }
+  // Collect all holdings in one array
+  return array_merge($adjusted_holdings, $ims_holdings);
+}
+
+function _fbs_compare_materials($m1, $m2)
+{
+    return $m1['material_id'] - $m2['material_id'];
 }

--- a/project-core.make
+++ b/project-core.make
@@ -21,4 +21,4 @@ projects[drupal][patch][] = "https://www.drupal.org/files/issues/2020-09-23/drup
 projects[ding2][type] = "profile"
 projects[ding2][download][type] = "git"
 projects[ding2][download][url] = "https://github.com/ding2/ding2.git"
-projects[ding2][download][branch] = "master"
+projects[ding2][download][tag] = "7.x-6.3.2"

--- a/project.make
+++ b/project.make
@@ -508,7 +508,7 @@ projects[xautoload][version] = "5.7"
 libraries[bpi-client][destination] = "modules/bpi/lib"
 libraries[bpi-client][download][type] = "git"
 libraries[bpi-client][download][url] = "http://github.com/ding2/bpi-client.git"
-libraries[bpi-client][download][branch] = "master"
+libraries[bpi-client][download][tag] = "7.x-6.3.2"
 
 ; For wysiwyg.
 libraries[ckeditor][download][type] = "get"
@@ -584,8 +584,8 @@ libraries[psr7][destination] = "libraries"
 ; For ting.
 libraries[ting-client][download][type] = "git"
 libraries[ting-client][download][url] = "http://github.com/ding2/ting-client.git"
-libraries[ting-client][download][branch] = "master"
 libraries[ting-client][destination] = "modules/opensearch/lib"
+libraries[ting-client][download][tag] = "7.x-6.3.2"
 
 ; Obsoleted. Only reference is in ding_frontend.
 libraries[zen-grids][download][type] = "git"
@@ -639,7 +639,7 @@ libraries[smart-app-banner][destination] = "libraries"
 
 ; For ding_react.
 libraries[ddb-react][download][type] = "get"
-libraries[ddb-react][download][url] = https://github.com/danskernesdigitalebibliotek/ddb-react/releases/download/latest/dist.zip
+libraries[ddb-react][download][url] = https://github.com/danskernesdigitalebibliotek/ddb-react/releases/download/2.4.0/dist.zip
 libraries[ddb-react][directory_name] = "ddb-react"
 libraries[ddb-react][destination] = "libraries"
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5295

#### Description

Modify holdings to provide users with more detailed placement information. This information is acquired from [IMS](https://lyngsoesystems.com/intelligent-material-management-system/). They have recently released a [SOAP Webservice endpoint](https://lyngsoe-imms.com/docs/webservices/ME-Ims4Ils-GetItemsOfBibliographicRecord.html) that exposes placement-information.

#### Screenshot of the result

![ims placement](https://user-images.githubusercontent.com/1641342/144436442-3e5fc0d3-58ae-41e6-a228-93f6c0f4dcda.png)

#### Additional comments or questions

This code is at a very early stage.
The integration to the ims webservice is not completed. Mainly because it has only very recently been released. I have added stub code for now.
The code in fbs.availability.inc is in a functional state

Questions
- Does the ims client look ok? I have used the old ting_covers_addi module as boilerplate code. Is this an acceptable approach?
- The code in fbs_availability_holdings is cluttered and difficult to read. This pull request makes the mess even worse. Should code be cleaned up? If so I need help on how. 

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.


