### PR TITLE
5284: Attach JS needed for Infomedia button

### DIFF
--- a/modules/ting_infomedia/ting_infomedia.module
+++ b/modules/ting_infomedia/ting_infomedia.module
@@ -149,6 +149,11 @@ function ting_infomedia_ding_entity_buttons($type, $entity) {
     $build[] = array(
       '#type' => 'markup',
       '#markup' => l(t('Read article'), $entity->online_url, $options),
+      '#attached' => array(
+        'library' => array(
+          ctools_attach_js('ajax-responder'),
+        ),
+      ),
     );
     return $build;
   }


### PR DESCRIPTION
-------

#### Link to issue

https://platform.dandigbib.org/issues/5284

#### Description

Infomedia button only worked on second click. Apparently the JS needed
for the ajax response to work only got loaded on the first click,
requiring another to trigger the redirect. So explicitly add the
ctools `ajax-responder` library.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.