### PR TITLE
5339: IMS - Add materials to result for periodica

### DIFF
--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -257,6 +257,7 @@ function fbs_availability_holdings($provider_ids) {
           if (isset($tmp_issues[$key])) {
             $tmp_issues[$key]['available'] += $material->available ? 1 : 0;
             $tmp_issues[$key]['total'] += 1;
+            $tmp_issues[$key]['materials'][] = array('material_id' => $material->itemNumber, 'available' => $material->available);
           }
           else {
             // Generate "vol key". Both volume and volumeNumber can be empty so
@@ -273,6 +274,8 @@ function fbs_availability_holdings($provider_ids) {
               'total' => 1,
               'placement' => $placement_string,
               'local_id' => _fbs_periodical_get_local_id($item->recordId, $material->periodical),
+              'placement_array' => $result_holding['placement'],
+              'materials' => [array('material_id' => $material->itemNumber, 'available' => $material->available)],
             );
           }
         }
@@ -306,6 +309,8 @@ function fbs_availability_holdings($provider_ids) {
           'available_count' => $issue['available'],
           'location' => $issue['placement'],
           'total_count' => $issue['total'],
+          'placement' => $issue['placement_array'],
+          'materials' => $issue['materials'],
         );
       }
       $result[$item->recordId]['issues'] = $issues;

--- a/modules/fbs/includes/fbs.availability.inc
+++ b/modules/fbs/includes/fbs.availability.inc
@@ -257,7 +257,10 @@ function fbs_availability_holdings($provider_ids) {
           if (isset($tmp_issues[$key])) {
             $tmp_issues[$key]['available'] += $material->available ? 1 : 0;
             $tmp_issues[$key]['total'] += 1;
-            $tmp_issues[$key]['materials'][] = array('material_id' => $material->itemNumber, 'available' => $material->available);
+            $tmp_issues[$key]['materials'][] = array(
+              'material_id' => $material->itemNumber, 
+              'available' => $material->available
+            );
           }
           else {
             // Generate "vol key". Both volume and volumeNumber can be empty so
@@ -273,9 +276,15 @@ function fbs_availability_holdings($provider_ids) {
               'available' => $material->available ? 1 : 0,
               'total' => 1,
               'placement' => $placement_string,
-              'local_id' => _fbs_periodical_get_local_id($item->recordId, $material->periodical),
+              'local_id' => _fbs_periodical_get_local_id(
+                $item->recordId, 
+                $material->periodical
+              ),
               'placement_array' => $result_holding['placement'],
-              'materials' => [array('material_id' => $material->itemNumber, 'available' => $material->available)],
+              'materials' => [array(
+                'material_id' => $material->itemNumber, 
+                'available' => $material->available
+              )],
             );
           }
         }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5339

#### Description
This pull request modifies the output of the fbs availability provider, so that periodical-holdings are enriched with material numbers and availiability status. This change is a prerequisite for an upcoming IMS-module that will modify the output of the fbs availability provider and add in detailed placement info acquired from IMS. The IMS-module will be developed as a stand alone module outside of ding2.

Note that a pull request regarding this issue has previously been accepted: https://github.com/ding2/ding2/pull/1851
The difference between the two is that this one enriches periodical-holdings while 1851 enriches holdings of monographies.

#### Screenshot of the result

The change has no visible result

