### PR TITLE
5362: Fixed access callback for easy web-hooks

### DIFF
--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -95,7 +95,7 @@ function ding_debt_easy_menu() {
     'page callback' => '_ding_debt_easy_webhook',
     // Allow all to make the callback regardless of permissions. This ensures
     // that nets always can call this callback.
-    'access arguments' => TRUE,
+    'access callback' => TRUE,
   ];
 
   return $items;


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5362

#### Description

The wrong array key was used in hook_menu (`access arguments` vs `access callback`).

#### Screenshot of the result

No screenshot.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comments.
