### PR TITLE
5362: Working on using web-hooks as callbacks in nets-easy

### DIFF
--- a/modules/ding_debt_easy/ding_debt_easy.install
+++ b/modules/ding_debt_easy/ding_debt_easy.install
@@ -69,6 +69,13 @@ function ding_debt_easy_schema() {
         'not null' => FALSE,
         'default' => 0,
       ],
+      'auth' => [
+        'description' => 'Authentication key used with web-hooks.',
+        'type' => 'varchar',
+        'length' => 32,
+        'not null' => FALSE,
+        'default' => '',
+      ],
       'changed' => [
         'description' => 'The Unix timestamp when the status was most recently updated.',
         'type' => 'int',
@@ -96,4 +103,12 @@ function ding_debt_easy_uninstall() {
   variable_del('ding_debt_easy_keys');
   variable_del('ding_debt_easy_privacy');
   variable_del('ding_debt_easy_terms');
+}
+
+/**
+ * Add auth field to database.
+ */
+function ding_debt_easy_update_7100() {
+  $schema = ding_debt_easy_schema();
+  db_add_field('ding_debt_easy', 'auth', $schema['ding_debt_easy']['fields']['auth']);
 }

--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -21,6 +21,7 @@ define('DING_DEBT_EASY_STATUS_RESERVED', 'reserved');
 define('DING_DEBT_EASY_STATUS_PENDING', 'pending');
 define('DING_DEBT_EASY_STATUS_COMPLETED', 'completed');
 define('DING_DEBT_EASY_STATUS_FAILED', 'failed');
+define('DING_DEBT_EASY_STATUS_CANCELED', 'canceled');
 
 define('DING_DEBT_EASY_MAX_RETRIES', 6);
 
@@ -523,18 +524,109 @@ function _ding_debt_easy_callback() {
   }
   $payment_id = $params['paymentid'];
 
+  // Clear the users cache before redirecting to ensure the payment overview is
+  // updated with data from the provider and not the cache.
+  if (module_exists('ding_session_cache')) {
+    ding_session_cache_clear('fbs', 'debt', TRUE);
+  }
+  ding_provider_invoke('user', 'clear_cache', $user);
+
   // Fetch order details form the database.
   $local_record = _ding_debt_easy_get_payment_local($payment_id);
 
-  // The payment gateway calls the callback two time with the same payload,
-  // sometimes, so to protect against this we have this extra check. In chrome
-  // the first callback will be marked as canceled, but the request have been
-  // sent to the backend. If in incognito mode this does not seam to happen. It
-  // has been testet on different system and the result is the same.
-  if ($local_record['status'] === DING_DEBT_EASY_STATUS_COMPLETED) {
-    drupal_goto(DING_DEBT_USER_DEBT_PAGE);
+  // Inform user. As the payment status is handle in async web-hooks we may get
+  // here before the payment have been processed. So we only have to different
+  // message we can set.
+  if (DING_DEBT_EASY_STATUS_COMPLETED === $local_record['status']) {
+    $msg = t('Your payment of @amount was received. Transaction ID: @transaction, order no.: @order.', [
+      '@amount' => $local_record['amount'] / 100,
+      '@transaction' => $payment_id,
+      '@order' => $local_record['order_id'],
+    ]);
+  }
+  else {
+    $msg = t('Your payment of @amount is begin processed. Transaction ID: @transaction, order no.: @order.', [
+      '@amount' => $local_record['amount'] / 100,
+      '@transaction' => $payment_id,
+      '@order' => $local_record['order_id'],
+    ]);
+  }
+  drupal_set_message($msg);
+
+  drupal_goto(DING_DEBT_USER_DEBT_PAGE);
+}
+
+/**
+ * Web-hook callback handling.
+ */
+function _ding_debt_easy_webhook() {
+  // When content-type is JSON the data is not placed in _POST variable, so we
+  // have to parse the payload by hand.
+  $data = json_decode(file_get_contents("php://input"), true);
+
+  $payment_id = $data['data']['paymentId'];
+  $local_record = _ding_debt_easy_get_payment_local($payment_id);
+
+  // Validate HTTP_AUTHORIZATION header to ensure call comes from nets.
+  $token = $_SERVER['HTTP_AUTHORIZATION'];
+  if ($local_record['auth'] !== $token) {
+    return;
   }
 
+  // The payment gateway web-hooks seen calling back two or more times with the
+  // same order sometimes, so to protect against this we have this extra check.
+  if (DING_DEBT_EASY_STATUS_COMPLETED === $local_record['status']) {
+    return;
+  }
+
+  switch ($data['event']) {
+    case 'payment.checkout.completed':
+      // Get data needed from the payload.
+      $amount = $data['data']['order']['amount']['amount'];
+
+      // Fetch order details form the database.
+      if (_ding_debt_easy_validate_payment($payment_id, $local_record)) {
+        _ding_debt_easy_process_payment($payment_id, $local_record, $amount);
+      }
+      break;
+
+    case 'payment.cancel.created':
+      _ding_debt_easy_update_status_local($payment_id, DING_DEBT_EASY_STATUS_CANCELED);
+      break;
+
+    case 'payment.reservation.created.v2':
+      _ding_debt_easy_update_status_local($payment_id, DING_DEBT_EASY_STATUS_RESERVED);
+      break;
+
+    default:
+      // Ignore all other callbacks.
+      break;
+  }
+}
+
+/**
+ * Canceled payment at the gateway.
+ *
+ * The payment status is updated in the web-hooks callback. So here simply
+ * inform the user about the cancellation.
+ */
+function _ding_debt_easy_canceled() {
+  drupal_set_message(t('The payment have been canceled'));
+  drupal_goto(DING_DEBT_USER_DEBT_PAGE);
+}
+
+/**
+ * Validate payment status.
+ *
+ * @param $payment_id
+ *   The payment id at the payment gateway.
+ * @param $local_record
+ *   Local record for the payment.
+ *
+ * @return bool
+ *   If the payment is ready for processing TRUE else FALSE.
+ */
+function _ding_debt_easy_validate_payment($payment_id, $local_record) {
   // Validate the current status for the local record to prevent payment errors.
   $valid_status = [
     DING_DEBT_EASY_STATUS_RESERVED,
@@ -546,63 +638,47 @@ function _ding_debt_easy_callback() {
       '%order_id' => $local_record['order_id'],
       '%state' => $local_record['status'],
     ], WATCHDOG_INFO);
-    drupal_set_message(t('Unable process payment for the order (%order_id). Please contact the library with the order id.', [
-      '%order_id' => $local_record['order_id'],
-    ]), 'error');
     _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_FAILED);
     _ding_debt_easy_remove_personal_info($payment_id);
-    drupal_goto(DING_DEBT_USER_DEBT_PAGE);
+
+    return FALSE;
   }
 
