### PR TITLE
5331: Fixed event query selection in menu expansion script

### DIFF
--- a/themes/ddbasic/scripts/menu.js
+++ b/themes/ddbasic/scripts/menu.js
@@ -77,11 +77,12 @@
    */
   function firstLevelExpandedHandler (event) {
     var first_level_expanded = $('.main-menu-wrapper > .main-menu > .expanded > a .main-menu-expanded-icon');
+    var target = $(event.target);
     if ($('.is-tablet').is(':visible')) {
       event.preventDefault();
-      first_level_expanded.not($(event)).parent().parent().children('.main-menu').slideUp(200);
-      $(event).toggleClass('open');
-      $(event).parent().parent().children('.main-menu').slideToggle(200);
+      first_level_expanded.not(target).parent().parent().children('.main-menu').slideUp(200);
+      target.toggleClass('open');
+      target.parent().parent().children('.main-menu').slideToggle(200);
     }
   }
 
@@ -91,12 +92,13 @@
    */
   function secondLevelExpandedHandler (event) {
     var second_level_expanded = $('.main-menu-wrapper > .main-menu > .expanded > .main-menu > .expanded > a .main-menu-expanded-icon');
+    var target = $(event.target);
     if ($('.is-tablet').is(':visible')) {
       event.preventDefault();
-      second_level_expanded.not($(event)).removeClass('open');
-      second_level_expanded.not($(event)).parent().parent().children('.main-menu').slideUp(200);
-      $(event).toggleClass('open');
-      $(event).parent().parent().children('.main-menu').slideToggle(200);
+      second_level_expanded.not(target).removeClass('open');
+      second_level_expanded.not(target).parent().parent().children('.main-menu').slideUp(200);
+      target.toggleClass('open');
+      target.parent().parent().children('.main-menu').slideToggle(200);
     }
   }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5331

#### Description

The menu on mobile devices do on slide up/down when clicked.

#### Screenshot of the result

![Screenshot 2022-03-02 at 17 06 48](https://user-images.githubusercontent.com/111397/156400941-ce7c0634-7695-4c59-8a6f-ecff333426fc.png)

![Screenshot 2022-03-02 at 17 06 54](https://user-images.githubusercontent.com/111397/156400953-11717520-c151-4cda-8786-ca65fd064c74.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
