### PR TITLE
5291: Disable progressbar by default in webforms

### DIFF
--- a/modules/ding_base/ding_base.install
+++ b/modules/ding_base/ding_base.install
@@ -246,3 +246,16 @@ function ding_base_update_7011() {
     ->condition('name', 'samesite_cookie', '=')
     ->execute();
 }
+
+/**
+ * Set values on webform so progressbar is disabled by default.
+ */
+function ding_base_update_7012() {
+  if (module_exists('webform')) {
+    $webform_progressbar = webform_variable_get('webform_progressbar_style');
+    if (is_array($webform_progressbar) && in_array('progressbar_bar', $webform_progressbar)) {
+      unset($webform_progressbar[array_search('progressbar_bar', $webform_progressbar)]);
+    }
+    variable_set('webform_progressbar_style', $webform_progressbar);
+  }
+}


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5291

#### Description

Disables the progresbar by default in webforms.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
