### PR TITLE
5316: Update WYSIWYG and CKEditor modules

### DIFF
--- a/project.make
+++ b/project.make
@@ -499,7 +499,7 @@ projects[workflow][patch][] = "https://www.drupal.org/files/issues/workflow-php_
 projects[workflow][patch][] = "https://www.drupal.org/files/issues/workflow-add_nid_index-2569801-3.patch"
 
 projects[wysiwyg][subdir] = "contrib"
-projects[wysiwyg][version] = "2.5"
+projects[wysiwyg][version] = "2.9"
 
 projects[ask_vopros][type] = "module"
 projects[ask_vopros][subdir] = "contrib"
@@ -519,7 +519,7 @@ libraries[bpi-client][download][branch] = "master"
 
 ; For wysiwyg.
 libraries[ckeditor][download][type] = "get"
-libraries[ckeditor][download][url] = https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.16.2/ckeditor_4.16.2_standard.zip
+libraries[ckeditor][download][url] = https://download.cksource.com/CKEditor/CKEditor/CKEditor%204.17.1/ckeditor_4.17.1_standard.zip
 libraries[ckeditor][directory_name] = "ckeditor"
 libraries[ckeditor][destination] = "libraries"
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5316

#### Description

https://www.drupal.org/sa-contrib-2022-003

Opdateret:
projects[wysiwyg] -> 2.9
libraries[ckeditor] -> CKEditor 4.17.1

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

