### PR TITLE
5240 place2book returns error

### DIFF
--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -511,13 +511,10 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
         if (is_array($items) && isset($items[0]['event_id']) && isset($items[0]['event_maker_id'])) {
           if ($items[0]['event_id'] == 1 && $items[0]['event_maker_id'] == 1) {
             // This should not happen so we abort the saving off the node and alert the editor.
+            watchdog('ding_place2book', 'Original items: @original_items. Synchronized items: @synchronized_items. Items to be saved: @items',
+             array('@original_items' => print_r($settings , TRUE), '@synchronized_items' => print_r($synchronized_items, TRUE), '@items' => print_r($items , TRUE)), WATCHDOG_ERROR);
 
-            watchdog('ding_place2book', 'Original items: @original_items', array('@original_items' => print_r($settings , TRUE)), WATCHDOG_ERROR);
-            watchdog('ding_place2book', 'Synchronized items: @synchronized_items', array('@synchronized_items' => print_r($synchronized_items, TRUE)), WATCHDOG_ERROR);
-            watchdog('ding_place2book', 'Items to be saved: @items', array('@items' => print_r($items , TRUE)), WATCHDOG_ERROR);
-
-            drupal_set_message(t('Det lykkedes ikke at gemme din begivenhed. Du kan prøve igen senere, men hvis det stadig ikke lykkes,
-                er der desværre ingen anden mulighed end at oprette begivenheden på ny forfra.'), 'error');
+            drupal_set_message(t('We couldnt save your event. Please try again later. If the problem persist you need to create the event again'), 'error');
 
             // We send the user to the front page to alert them that something has gone wrong.
             drupal_goto();

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -512,9 +512,9 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
           if ($items[0]['event_id'] == 1 && $items[0]['event_maker_id'] == 1) {
             // This should not happen so we abort the saving off the node and alert the editor.
             $variables = array(
-              '@original_items' => print_r($settings , TRUE),
+              '@original_items' => print_r($settings, TRUE),
               '@synchronized_items' => print_r($synchronized_items, TRUE),
-              '@items' => print_r($items , TRUE)
+              '@items' => print_r($items, TRUE),
             );
             watchdog('ding_place2book', 'Original items: @original_items. Synchronized items: @synchronized_items. Items to be saved: @items', $variables, WATCHDOG_ERROR);
 

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -507,6 +507,22 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
             ),
           );
         }
+
+        if (is_array($items) && isset($items[0]['event_id']) && isset($items[0]['event_maker_id'])) {
+          if ($items[0]['event_id'] == 1 && $items[0]['event_maker_id'] == 1) {
+            // This should not happen so we abort the saving off the node and alert the editor.
+
+            watchdog('ding_place2book', 'Original items: @original_items', array('@original_items' => print_r($settings , TRUE)), WATCHDOG_ERROR);
+            watchdog('ding_place2book', 'Synchronized items: @synchronized_items', array('@synchronized_items' => print_r($synchronized_items, TRUE)), WATCHDOG_ERROR);
+            watchdog('ding_place2book', 'Items to be saved: @items', array('@items' => print_r($items , TRUE)), WATCHDOG_ERROR);
+
+            drupal_set_message(t('Det lykkedes ikke at gemme din begivenhed. Du kan prøve igen senere, men hvis det stadig ikke lykkes,
+                er der desværre ingen anden mulighed end at oprette begivenheden på ny forfra.'), 'error');
+
+            // We send the user to the front page to alert them that something has gone wrong.
+            drupal_goto();
+          }
+        }
       }
       break;
   }
@@ -700,10 +716,10 @@ function _ding_place2book_sync_p2b_entities($entity, array $settings) {
     }
 
     if ($is_new) {
-      drupal_set_message(t('Event was successfully created.'));
+      drupal_set_message(t('Event was successfully created in place2book service.'));
     }
     else {
-      drupal_set_message(t('Event was successfully updated.'));
+      drupal_set_message(t('Event was successfully updated in place2book service.'));
     }
   }
   return $items;

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -58,7 +58,11 @@ function ding_place2book_field_widget_form(&$form, &$form_state, $field, $instan
     }
     // Otherwise this an existing p2b-synced entity.
     else {
-      list($event_id, $event_maker_id, $synchronize) = array_values(reset($items));
+      $settings = reset($items);
+      $event_id = $settings['event_id'];
+      $event_maker_id = $settings['event_maker_id'];
+      $synchronize = $settings['synchronize'];
+
       try {
         $p2b = ding_place2book_instance();
         $event = $p2b->getEvent($event_maker_id, $event_id);

--- a/modules/ding_place2book/ding_place2book.fields.inc
+++ b/modules/ding_place2book/ding_place2book.fields.inc
@@ -511,8 +511,12 @@ function ding_place2book_field_presave($entity_type, $entity, $field, $instance,
         if (is_array($items) && isset($items[0]['event_id']) && isset($items[0]['event_maker_id'])) {
           if ($items[0]['event_id'] == 1 && $items[0]['event_maker_id'] == 1) {
             // This should not happen so we abort the saving off the node and alert the editor.
-            watchdog('ding_place2book', 'Original items: @original_items. Synchronized items: @synchronized_items. Items to be saved: @items',
-             array('@original_items' => print_r($settings , TRUE), '@synchronized_items' => print_r($synchronized_items, TRUE), '@items' => print_r($items , TRUE)), WATCHDOG_ERROR);
+            $variables = array(
+              '@original_items' => print_r($settings , TRUE),
+              '@synchronized_items' => print_r($synchronized_items, TRUE),
+              '@items' => print_r($items , TRUE)
+            );
+            watchdog('ding_place2book', 'Original items: @original_items. Synchronized items: @synchronized_items. Items to be saved: @items', $variables, WATCHDOG_ERROR);
 
             drupal_set_message(t('We couldnt save your event. Please try again later. If the problem persist you need to create the event again'), 'error');
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5240

#### Description

This PR deals with a error that I have not been able to reproduce. The errors shows up as event_id and event_maker_id get set to 1 and the event loses connection to its counterpart in place2book service. This PR introduces som definsive programming and logging if the error occurs. It hinders the page from saving invalid event_id and event_maker_id to the database. And it changes to place moste likely to cause this errors to a more robust code. It also changes message text that would otherwise be confusing to users.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md). 
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
