### PR TITLE
5288: New placement for material-item messages

### DIFF
--- a/themes/ddbasic/sass/components/ting-object/material-item.scss
+++ b/themes/ddbasic/sass/components/ting-object/material-item.scss
@@ -136,12 +136,8 @@
 
   // Specific style for messages on material item
   .messages {
-    position: absolute;
-    top: 16px;
-    right: 0;
-    width: 190px;
     padding: 10px;
-    margin: 0;
+    margin: 0 0 10px 0;
     background-image: none;
     color: $white;
     border: 0;

--- a/themes/ddbasic/templates/material-item.tpl.php
+++ b/themes/ddbasic/templates/material-item.tpl.php
@@ -24,10 +24,11 @@
     <?php if (!empty($material_type)) : ?>
       <div class="item-material-type"><?php print $material_type; ?></div>
     <?php endif; ?>
-    <h3 id="<?php print $availability_id; ?>" class="item-title<?php if (isset($material_message)) : ?> has-message <?php endif; ?>"><?php print $title; ?></h3>
-    <?php if (!empty($creators)) : ?>
-      <div class="item-creators"><?php print $creators; ?></div>
-    <?php endif; ?>
+    <h3 id="<?php print $availability_id; ?>" class="item-title<?php if (isset($material_message)) : ?> has-message <?php
+   endif; ?>"><?php print $title; ?></h3>
+   <?php if (!empty($creators)) : ?>
+     <div class="item-creators"><?php print $creators; ?></div>
+   <?php endif; ?>
 
     <ul class="item-information-list">
       <?php foreach ($information as $info) : ?>

--- a/themes/ddbasic/templates/material-item.tpl.php
+++ b/themes/ddbasic/templates/material-item.tpl.php
@@ -18,14 +18,16 @@
     <?php print $cover; ?>
   </div>
   <div class="right-column">
+    <?php if (isset($material_message)) : ?>
+      <div class="<?php print $material_message['class']; ?>"><?php print $material_message['message']; ?></div>
+    <?php endif; ?>
     <?php if (!empty($material_type)) : ?>
       <div class="item-material-type"><?php print $material_type; ?></div>
     <?php endif; ?>
-    <h3 id="<?php print $availability_id; ?>" class="item-title<?php if (isset($material_message)) : ?> has-message <?php
-   endif; ?>"><?php print $title; ?></h3>
-   <?php if (!empty($creators)) : ?>
-     <div class="item-creators"><?php print $creators; ?></div>
-   <?php endif; ?>
+    <h3 id="<?php print $availability_id; ?>" class="item-title<?php if (isset($material_message)) : ?> has-message <?php endif; ?>"><?php print $title; ?></h3>
+    <?php if (!empty($creators)) : ?>
+      <div class="item-creators"><?php print $creators; ?></div>
+    <?php endif; ?>
 
     <ul class="item-information-list">
       <?php foreach ($information as $info) : ?>
@@ -37,8 +39,5 @@
         </li>
       <?php endforeach; ?>
     </ul>
-    <?php if (isset($material_message)) : ?>
-    <div class="<?php print $material_message['class']; ?>"><?php print $material_message['message']; ?></div>
-    <?php endif; ?>
   </div>
 </div>


### PR DESCRIPTION
#### Link to issue

[Please add a link to the issue being addressed by this change.](https://platform.dandigbib.org/issues/5288)

#### Description

Position messages in flow with content instead of absolute, wich resulted in content being hidden behind.

#### Screenshot of the result

![Screenshot 2022-03-17 at 13 11 45](https://user-images.githubusercontent.com/332915/158806351-ee04cbcf-ebdd-4b9c-9b6c-92bd7ad961ed.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions


