### PR TITLE
5263: Tab sequence changes

### DIFF
--- a/modules/ding_carousel/js/ding_carousel.js
+++ b/modules/ding_carousel/js/ding_carousel.js
@@ -180,6 +180,9 @@
         // Ensure that behaviors are attached to the new content.
         Drupal.attachBehaviors($('.ding-carousel-item'));
 
+        // Ensure focusable elements are not tagged with aria-hidden = true.
+        $('.ding-carousel-item').attr('aria-hidden', false);
+
         // Carry on processing the queue.
         running = false;
         check_for_update(item.tab, item.slick);
@@ -282,6 +285,8 @@
 
         tabs.insert($(this));
       });
+      // Ensure buttons are not a part off the tab sequence for screenreaders.
+      $('button.slick-arrow').attr('tabindex', -1);
     }
   };
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5263

#### Description

Changed aria-hidden values to false in order to fix siteimprove report error. Took next and previous buttons out of tab order.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
