### PR TITLE
5307: Fixed confirmation message styling

### DIFF
--- a/modules/ting_das/css/ting_das.css
+++ b/modules/ting_das/css/ting_das.css
@@ -57,11 +57,28 @@
     height:90% !important;
     overflow-y: auto !important;
   }
+
+  .popupbar-content.selected {
+    display: block;
+  }
+
+  .popupbar-content {
+    display: none;
+  }
 }
+
 @media screen and (max-height: 750px) and (max-width: 600px) {
   .popupbar {
     height:100% !important;
     overflow-y: auto !important;
+  }
+
+  .popupbar-content.selected {
+    display: block;
+  }
+
+  .popupbar-content {
+    display: none;
   }
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5307

#### Description

The problem was that the form was still there which made the confirmation page extra long and scrolled down to the bottom. Fixed by not displaying the form on confirmation page.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/73946470/159337550-260e78e8-37b8-4e7f-9b12-c8a9e0e02ad0.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
