### PR TITLE
Core: Revert "5325: update Drupal to v7.86"

### DIFF
--- a/project-core.make
+++ b/project-core.make
@@ -3,7 +3,7 @@ api = 2
 
 ; Core
 projects[drupal][type] = core
-projects[drupal][version] = 7.86
+projects[drupal][version] = 7.82
 projects[drupal][patch][] = "https://drupal.org/files/issues/menu-get-item-rebuild-1232346-45.patch"
 projects[drupal][patch][] = "https://www.drupal.org/files/issues/1232416-autocomplete-for-drupal7x53.patch"
 projects[drupal][patch][] = "https://drupal.org/files/issues/translate_role_names-2205581-1.patch"


### PR DESCRIPTION
We currently see problems during site updates relating to a conflict between Drupal 7.83 which introduces a changed column to users and the Entity Cache module:

WD php: PDOException: SQLSTATE[42S22]: Column not found: 1054 Unknown[error]
column 'base.changed' in 'field list': SELECT base.uid AS uid,
[base.name](http://base.name/) AS name, base.pass AS pass, base.mail AS mail, base.theme
[...]
in EntityCacheControllerHelper::entityCacheLoad() (line 100 of
/var/aegir/platforms/ddb650beta1/profiles/ding2/modules/contrib/entitycache/entitycache.module).

To address this we roll back to the previous version of Drupal Core for now.

This reverts ding2/ding2#1859