### PR TITLE
5117: Fixed retries type in easy payment retries

### DIFF
--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -258,8 +258,9 @@ function _ding_debt_easy_retry_payments() {
     }
 
     // Update the number of retires, no matter what happened above this was a
-    // retry.
-    _ding_debt_easy_update_retries_local($order['payment_id'], $order['retries']);
+    // retry. For some reason the retries counter from the database is a string
+    // when loaded from the database, so we cast it here.
+    _ding_debt_easy_update_retries_local($order['payment_id'], (int) $order['retries']);
   }
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5117

#### Description

When loading the retries counter from the database it is a string and during strict comparison with a max retries count that is an int fails.

#### Screenshot of the result

![Screenshot 2022-02-25 at 11 29 24](https://user-images.githubusercontent.com/111397/155702008-c65c2fd5-7232-42f4-b5c4-12b0c6479ae1.png)

![Screenshot 2022-02-25 at 11 42 32](https://user-images.githubusercontent.com/111397/155702039-3e604ff5-ec47-4d7e-ae9d-b3b1c075c87b.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.