### PR TITLE
4935 bpi material list

### DIFF
--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1049,7 +1049,7 @@ function bpi_validate_materials(array $ting_object_ids) {
  * @return array
  *   Ids of found objects.
  */
-function bpi_validate_do_search($ids) {
+function bpi_validate_do_search(array $ids) {
   $found_ids = array();
   try {
     $query = ting_start_query()

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -6,6 +6,8 @@
  * Defines BPI specific constants, menu, theme and node hooks.
  */
 
+use Ting\Search\TingSearchRequest;
+
 include_once drupal_get_path('module', 'bpi') . '/bpi.images.inc';
 include_once drupal_get_path('module', 'bpi') . '/bpi.push.inc';
 
@@ -353,18 +355,19 @@ function bpi_form_node_form_alter(&$form, &$form_state, $form_id) {
     if (module_exists('ting_reference') && isset($bpi_content['material'])) {
       // Make a copy of the default field settings and values.
       $default_field = $form[$materials_field][$current_language][0];
+      $ting_object_ids = bpi_validate_materials(array_values($bpi_content['material']));
 
       // Loop over materials from BPI inserting new default field for each.
-      foreach ($bpi_content['material'] as $key => $material_number) {
-        $id = bpi_validate_material($material_number);
+      $key = 0;
+      foreach ($ting_object_ids as $id => $exists) {
         $form[$materials_field][$current_language][$key] = $default_field;
-        if (!$id) {
-          $id = $material_number;
+        if (!$exists) {
           $form[$materials_field][$current_language][$key]['ting_object_id']['#attributes'] = array('class' => array('error'));
           drupal_set_message(t('These materials doesn\'t exists.'), 'error', FALSE);
         }
         $form[$materials_field][$current_language][$key]['#weight'] = $key;
         $form[$materials_field][$current_language][$key]['ting_object_id']['#default_value'] = $id;
+        $key++;
       }
     }
 
@@ -1005,9 +1008,77 @@ function bpi_validate_material($ting_object_id) {
 
   // Load the object to validate it exists.
   // Loading it should make it available for use with ting_get_object().
-  $ting_entity = ting_object_load($ting_object_id);
+  $response = bpi_validate_materials(array($ting_object_id));
 
-  return $ting_entity ? $ting_object_id : FALSE;
+  return $response[$ting_object_id];
+}
+
+/**
+ * Makes request to ting and checks exist multiple materials with such ids.
+ *
+ * @param array $ting_object_ids
+ *   The Ting object ids.
+ *
+ * @return array
+ *   Key is object id. Value is FALSE in case when id not exist or ting_object_id when it exist
+ */
+function bpi_validate_materials($ting_object_ids) {
+  $result_ids = array();
+  $search_query = '';
+
+  if (isset($ting_object_ids) && is_array($ting_object_ids)) {
+    $prefix = '';
+    foreach ($ting_object_ids as $id) {
+      // If the colon was URL-encoded, decode it - and trim whitespace from
+      // both ends of the input string.
+      $id = trim(str_replace('%3A', ':', $id));
+      $search_query .= $prefix . 'rec.id="' . $id . '"';
+      $prefix = ' OR ';
+    }
+
+  }
+  $found_ids = bpi_validate_do_search($search_query);
+  foreach ($ting_object_ids as $id) {
+    if (in_array($id, $found_ids)) {
+      $result_ids[$id] = $id;
+    } else {
+      $result_ids[$id] = FALSE;
+    }
+  }
+
+  return $result_ids;
+}
+
+/**
+ * Exuecutes the search query against the well.
+ *
+ * @param string $search_query
+ *   The search query.
+ *
+ * @return array
+ *   Ids of found objects.
+ */
+function bpi_validate_do_search($search_query) {
+  $found_ids = array();
+  try {
+    $query = ting_start_query()
+    ->withRawQuery($search_query)
+    ->withCollectionType(TingSearchRequest::COLLECTION_TYPE_SINGLE_OBJECT)
+    // We handle max 50 materials in one article. Should be enough.
+    ->withCount(50)
+    ->withPopulateCollections(FALSE);
+
+    $results = $query->execute();
+    $collections = $results->getTingEntityCollections();
+    foreach ($collections as $collection) {
+      foreach ($collection->getEntities() as $entity) {
+        $found_ids[] = $entity->getId();
+      }
+    }
+  } catch (\Exception $e) {
+    //TOdo handle exception
+  }
+  return $found_ids;
 }
 
 /**

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1018,7 +1018,7 @@ function bpi_validate_material($ting_object_id) {
  * @return array
  *   Key is object id. Value is FALSE in case when id not exist or ting_object_id when it exist
  */
-function bpi_validate_materials($ting_object_ids) {
+function bpi_validate_materials(array $ting_object_ids) {
   $result_ids = array();
   $search_query = '';
 
@@ -1038,7 +1038,8 @@ function bpi_validate_materials($ting_object_ids) {
   foreach ($ting_object_ids as $id) {
     if (in_array($id, $found_ids)) {
       $result_ids[$id] = $id;
-    } else {
+    }
+    else {
       $result_ids[$id] = FALSE;
     }
   }
@@ -1072,9 +1073,10 @@ function bpi_validate_do_search($search_query) {
         $found_ids[] = $entity->getId();
       }
     }
-  } catch (Exception $e) {
+  }
+  catch (Exception $e) {
     watchdog_exception('bpi', $e, 'Failed to get materials from Opensearch');
-    drupal_set_message('Validation af materials failed', 'error');
+    drupal_set_message(t('Validation af materials failed'), 'error');
   }
   return $found_ids;
 }

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -998,16 +998,12 @@ function bpi_workflow_by_machine_names($machine_names) {
  *   The Ting object id.
  *
  * @return mixed
- *   FALSE in case when id not exist
- *   int in case when material with same id was found.
+ *   FALSE in case when id not exist.
+ *   Id in case when material with same id was found.
  */
 function bpi_validate_material($ting_object_id) {
-  // If the colon was URL-encoded, decode it - and trim whitespace from
-  // both ends of the input string.
-  $ting_object_id = trim(str_replace('%3A', ':', $ting_object_id));
-
+  // Paragraphs module expects this function to exist.
   // Load the object to validate it exists.
-  // Loading it should make it available for use with ting_get_object().
   $response = bpi_validate_materials(array($ting_object_id));
 
   return $response[$ting_object_id];
@@ -1038,6 +1034,7 @@ function bpi_validate_materials($ting_object_ids) {
 
   }
   $found_ids = bpi_validate_do_search($search_query);
+
   foreach ($ting_object_ids as $id) {
     if (in_array($id, $found_ids)) {
       $result_ids[$id] = $id;
@@ -1062,11 +1059,11 @@ function bpi_validate_do_search($search_query) {
   $found_ids = array();
   try {
     $query = ting_start_query()
-    ->withRawQuery($search_query)
-    ->withCollectionType(TingSearchRequest::COLLECTION_TYPE_SINGLE_OBJECT)
-    // We handle max 50 materials in one article. Should be enough.
-    ->withCount(50)
-    ->withPopulateCollections(FALSE);
+      ->withRawQuery($search_query)
+      ->withCollectionType(TingSearchRequest::COLLECTION_TYPE_SINGLE_OBJECT)
+      // We handle max 50 materials in one article. Should be enough.
+      ->withCount(50)
+      ->withPopulateCollections(FALSE);
 
     $results = $query->execute();
     $collections = $results->getTingEntityCollections();
@@ -1075,8 +1072,9 @@ function bpi_validate_do_search($search_query) {
         $found_ids[] = $entity->getId();
       }
     }
-  } catch (\Exception $e) {
-    //TOdo handle exception
+  } catch (Exception $e) {
+    watchdog_exception('bpi', $e, 'Failed to get materials from Opensearch');
+    drupal_set_message('Validation af materials failed', 'error');
   }
   return $found_ids;
 }

--- a/modules/bpi/bpi.module
+++ b/modules/bpi/bpi.module
@@ -1020,20 +1020,13 @@ function bpi_validate_material($ting_object_id) {
  */
 function bpi_validate_materials(array $ting_object_ids) {
   $result_ids = array();
-  $search_query = '';
+  $ids = array();
 
-  if (isset($ting_object_ids) && is_array($ting_object_ids)) {
-    $prefix = '';
-    foreach ($ting_object_ids as $id) {
-      // If the colon was URL-encoded, decode it - and trim whitespace from
-      // both ends of the input string.
-      $id = trim(str_replace('%3A', ':', $id));
-      $search_query .= $prefix . 'rec.id="' . $id . '"';
-      $prefix = ' OR ';
-    }
-
+  foreach ($ting_object_ids as $id) {
+    $ids[] = trim(urldecode($id));
   }
-  $found_ids = bpi_validate_do_search($search_query);
+
+  $found_ids = bpi_validate_do_search($ids);
 
   foreach ($ting_object_ids as $id) {
     if (in_array($id, $found_ids)) {
@@ -1050,17 +1043,17 @@ function bpi_validate_materials(array $ting_object_ids) {
 /**
  * Exuecutes the search query against the well.
  *
- * @param string $search_query
- *   The search query.
+ * @param array $ids
+ *   Array off ids to check.
  *
  * @return array
  *   Ids of found objects.
  */
-function bpi_validate_do_search($search_query) {
+function bpi_validate_do_search($ids) {
   $found_ids = array();
   try {
     $query = ting_start_query()
-      ->withRawQuery($search_query)
+      ->withMaterialFilter($ids)
       ->withCollectionType(TingSearchRequest::COLLECTION_TYPE_SINGLE_OBJECT)
       // We handle max 50 materials in one article. Should be enough.
       ->withCount(50)


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4935

#### Description

The getobject method in opensearch was used to validate the existence of materials locally on BPI imports. That method doesn't not check whether the library has holdings locally or not. Only search does. So the validation method was changed to use a search instead. The paragraphs module expects the bpi_validate_material to exist so that method was retained. 

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
