### PR TITLE
5292 das text

### DIFF
--- a/modules/ting_das/css/ting_das.css
+++ b/modules/ting_das/css/ting_das.css
@@ -22,7 +22,7 @@
   }
 
   .popupbar .digital-order-form .form-item.form-item-mail {
-    margin-right: 0;
+    margin-right: 5%;
   }
 
   .popupbar .digital-order-form .form-type-markup {
@@ -38,6 +38,7 @@
     float: left;
     margin-right: 3%;
     margin-bottom: 14px;
+    margin-top: 20px;
   }
 
   .popupbar #popupbar-ting_das .messages {

--- a/modules/ting_das/includes/ting_das.admin.inc
+++ b/modules/ting_das/includes/ting_das.admin.inc
@@ -78,17 +78,7 @@ function ting_das_admin_settings_form() {
     '#default_value' => _ting_das_get_configured_well_types(),
   );
 
-  $defaults = variable_get('ting_das_text', array(
-    'description' => array(
-      'format' => 'ding_wysiwyg',
-      'value' => _ting_das_default_usage_text('description'),
-    ),
-    'gdpr' => array(
-      'format' => 'ding_wysiwyg',
-      'value' => _ting_das_default_usage_text('gdpr'),
-    ),
-    'placement' => TING_DAS_PLACEMENT_WEIGHT_ABOVE,
-  ));
+  $defaults = variable_get('ting_das_text', ting_das_default_usage_text_settings());
 
   $form['ting_das_text'] = array(
     '#type' => 'fieldset',

--- a/modules/ting_das/ting_das.module
+++ b/modules/ting_das/ting_das.module
@@ -180,7 +180,7 @@ function ting_das_order_form($form_id, &$form_state, TingEntity $entity) {
     $profile = entity_metadata_wrapper('profile2', $profile);
   }
 
-  $texts = variable_get('ting_das_text', array());
+  $texts = variable_get('ting_das_text', ting_das_default_usage_text_settings());
   $creds = ding_user_get_creds();
 
   if (isset($creds['resident']) && $creds['resident']) {
@@ -354,19 +354,21 @@ function _ting_das_get_configured_well_types() {
 }
 
 /**
- * Default usage text.
+ * Default usage text settings.
  *
- * @param $type
- *   The type of text to fetch (description, gdpr).
- *
- * @return string
- *   The text for the type given.
+ * @return array
+ *   The default settings for usage text.
  */
-function _ting_das_default_usage_text($type) {
-  $data = array(
-    'description' => '<p>Som bruger af [bibliotek] og borger i kommunen kan du via Digital Artikelservice, Det Kgl. Bibliotek, Aarhus, bestille digitale kopier af tidskriftartikler og få dem sendt som PDF direkte til din e-mail. Artiklerne digitaliseres og leveres fra Det Kgl. Biblioteks samlinger af fysiske danske tidsskrifter, som indeholder over 40.000 forskellige titler. Leveringstiden er på få minutter for artikler som allerede er scannede, imens “ny-bestilte” artikler (dvs. artikler som ikke tidligere er bestilt) scannes og sendes i løbet af maksimalt 24 timer på hverdage.',
-    'gdpr' => '<p>I forbindelse med anvendelse af Digital Artikelservice, skal vi jf. Databeskyttelsesforordningen informere dig om [bibliotekets behandling af personoplysninger.][sæt et link ind til oplysningsteksten]</p><p>Se endvidere Det Kgl. Biblioteks privatlivs politik: <a href="http://www.kb.dk/da/kb/webstedet/privatliv.html" target="_blank">http://www.kb.dk/da/kb/webstedet/privatliv.html</a></p>'
+function ting_das_default_usage_text_settings() {
+  return array(
+    'description' => array(
+      'format' => 'ding_wysiwyg',
+      'value' => '<p>Som bruger af [bibliotek] og borger i kommunen kan du via Digital Artikelservice, Det Kgl. Bibliotek, Aarhus, bestille digitale kopier af tidskriftartikler og få dem sendt som PDF direkte til din e-mail. Artiklerne digitaliseres og leveres fra Det Kgl. Biblioteks samlinger af fysiske danske tidsskrifter, som indeholder over 40.000 forskellige titler. Leveringstiden er på få minutter for artikler som allerede er scannede, imens “ny-bestilte” artikler (dvs. artikler som ikke tidligere er bestilt) scannes og sendes i løbet af maksimalt 24 timer på hverdage.',
+    ),
+    'gdpr' => array(
+      'format' => 'ding_wysiwyg',
+      'value' => '<p>I forbindelse med anvendelse af Digital Artikelservice, skal vi jf. Databeskyttelsesforordningen informere dig om [bibliotekets behandling af personoplysninger.][sæt et link ind til oplysningsteksten]</p><p>Se endvidere Det Kgl. Biblioteks privatlivs politik: <a href="http://www.kb.dk/da/kb/webstedet/privatliv.html" target="_blank">http://www.kb.dk/da/kb/webstedet/privatliv.html</a></p>'
+    ),
+    'placement' => TING_DAS_PLACEMENT_WEIGHT_ABOVE,
   );
-
-  return $data[$type];
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5292?next_issue_id=5291&prev_issue_id=5293

#### Description

The texts in the form where not showing if the admin page had not been saved. That was because the default settings were in the admin page. The default setting is now moved to a function so it works out off the box. Also minor css styling fixes.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/73946470/144878919-f541f9ee-8e5b-46e8-b38d-5350e328474f.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
