### PR TITLE
3750: Send user to login page when not logged in

### DIFF
--- a/modules/ding_user_frontend/ding_user_frontend.module
+++ b/modules/ding_user_frontend/ding_user_frontend.module
@@ -308,6 +308,9 @@ function ding_user_frontend_url_inbound_alter(&$path, $original_path, $path_lang
         $path .= '/' . $matches[1];
       }
     } else {
+      // Don't cache this page so we don't get any weird caching problems.
+      drupal_page_is_cacheable(FALSE);
+
       // If the user is not logged in we send them to login page.
       $options = ['query' => ['destination' => $path]];
       $login_url = ding_provider_invoke( 'openplatform_token', 'login_url');

--- a/modules/ding_user_frontend/ding_user_frontend.module
+++ b/modules/ding_user_frontend/ding_user_frontend.module
@@ -307,6 +307,11 @@ function ding_user_frontend_url_inbound_alter(&$path, $original_path, $path_lang
       if (isset($matches[1])) {
         $path .= '/' . $matches[1];
       }
+    } else {
+      // If the user is not logged in we send them to login page.
+      $options = ['query' => ['destination' => $path]];
+      $login_url = ding_provider_invoke( 'openplatform_token', 'login_url');
+      drupal_goto($login_url, $options);
     }
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3750

#### Description

Uses the same alter_inbound_url that already handles the user/me urls. There is a question about Varnish here. In order to ensuere there are no caching problems caching is disabled for these pages. May not be needed but could cause weird problems.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
