### PR TITLE
Feature/5341 ims periodica zero placements

### DIFF
--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -605,7 +605,7 @@ function ding_availability_periodical_holdings_build_table(array $availability) 
     $i++;
   }
 
-  // Write a message if availablility contains no placements
+  // Write a message if availablility contains no placements.
   if (!$availability['placement']) {
     $rows = array(
       'data' => array(

--- a/modules/ding_availability/ding_availability.module
+++ b/modules/ding_availability/ding_availability.module
@@ -605,6 +605,18 @@ function ding_availability_periodical_holdings_build_table(array $availability) 
     $i++;
   }
 
+  // Write a message if availablility contains no placements
+  if (!$availability['placement']) {
+    $rows = array(
+      'data' => array(
+        array(
+          'data' => t('We have 0 copies available.'),
+          'colspan' => 3,
+        ),
+      ),
+    );
+  }
+
   // Note: If stikcy header is TRUE, it will keep adding the js in FF until the
   // browser goes down.
   return theme('table', array(


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5341

#### Description

Holdings for periodica with zero placements are not displayed correctly. A message should be output. That is how DDB CMS handles monographies with zero placements.

In standard DDB CMS the problem doesn't arise. But with the IMS-module installed this changes.

#### Screenshot of the result
Periodical with zero placements BEFORE the pull request is applied
![Zero placement holding on periodical](https://user-images.githubusercontent.com/1641342/158140535-8ecc1dcf-041b-4638-bc47-cf8b3e961ecd.png)

Periodical with zero placements AFTER the pull request has been applied
![Zero placement holding on periodical - fixed](https://user-images.githubusercontent.com/1641342/158140843-b3f505d2-a65e-49ce-a24e-d74aaa16ae7e.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
