### PR TITLE
5360: Compare strings lowercase

### DIFF
--- a/modules/ting/ting.field.inc
+++ b/modules/ting/ting.field.inc
@@ -463,7 +463,7 @@ function ting_field_formatter_view($entity_type, $entity, $field, $instance, $la
         $is_title_suffix_type = (!empty($title_suffix_types[strtolower($entity->getType())]));
         $language = $entity->getLanguage();
         $has_language = !empty($language);
-        $is_default_language = $language == $default_language;
+        $is_default_language = strtolower($language) == strtolower($default_language);
 
         if ($is_title_suffix_type && $has_language && !$is_default_language) {
           $title .= " ($language)";


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5360

#### Description

Comparing language strings in lowercase because both upper and lowercase can happen in the data..

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