-  // Mark the local order as reserved at the payment gateway.
-  _ding_debt_easy_update_status_local($payment_id, DING_DEBT_EASY_STATUS_RESERVED);
+  return TRUE;
+}
 
+/**
+ * Process the payment at the provider and update the local record.
+ *
+ * @param $payment_id
+ * @param $local_record
+ * @param $amount
+ *
+ * @return void
+ * @throws \DingProviderDoesntImplement
+ * @throws \DingProviderNoProvider
+ * @throws \GuzzleHttp\Exception\GuzzleException
+ */
+function _ding_debt_easy_process_payment($payment_id, $local_record, $amount) {
   $client = _ding_debt_easy_get_client();
-  try {
-    $data = $client->fetchPayment($payment_id);
-  }
-  catch (PaymentException $exception) {
-    watchdog_exception('ding_debt_easy', $exception, 'Unable to process payment as the order was not found at Nets (Order ID: %order_id)', [
-      '%order_id' => $local_record['order_id'],
-    ]);
-    drupal_set_message(t('Unable process payment as the order (%order_id) was not found at the gateway. Please contact the library with the order id.', [
-      '%order_id' => $local_record['order_id'],
-    ]), 'error');
-    _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_FAILED);
-    _ding_debt_easy_remove_personal_info($payment_id);
-    drupal_goto(DING_DEBT_USER_DEBT_PAGE);
-  }
-  catch (PaymentCommunicationException $exception) {
-    watchdog_exception('ding_debt_easy', $exception, 'There is a communication problem with the gateway (Order ID: %order_id)', [
-      '%order_id' => $local_record['order_id'],
-    ]);
-    drupal_set_message(t('Unable to process payment as there was a communication error. We will try automatically later with order id: %order_id.', [
-      '%order_id' => $local_record['order_id'],
-    ]), 'warning');
-    _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_PENDING);
-    drupal_goto(DING_DEBT_USER_DEBT_PAGE);
-  }
 
   // Mark the order as paid at the provider, which only return true/false. It's
