### PR TITLE
5315: Fix cookie compatibility with older browsers e.g. iOS 12/Safari

### DIFF
--- a/modules/ding_base/ding_base.install
+++ b/modules/ding_base/ding_base.install
@@ -229,3 +229,20 @@ function ding_base_update_7009() {
 function ding_base_update_7010() {
   variable_set('webform_store_ip_address', 'as-needed');
 }
+
+/**
+ * Make samesite_cookie run before variable_realm
+ */
+function ding_base_update_7011() {
+  // This is the same database update as suggested in
+  // https://www.drupal.org/project/samesite_cookie/issues/3257266#comment-14358928
+  // We choose to duplicate it here to avoid potential conflicts in the future
+  // where update hook numbering may vary between patch and merged code.
+  // If the patch is accepted then running this update multiple times should
+  // not cause problems.
+  db_update('system')
+    // variable_realm uses weight -1000.
+    ->fields(array('weight' => -1001))
+    ->condition('name', 'samesite_cookie', '=')
+    ->execute();
+}

--- a/project.make
+++ b/project.make
@@ -375,8 +375,6 @@ projects[rules][version] = "2.7"
 
 projects[samesite_cookie][subdir] = "contrib"
 projects[samesite_cookie][version] = "1.0-rc1"
-; Fix hook_boot invocation order for compatability with variable_realm
-projects[samesite_cookie][patch][] = "https://www.drupal.org/files/issues/2022-01-06/samesite_cookie-fix-hook-boot-order-3257266-2.patch"
 
 projects[scheduler][subdir] = "contrib"
 projects[scheduler][version] = "1.5"

--- a/project.make
+++ b/project.make
@@ -375,6 +375,8 @@ projects[rules][version] = "2.7"
 
 projects[samesite_cookie][subdir] = "contrib"
 projects[samesite_cookie][version] = "1.0-rc1"
+; Fix hook_boot invocation order for compatability with variable_realm
+projects[samesite_cookie][patch][] = "https://www.drupal.org/files/issues/2022-01-06/samesite_cookie-fix-hook-boot-order-3257266-2.patch"
 
 projects[scheduler][subdir] = "contrib"
 projects[scheduler][version] = "1.5"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5315

#### Description

The SameSite Cookie module tries to ensure that
samesite_cookie_boot() executes as early as possible by implementing
hook_module_implements_alter(). However as far as I can tell this
does not work in practice.

hook_boot implementations are called from bootstrap_invoke_all() -
never from module_invoke_all(). As far as I can tell
bootstrap_invoke_all() calls modules ordered by module weight - not
in any way that involves invocations of module_implements_alter
hooks. Consequently the code in
samesite_cookie_module_implements_alter() has no effect.

This can cause problems when there are other modules working with the
global conf array. One such example is Variable Realm.

Consequently we should use module weight instead of
module_implements_alter to control order of hook implementations.

Weights are always tricky to set right. For now we set it to  -1001
as that is 1 lower than -1000 which is used by Variable Realm. Patch the
module to achieve this.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.