### PR TITLE
5332: Ensure payment intro text is always shown

### DIFF
--- a/modules/ding_debt/plugins/content_types/debts/debts.inc
+++ b/modules/ding_debt/plugins/content_types/debts/debts.inc
@@ -36,6 +36,12 @@ function ding_debt_debts_content_type_render($subtype, $conf, $panel_args, $cont
     $internal_debts = array_filter($debts, '_ding_debt_filter_payable');
     $external_debts = array_filter($debts, '_ding_debt_filter_nonpayable');
 
+    if (variable_get('ding_debt_show_introtext', TRUE)) {
+      $ding_debt_introtext = variable_get('ding_debt_introtext', _ding_debt_introtext_default());
+
+      $block->content .= '<div class="debt-body">'.check_markup($ding_debt_introtext['value'], $ding_debt_introtext['format']).'</div>';
+    }
+
     $has_internal = !empty($internal_debts) && variable_get('ding_debt_enable_internal', TRUE);
     if ($has_internal) {
       $build = ding_provider_get_form('ding_debt_debts_form', $internal_debts, $external_debts);
@@ -90,16 +96,6 @@ function ding_debt_debts_form($form, &$form_state, $internal_debts, $external_de
     ];
 
     return $form;
-  }
-
-  if (variable_get('ding_debt_show_introtext', TRUE)) {
-    $ding_debt_introtext = variable_get('ding_debt_introtext', _ding_debt_introtext_default());
-
-    $form['introtext'] = [
-      '#prefix' => '<div class="debt-body">',
-      '#suffix' => '</div>',
-      '#markup' => check_markup($ding_debt_introtext['value'], $ding_debt_introtext['format']),
-    ];
   }
 
   if ($has_internal) {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5332

#### Description

Always display intro text on debts page.

#### Screenshot of the result

![Screenshot 2022-02-16 at 10 50 25](https://user-images.githubusercontent.com/111397/154239126-c10e82f9-fb09-4821-838b-1f46962f9625.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