-  // the most we can do in regard to what went wrong.
-  $status = ding_provider_invoke('debt', 'payment_received', $user, $local_record['provider_ids'], $local_record['order_id']);
+  // the most we can do in regard to what went wrong. Also we don't send any
+  // user into this as this is handled in a web-hook.
+  $status = ding_provider_invoke('debt', 'payment_received', NULL, $local_record['provider_ids'], $local_record['order_id'], $local_record['patron_id']);
 
   if ($status) {
-    $success = false;
-
     // Charged the payment gateway.
     try {
-      $charge_id = $client->chargePayment($payment_id, $data['orderDetails']['amount']);
+      $charge_id = $client->chargePayment($payment_id, $amount);
       _ding_debt_easy_set_charge_id_local($payment_id, $charge_id);
       _ding_debt_easy_update_status_local($payment_id, DING_DEBT_EASY_STATUS_COMPLETED);
       _ding_debt_easy_remove_personal_info($payment_id);
-      $success = true;
     }
     catch (PaymentCommunicationException $exception) {
       watchdog_exception('ding_debt_easy', $exception, 'There is a communication problem with the gateway (Order ID: %order_id)', [
         '%order_id' => $local_record['order_id'],
       ]);
-      drupal_set_message(t('There is a communication problem with the gateway. The amount has been reserved but not charged at the gateway yet.'));
 
       // As the amount has not been charged. The local order will be set to pending for retry via cron.
       _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_PENDING);
@@ -611,57 +687,21 @@ function _ding_debt_easy_callback() {
       watchdog_exception('ding_debt_easy', $exception, 'There is a communication problem with the gateway (Order ID: %order_id)', [
         '%order_id' => $local_record['order_id'],
       ]);
-      drupal_set_message(t('The amount has been reserved but not charged at the gateway yet. It will automatically be charged later if possible.'));
 
       // As the amount has not been charged. The local order will be set to
       // pending for retry via cron.
       _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_PENDING);
     }
-
-    // Inform user.
-    if ($success) {
-      $msg = t('Your payment of @amount was received. Transaction ID: @transaction, order no.: @order.', [
-        '@amount' => $data['orderDetails']['amount'] / 100,
-        '@transaction' => $payment_id,
-        '@order' => $local_record['order_id'],
-      ]);
-    }
-    else {
-      $msg = t('Transaction ID: @transaction, order no.: @order.', [
-        '@transaction' => $payment_id,
-        '@order' => $local_record['order_id'],
-      ]);
-    }
-    drupal_set_message($msg);
   }
   else {
     watchdog('ding_debt_easy', 'There is a communication problem with the provider (Order ID: %order_id)', [
       '%order_id' => $local_record['order_id'],
     ]);
-    drupal_set_message(t('The amount has been reserved but not charged at the gateway yet. It will automatically be charged later if possible.'));
 
     // As the amount has not been marked as paid at the provider. The local
     // order will be set to pending for retry via cron.
     _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_PENDING);
   }
