### PR TITLE
5269: Apply dark-red on form-required asterisk

### DIFF
--- a/themes/ddbasic/sass/components/messages.scss
+++ b/themes/ddbasic/sass/components/messages.scss
@@ -77,8 +77,6 @@
   }
 }
 
-.pane-user-login {
-  .form-required {
-    color: $red-error;
-  }
+.form-required {
+  color: $red-error;
 }


### PR DESCRIPTION
#### Link to issue

[Please add a link to the issue being addressed by this change.](https://platform.dandigbib.org/issues/5269?issue_count=40&issue_position=1&next_issue_id=5263)

#### Description

Use a darker red for better contrast

#### Screenshot of the result

![Screenshot 2022-02-02 at 15 43 38](https://user-images.githubusercontent.com/332915/152176012-befe1abb-7d97-40cd-840a-0583e53bb60f.png)

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

Contrast check: https://webaim.org/resources/contrastchecker/?fcolor=A11515&bcolor=F1F1F2
