### PR TITLE
Redirect existing users in registration

### DIFF
--- a/modules/ding_registration/includes/ding_registration.acceptance.inc
+++ b/modules/ding_registration/includes/ding_registration.acceptance.inc
@@ -115,12 +115,22 @@ function ding_registration_acceptance_form_submit($form, $form_state) {
 
   // Try to create the user at the provider.
   try {
-    // Create user as the provider.
-    ding_provider_invoke('user', 'create', $user_info['attributes']['userId'], $values['pin'], $values['name'], $values['mail'], $values['branch']);
+    $redirect_to = NULL;
+    try {
+      // Create user at the provider.
+      ding_provider_invoke('user', 'create', $user_info['attributes']['userId'], $values['pin'], $values['name'], $values['mail'], $values['branch']);
+      $redirect_to = DING_REGISTRATION_SUCCESS_URL;
+    }
+    catch (DingProviderUserExistsError $e) {
+      // If they exists, just carry on trying logging them in, but redirect to
+      // user edit.
+      drupal_set_message(t('You already have an account, so you have been logged in. Please check your profile information, and update your pincode.'));
+      $redirect_to = 'user/me/edit';
+    }
 
     // Set redirect and try logging in the user.
     if (_ding_adgangsplatformen_provider_login($user_info)) {
-      _ding_adgangsplatformen_redirect_user(DING_REGISTRATION_SUCCESS_URL);
+      _ding_adgangsplatformen_redirect_user($redirect_to);
     }
     else {
       ding_adgangsplatformen_logout();

--- a/modules/fbs/includes/fbs.user.inc
+++ b/modules/fbs/includes/fbs.user.inc
@@ -153,6 +153,15 @@ function fbs_user_create($cpr, $pin_code, $name, $mail, $branch_id) {
     // Re-throw other errors.
     throw $exception;
   }
+  catch (\Reload\Prancer\SwaggerApiError $exception) {
+    // When trying to registry use that exists FBS returns status 409.
+    if ($exception->getCode() === 409) {
+      throw new DingProviderUserExistsError('User account already exists');
+    }
+
+    // Re-throw other errors.
+    throw $exception;
+  }
 }
 
 /**


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5092

#### Description

When trying to register, redirect existing users to their profile edit
page.

Includes #1833.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.