-
-  // Clear the users cache before redirecting to ensure the payment overview is
-  // updated with data from the provider and not the cache.
-  ding_provider_invoke('user', 'clear_cache', $user);
-  drupal_goto(DING_DEBT_USER_DEBT_PAGE);
-}
-
-function _ding_debt_easy_webhook() {
-  $data = $_POST;
-  $t = 1;
-}
-
-/**
- * Canceled payment at the gateway.
- */
-function _ding_debt_easy_canceled() {
-  drupal_set_message(t('The payment have been canceled'), 'status');
-  drupal_goto(DING_DEBT_USER_DEBT_PAGE);
 }
 
 /**
@@ -721,6 +761,7 @@ function _ding_debt_easy_create_order_local($patron_id, $provider_ids, $amount) 
         'status' => DING_DEBT_EASY_STATUS_CREATED,
         'amount' => $amount,
         'changed' => REQUEST_TIME,
+        'auth' => md5(bin2hex(random_bytes(32))),
       ])
       ->execute();
   } catch (Exception $e) {
@@ -920,6 +961,7 @@ function _ding_debt_easy_load_library() {
   require_once $path . 'Checkout.inc';
   require_once $path . 'Client.inc';
   require_once $path . 'Order.inc';
+  require_once $path . 'Notification.inc';
   require_once $path . 'OrderItem.inc';
   require_once $path . 'Exceptions/PaymentCommunicationException.inc';
   require_once $path . 'Exceptions/PaymentException.inc';

--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -12,6 +12,7 @@ use Nets\Easy\Exception\PaymentException;
 define('DING_DEBT_EASY_DEFAULT_TERMS_URL', 'payment/easy/terms');
 define('DING_DEBT_EASY_DEFAULT_PRIVACY_URL', 'payment/easy/privacy');
 define('DING_DEBT_EASY_CALLBACK_URL', 'payment/easy/callback');
+define('DING_DEBT_EASY_WEBHOOK', 'payment/easy/webhook');
 define('DING_DEBT_EASY_CANCEL_URL', 'payment/easy/cancel');
 
 // Looking forward to PHP 8.1's enums.
@@ -84,6 +85,14 @@ function ding_debt_easy_menu() {
     'type' => MENU_CALLBACK,
     'page callback' => '_ding_debt_easy_canceled',
     'access arguments' => array('perform payment'),
+  ];
+
+  // Payment webhook (callback).
+  $items[DING_DEBT_EASY_WEBHOOK] = [
+    'title' => 'Payment webhook callback',
+    'type' => MENU_CALLBACK,
+    'page callback' => '_ding_debt_easy_webhook',
+    'access arguments' => array('access content'),
   ];
 
   return $items;
@@ -640,6 +649,11 @@ function _ding_debt_easy_callback() {
   // updated with data from the provider and not the cache.
   ding_provider_invoke('user', 'clear_cache', $user);
   drupal_goto(DING_DEBT_USER_DEBT_PAGE);
+}
+
+function _ding_debt_easy_webhook() {
+  $data = $_POST;
+  $t = 1;
 }
 
 /**

--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -511,7 +511,6 @@ function _ding_debt_easy_get_payment_types_options() {
  *
  * @throws \DingProviderDoesntImplement
  * @throws \DingProviderNoProvider
- * @throws \GuzzleHttp\Exception\GuzzleException
  */
 function _ding_debt_easy_callback() {
   global $user;
@@ -618,15 +617,15 @@ function _ding_debt_easy_canceled() {
 /**
  * Validate payment status.
  *
- * @param $payment_id
+ * @param string $payment_id
  *   The payment id at the payment gateway.
- * @param $local_record
+ * @param array $local_record
  *   Local record for the payment.
  *
  * @return bool
  *   If the payment is ready for processing TRUE else FALSE.
  */
-function _ding_debt_easy_validate_payment($payment_id, $local_record) {
+function _ding_debt_easy_validate_payment($payment_id, array $local_record) {
   // Validate the current status for the local record to prevent payment errors.
   $valid_status = [
     DING_DEBT_EASY_STATUS_RESERVED,
@@ -650,16 +649,18 @@ function _ding_debt_easy_validate_payment($payment_id, $local_record) {
 /**
  * Process the payment at the provider and update the local record.
  *
- * @param $payment_id
- * @param $local_record
- * @param $amount
+ * @param string $payment_id
+ *   The payment id at the payment gateway.
+ * @param array $local_record
+ *   Local record for the payment.
+ * @param int $amount
+ *   The amount to process.
  *
- * @return void
  * @throws \DingProviderDoesntImplement
  * @throws \DingProviderNoProvider
  * @throws \GuzzleHttp\Exception\GuzzleException
  */
-function _ding_debt_easy_process_payment($payment_id, $local_record, $amount) {
+function _ding_debt_easy_process_payment($payment_id, array $local_record, $amount) {
   $client = _ding_debt_easy_get_client();
 
   // Mark the order as paid at the provider, which only return true/false. It's

--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -93,7 +93,9 @@ function ding_debt_easy_menu() {
     'title' => 'Payment webhook callback',
     'type' => MENU_CALLBACK,
     'page callback' => '_ding_debt_easy_webhook',
-    'access arguments' => array('access content'),
+    // Allow all to make the callback regardless of permissions. This ensures
+    // that nets always can call this callback.
+    'access arguments' => TRUE,
   ];
 
   return $items;
@@ -525,9 +527,6 @@ function _ding_debt_easy_callback() {
 
   // Clear the users cache before redirecting to ensure the payment overview is
   // updated with data from the provider and not the cache.
-  if (module_exists('ding_session_cache')) {
-    ding_session_cache_clear('fbs', 'debt', TRUE);
-  }
   ding_provider_invoke('user', 'clear_cache', $user);
 
   // Fetch order details form the database.
@@ -557,8 +556,17 @@ function _ding_debt_easy_callback() {
 
 /**
  * Web-hook callback handling.
+ *
+ * This function is a callback used by Nets-easy web-hooks and should always
+ * return http status code 200. If any other status is returned nets will keep
+ * re-calling the site with different intervals.
+ *
+ * @see https://developers.nets.eu/nets-easy/en-EU/api/webhooks/
  */
 function _ding_debt_easy_webhook() {
+  // This callback should never be cached.
+  drupal_page_is_cacheable(FALSE);
+
   // When content-type is JSON the data is not placed in _POST variable, so we
   // have to parse the payload by hand.
   $data = json_decode(file_get_contents("php://input"), true);
@@ -569,12 +577,14 @@ function _ding_debt_easy_webhook() {
   // Validate HTTP_AUTHORIZATION header to ensure call comes from nets.
   $token = $_SERVER['HTTP_AUTHORIZATION'];
   if ($local_record['auth'] !== $token) {
+    watchdog('ding_debt_easy', 'Web-hook callback with wrong authorization header. Payment id: %id', ['%id' => $payment_id], 'WATCHDOG_WARNING');
     return;
   }
 
   // The payment gateway web-hooks seen calling back two or more times with the
   // same order sometimes, so to protect against this we have this extra check.
   if (DING_DEBT_EASY_STATUS_COMPLETED === $local_record['status']) {
+    watchdog('ding_debt_easy', 'Web-hook callback all ready completed. Payment id: %id', ['%id' => $payment_id], 'WATCHDOG_WARNING');
     return;
   }
 

--- a/modules/ding_debt_easy/includes/easy.payment.inc
+++ b/modules/ding_debt_easy/includes/easy.payment.inc
@@ -58,9 +58,14 @@ function ding_debt_easy_payment_get_url($amount, $params, $callback) {
   $order_id = _ding_debt_easy_create_order_local($patron_id, $item_ids, $checkout->getOrder()->getTotalAmount());
   $checkout->getOrder()->setReference($order_id);
 
-  // Add notifications (payment.checkout.completed and payment.created).
+  // Add notifications (web-hooks events)
   $local_record = _ding_debt_easy_get_payment_local($order_id);
-  foreach (['payment.checkout.completed', 'payment.cancel.created', 'payment.reservation.created.v2', 'payment.created'] as $type) {
+  $eventTypes = [
+    'payment.checkout.completed',
+    'payment.cancel.created',
+    'payment.reservation.created.v2',
+  ];
+  foreach ($eventTypes as $type) {
     $notification = new Notification();
     $notification->setName($type)
       ->setAuthorization($local_record['auth'])

--- a/modules/ding_debt_easy/includes/easy.payment.inc
+++ b/modules/ding_debt_easy/includes/easy.payment.inc
@@ -6,6 +6,7 @@
  */
 
 use Nets\Easy\Checkout;
+use Nets\Easy\Notification;
 use Nets\Easy\OrderItem;
 use Nets\Easy\Exception\PaymentCommunicationException;
 use Nets\Easy\Exception\PaymentException;
@@ -56,6 +57,16 @@ function ding_debt_easy_payment_get_url($amount, $params, $callback) {
 
   $order_id = _ding_debt_easy_create_order_local($patron_id, $item_ids, $checkout->getOrder()->getTotalAmount());
   $checkout->getOrder()->setReference($order_id);
+
+  // Add notifications (payment.checkout.completed and payment.created).
+  $local_record = _ding_debt_easy_get_payment_local($order_id);
+  foreach (['payment.checkout.completed', 'payment.cancel.created', 'payment.reservation.created.v2', 'payment.created'] as $type) {
+    $notification = new Notification();
+    $notification->setName($type)
+      ->setAuthorization($local_record['auth'])
+      ->setUrl(url(DING_DEBT_EASY_WEBHOOK, ['absolute' => TRUE]));
+    $checkout->addNotification($notification);
+  }
 
   // Create payment with the checkout and order as payload.
   $client = _ding_debt_easy_get_client();
@@ -182,6 +193,9 @@ function ding_debt_easy_payment_buttons() {
  *
  * @return DingProviderDebt[]
  *   The debts object enriched with pending and failed status.
+ *
+ * @throws \DingProviderDoesntImplement
+ * @throws \DingProviderNoProvider
  */
 function ding_debt_easy_payment_status(array $debts) {
   $patron_id = ding_user_provider_id();
@@ -196,6 +210,8 @@ function ding_debt_easy_payment_status(array $debts) {
       ->condition('provider_ids', '%' . $debt->id . '%', 'LIKE')
       ->condition('patron_id', $patron_id)
       ->condition('status', [
+        DING_DEBT_EASY_STATUS_COMPLETED,
+        DING_DEBT_EASY_STATUS_RESERVED,
         DING_DEBT_EASY_STATUS_PENDING,
         DING_DEBT_EASY_STATUS_FAILED,
       ], 'IN')

--- a/modules/ding_debt_easy/lib/Nets/Easy/Checkout.inc
+++ b/modules/ding_debt_easy/lib/Nets/Easy/Checkout.inc
@@ -12,6 +12,7 @@ class Checkout {
   private $returnUrl;
   private $cancelUrl;
   private $order;
+  private $notifications = [];
 
   /**
    * Default constructor.
@@ -153,7 +154,7 @@ class Checkout {
   /**
    * Set order.
    *
-   * @param string $order
+   * @param Order $order
    *   Set order to the checkout.
    *
    * @return $this
@@ -165,13 +166,50 @@ class Checkout {
   }
 
   /**
+   * Get notifications.
+   *
+   * @return \Nets\Easy\Notification[]
+   *   The notifications for this checkout.
+   */
+  public function getNotifications() {
+    return $this->notifications;
+  }
+
+  /**
+   * Set notifications.
+   *
+   * @param Notification[] $notifications
+   *   Set notifications to the checkout.
+   *
+   * @return $this
+   */
+  public function setNotifications($notifications) {
+    $this->notifications = $notifications;
+
+    return $this;
+  }
+
+  /**
+   * Add single notification.
+   *
+   * @param \Nets\Easy\Notification $notification
+   *
+   * @return $this
+   */
+  public function addNotification($notification) {
+    $this->notifications[] = $notification;
+
+    return $this;
+  }
+
+  /**
    * Build and encoded the checkout as json string.
    *
    * @return array
    *   The complete order that matches the payment gateways format.
    */
   public function toArray() {
-    return [
+    $checkout = [
       'checkout' => [
         'integrationType' => $this->getIntegrationType(),
         'termsUrl' => $this->getTermsUrl(),
@@ -200,26 +238,19 @@ class Checkout {
         'cancelUrl' => $this->cancelUrl,
       ],
       'order' => $this->getOrder()->toArray(),
-      'notifications' => [
-        'webHooks' => [
-          [
-            'eventName' => 'payment.checkout.completed',
-            'url' => 'https://6f3e-193-105-220-62.eu.ngrok.io/payment/easy/webhook',
-            'authorization' => '123456789'
-          ],
-          [
-            'eventName' => 'payment.cancel.created',
-            'url' => 'https://6f3e-193-105-220-62.eu.ngrok.io/payment/easy/webhook',
-            'authorization' => '123456789'
-          ],
-          [
-            'eventName' => 'payment.created',
-            'url' => 'https://6f3e-193-105-220-62.eu.ngrok.io/payment/easy/webhook',
-            'authorization' => '123456789'
-          ],
-        ],
-      ],
     ];
+
+    // Add notifications (web-hooks) to the array.
+    if (!empty($this->getNotifications())) {
+      $checkout['notifications'] = [
+        'webhooks' => [],
+      ];
+      foreach ($this->getNotifications() as $notification) {
+        $checkout['notifications']['webhooks'][] = $notification->toArray();
+      }
+    }
+
+    return $checkout;
   }
 
 }

--- a/modules/ding_debt_easy/lib/Nets/Easy/Checkout.inc
+++ b/modules/ding_debt_easy/lib/Nets/Easy/Checkout.inc
@@ -200,6 +200,25 @@ class Checkout {
         'cancelUrl' => $this->cancelUrl,
       ],
       'order' => $this->getOrder()->toArray(),
+      'notifications' => [
+        'webHooks' => [
+          [
+            'eventName' => 'payment.checkout.completed',
+            'url' => 'https://6f3e-193-105-220-62.eu.ngrok.io/payment/easy/webhook',
+            'authorization' => '123456789'
+          ],
+          [
+            'eventName' => 'payment.cancel.created',
+            'url' => 'https://6f3e-193-105-220-62.eu.ngrok.io/payment/easy/webhook',
+            'authorization' => '123456789'
+          ],
+          [
+            'eventName' => 'payment.created',
+            'url' => 'https://6f3e-193-105-220-62.eu.ngrok.io/payment/easy/webhook',
+            'authorization' => '123456789'
+          ],
+        ],
+      ],
     ];
   }
 

--- a/modules/ding_debt_easy/lib/Nets/Easy/Checkout.inc
+++ b/modules/ding_debt_easy/lib/Nets/Easy/Checkout.inc
@@ -159,7 +159,7 @@ class Checkout {
    *
    * @return $this
    */
-  public function setOrder($order) {
+  public function setOrder(Order $order) {
     $this->order = $order;
 
     return $this;
@@ -183,7 +183,7 @@ class Checkout {
    *
    * @return $this
    */
-  public function setNotifications($notifications) {
+  public function setNotifications(array $notifications) {
     $this->notifications = $notifications;
 
     return $this;
@@ -193,10 +193,11 @@ class Checkout {
    * Add single notification.
    *
    * @param \Nets\Easy\Notification $notification
+   *   Notification to add.
    *
    * @return $this
    */
-  public function addNotification($notification) {
+  public function addNotification(Notification $notification) {
     $this->notifications[] = $notification;
 
     return $this;

--- a/modules/ding_debt_easy/lib/Nets/Easy/Notification.inc
+++ b/modules/ding_debt_easy/lib/Nets/Easy/Notification.inc
@@ -1,0 +1,111 @@
+<?php
+
+namespace Nets\Easy;
+
+/**
+ * Representation of Nets Easy notification.
+ */
+class Notification {
+
+  private $name = '';
+  private $url = '';
+  private $authorization = '';
+
+  /**
+   * Get event name.
+   *
+   * @see https://developers.nets.eu/nets-easy/en-EU/api/webhooks/
+   *
+   * @return string
+   *   The event name.
+   */
+  public function getName() {
+    return $this->name;
+  }
+
+  /**
+   * Set event name.
+   *
+   * @param string $name
+   *   Name of the event.
+   *
+   * @see https://developers.nets.eu/nets-easy/en-EU/api/webhooks/
+   *
+   * @return $this
+   */
+  public function setName($name) {
+    $this->name = $name;
+
+    return $this;
+  }
+
+  /**
+   * Get webhook callback url.
+   *
+   * @return string
+   *   The URL to call when the event happens.
+   */
+  public function getUrl() {
+    return $this->url;
+  }
+
+  /**
+   * Set the URL to call when the event happens.
+   *
+   * @param string $url
+   *   The URL to call.
+   *
+   * @return $this
+   */
+  public function setUrl($url) {
+    $this->url = $url;
+
+    return $this;
+  }
+
+  /**
+   * Get authorization used to identify the callback.
+   *
+   * @return string
+   *   The token.
+   */
+  public function getAuthorization() {
+    return $this->authorization;
+  }
+
+  /**
+   * Set authorization used to identify the callback.
+   *
+   * @param string $authorization
+   *   The token to use.
+   *
+   * @return $this
+   */
+  public function setAuthorization($authorization) {
+    $this->authorization = $authorization;
+
+    return $this;
+  }
+
+  /**
+   * Convert the notification to an array.
+   *
+   * @return string[]
+   *   The notification as array.
+   */
+  public function toArray() {
+    return [
+      'eventName' => $this->getName(),
+      'url' => $this->getUrl(),
+      'authorization' => $this->getAuthorization(),
+      // Header add here to make testing webhooks through localtunnel as
+      // recommend by Nets-easy support to local development setup.
+      'headers' => [
+        [
+          'Bypass-Tunnel-Reminder' => TRUE,
+        ]
+      ]
+    ];
+  }
+
+}

--- a/modules/ding_debt_easy/lib/Nets/Easy/Notification.inc
+++ b/modules/ding_debt_easy/lib/Nets/Easy/Notification.inc
@@ -17,7 +17,7 @@ class Notification {
    * @see https://developers.nets.eu/nets-easy/en-EU/api/webhooks/
    *
    * @return string
-   *   The event name.
+   *   Name of the event.
    */
   public function getName() {
     return $this->name;
@@ -103,8 +103,8 @@ class Notification {
       'headers' => [
         [
           'Bypass-Tunnel-Reminder' => TRUE,
-        ]
-      ]
+        ],
+      ],
     ];
   }
 

--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -184,7 +184,7 @@ function fbs_debt_payment_received($account, $debt_ids = array(), $order_id = NU
   $patron_id = is_null($patron_id) ? fbs_patron_id($account) : $patron_id;
 
   try {
-//    $res = fbs_service()->Payment->payFees(fbs_service()->agencyId, $patron_id, $payment_order);
+    $res = fbs_service()->Payment->payFees(fbs_service()->agencyId, $patron_id, $payment_order);
   }
   catch (Exception $e) {
     watchdog_exception('fbs', $e);

--- a/modules/fbs/includes/fbs.debt.inc
+++ b/modules/fbs/includes/fbs.debt.inc
@@ -184,7 +184,7 @@ function fbs_debt_payment_received($account, $debt_ids = array(), $order_id = NU
   $patron_id = is_null($patron_id) ? fbs_patron_id($account) : $patron_id;
 
   try {
-    $res = fbs_service()->Payment->payFees(fbs_service()->agencyId, $patron_id, $payment_order);
+//    $res = fbs_service()->Payment->payFees(fbs_service()->agencyId, $patron_id, $payment_order);
   }
   catch (Exception $e) {
     watchdog_exception('fbs', $e);


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5362

#### Description

Enabled callback using webhooks for payments. When paying with mobil payment (mobilpay) the user may not always be redirect back to the library site.

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments
