### PR TITLE
5150: Shows fulltext for lektørudtalelser on object pages

### DIFF
--- a/modules/ting_fulltext/js/ting_fulltext.js
+++ b/modules/ting_fulltext/js/ting_fulltext.js
@@ -1,0 +1,14 @@
+(function ($) {
+    "use strict";
+
+    var SearchExpansionResults = function (response) {
+        $("#ting-lektor-fulltext").html(response);
+    }
+
+    Drupal.behaviors.fullTextReview = {
+        attach: function (context) {
+            $.get(Drupal.settings.tingFulltext.url, null, SearchExpansionResults);
+        }
+    };
+
+})(jQuery);

--- a/modules/ting_fulltext/js/ting_fulltext.js
+++ b/modules/ting_fulltext/js/ting_fulltext.js
@@ -3,14 +3,14 @@
 
   Drupal.behaviors.fullTextReview = {
     attach: function (context) {
-      var selector = '#js-ting-lektor-fulltext';
+      var selector = '.js-ting-lektor-fulltext';
       $(selector, context).once('js-ting-lektor-fulltext', function () {
          var url = $(this).attr("data-fulltext-url");
          $.ajax({
            type: 'POST',
            url: url,
            success: function (result) {
-             $("#js-ting-lektor-fulltext").html(result);
+             $(".js-ting-lektor-fulltext").html(result);
            }
          });
       });

--- a/modules/ting_fulltext/js/ting_fulltext.js
+++ b/modules/ting_fulltext/js/ting_fulltext.js
@@ -1,14 +1,20 @@
 (function ($) {
-    "use strict";
+  "use strict";
 
-    var SearchExpansionResults = function (response) {
-        $("#ting-lektor-fulltext").html(response);
+  Drupal.behaviors.fullTextReview = {
+    attach: function (context) {
+      var selector = '#js-ting-lektor-fulltext';
+      $(selector, context).once('js-ting-lektor-fulltext', function () {
+         var url = $(this).attr("data-fulltext-url");
+         $.ajax({
+           type: 'POST',
+           url: url,
+           success: function (result) {
+             $("#js-ting-lektor-fulltext").html(result);
+           }
+         });
+      });
     }
-
-    Drupal.behaviors.fullTextReview = {
-        attach: function (context) {
-            $.get(Drupal.settings.tingFulltext.url, null, SearchExpansionResults);
-        }
-    };
+  };
 
 })(jQuery);

--- a/modules/ting_fulltext/js/ting_fulltext.js
+++ b/modules/ting_fulltext/js/ting_fulltext.js
@@ -6,11 +6,12 @@
       var selector = '.js-ting-lektor-fulltext';
       $(selector, context).once('js-ting-lektor-fulltext', function () {
          var url = $(this).attr("data-fulltext-url");
+         var selectedElement = $(this);
          $.ajax({
            type: 'POST',
            url: url,
            success: function (result) {
-             $(".js-ting-lektor-fulltext").html(result);
+            selectedElement.html(result);
            }
          });
       });

--- a/modules/ting_fulltext/ting_fulltext.module
+++ b/modules/ting_fulltext/ting_fulltext.module
@@ -127,6 +127,7 @@ function ting_fulltext_get_review($object_id) {
   }
   catch (Exception $e) {
     watchdog_exception('ting_fulltext', $e);
-    return drupal_json_output('');
+    drupal_add_http_header('Status', '500 Internal Server Error');
+    drupal_exit();
   }
 }

--- a/modules/ting_fulltext/ting_fulltext.module
+++ b/modules/ting_fulltext/ting_fulltext.module
@@ -84,7 +84,7 @@ function ting_fulltext_preprocess_ting_relation(&$variables) {
     if ($ting_object instanceof OpenSearchTingObject && in_array('docbook', $relation->getObject()->getTingObject()->getFormatsAvailable())) {
       // For performance reasons we load the review in full text as ajax.
       drupal_add_js(drupal_get_path('module', 'ting_fulltext') . '/js/ting_fulltext.js');
-      $url = url('ting/object/' . $relation->uri . '/fulltext/ajax') ;
+      $url = url('ting/object/' . $relation->uri . '/fulltext/ajax');
       $variables['abstract'] = '<div id="js-ting-lektor-fulltext" data-fulltext-url="' . $url . '">' . $variables['abstract'] . '</div>';
     }
   }

--- a/modules/ting_fulltext/ting_fulltext.module
+++ b/modules/ting_fulltext/ting_fulltext.module
@@ -23,6 +23,14 @@ function ting_fulltext_menu() {
     'type' => MENU_CALLBACK | MENU_VISIBLE_IN_BREADCRUMB,
   );
 
+  $items['ting/fulltext/ajax/%'] = array(
+    'title' => 'Retrieves review off the object',
+    'page callback' => 'ting_fulltext_get_review',
+    'page arguments' => array(3),
+    'access arguments' => array('access content'),
+    'type' => MENU_CALLBACK,
+  );
+
   return $items;
 }
 
@@ -67,7 +75,6 @@ function ting_fulltext_object_load($object_id) {
 function ting_fulltext_preprocess_ting_relation(&$variables) {
   /** @var \TingRelation $relation */
   $relation = $variables['relation'];
-
   if (!$variables['online'] && (NULL !== $relation->getObject() && NULL != $relation->getObject()->getTingObject())) {
     /** @var \OpenSearch\OpenSearchTingObject $ting_object */
     $ting_object = $relation->getObject()->getTingObject();
@@ -75,7 +82,10 @@ function ting_fulltext_preprocess_ting_relation(&$variables) {
     // This will only work for the opensearch search provider, so check what
     // type of object we have.
     if ($ting_object instanceof OpenSearchTingObject && in_array('docbook', $relation->getObject()->getTingObject()->getFormatsAvailable())) {
-      $variables['fulltext_link'] = l(t('See the full-text version'), 'ting/object/' . $relation->uri . '/fulltext');
+      // For performance reasons we load the review in full text as ajax.
+      drupal_add_js(drupal_get_path('module', 'ting_fulltext') . '/js/ting_fulltext.js');
+      drupal_add_js(array('tingFulltext' => array('url' => '/ting/fulltext/ajax/' . $relation->uri)), 'setting');
+      $variables['abstract'] = '<div id="ting-lektor-fulltext">' . $variables['abstract'] . '</div>';
     }
   }
 }
@@ -90,5 +100,32 @@ function ting_fulltext_preprocess_ting_relation(&$variables) {
 function ting_fulltext_ctools_plugin_directory($module, $plugin) {
   if ($module == 'ctools' && !empty($plugin)) {
     return "plugins/$plugin";
+  }
+}
+
+/**
+ * Ajax call function wich returns the review in full text.
+ */
+function ting_fulltext_get_review($object_id) {
+  try {
+    $path = drupal_get_path('module', 'ting_fulltext');
+    // Include functions to parse the xml.
+    include_once $path . '/includes/ting_fulltext.pages.inc';
+
+    $xml = ting_fulltext_object_load($object_id);
+    $full_text = ting_fulltext_parse($xml);
+    // We dont need to display the title again.
+    unset($full_text['title']);
+
+    $results = array(
+      '#theme' => 'ting_fulltext',
+      '#fields' => $full_text,
+    );
+    $output = drupal_render($results);
+
+    return drupal_json_output($output );
+  } catch (Exception $e) {
+    watchdog_exception('ting_fulltext', $e);
+    return drupal_json_output('');
   }
 }

--- a/modules/ting_fulltext/ting_fulltext.module
+++ b/modules/ting_fulltext/ting_fulltext.module
@@ -85,7 +85,7 @@ function ting_fulltext_preprocess_ting_relation(&$variables) {
       // For performance reasons we load the review in full text as ajax.
       drupal_add_js(drupal_get_path('module', 'ting_fulltext') . '/js/ting_fulltext.js');
       $url = url('ting/object/' . $relation->uri . '/fulltext/ajax');
-      $variables['abstract'] = '<div id="js-ting-lektor-fulltext" data-fulltext-url="' . $url . '">' . $variables['abstract'] . '</div>';
+      $variables['abstract'] = '<div class="js-ting-lektor-fulltext" data-fulltext-url="' . $url . '">' . $variables['abstract'] . '</div>';
     }
   }
 }

--- a/modules/ting_fulltext/ting_fulltext.module
+++ b/modules/ting_fulltext/ting_fulltext.module
@@ -123,8 +123,9 @@ function ting_fulltext_get_review($object_id) {
     );
     $output = drupal_render($results);
 
-    return drupal_json_output($output );
-  } catch (Exception $e) {
+    return drupal_json_output($output);
+  }
+  catch (Exception $e) {
     watchdog_exception('ting_fulltext', $e);
     return drupal_json_output('');
   }

--- a/modules/ting_fulltext/ting_fulltext.module
+++ b/modules/ting_fulltext/ting_fulltext.module
@@ -23,10 +23,10 @@ function ting_fulltext_menu() {
     'type' => MENU_CALLBACK | MENU_VISIBLE_IN_BREADCRUMB,
   );
 
-  $items['ting/fulltext/ajax/%'] = array(
+  $items['ting/object/%ting_fulltext_object/fulltext/ajax'] = array(
     'title' => 'Retrieves review off the object',
     'page callback' => 'ting_fulltext_get_review',
-    'page arguments' => array(3),
+    'page arguments' => array(2),
     'access arguments' => array('access content'),
     'type' => MENU_CALLBACK,
   );
@@ -84,8 +84,8 @@ function ting_fulltext_preprocess_ting_relation(&$variables) {
     if ($ting_object instanceof OpenSearchTingObject && in_array('docbook', $relation->getObject()->getTingObject()->getFormatsAvailable())) {
       // For performance reasons we load the review in full text as ajax.
       drupal_add_js(drupal_get_path('module', 'ting_fulltext') . '/js/ting_fulltext.js');
-      drupal_add_js(array('tingFulltext' => array('url' => '/ting/fulltext/ajax/' . $relation->uri)), 'setting');
-      $variables['abstract'] = '<div id="ting-lektor-fulltext">' . $variables['abstract'] . '</div>';
+      $url = url('ting/object/' . $relation->uri . '/fulltext/ajax') ;
+      $variables['abstract'] = '<div id="js-ting-lektor-fulltext" data-fulltext-url="' . $url . '">' . $variables['abstract'] . '</div>';
     }
   }
 }
@@ -106,28 +106,19 @@ function ting_fulltext_ctools_plugin_directory($module, $plugin) {
 /**
  * Ajax call function wich returns the review in full text.
  */
-function ting_fulltext_get_review($object_id) {
-  try {
-    $path = drupal_get_path('module', 'ting_fulltext');
-    // Include functions to parse the xml.
-    include_once $path . '/includes/ting_fulltext.pages.inc';
+function ting_fulltext_get_review($object) {
+  // Include functions to parse the xml.
+  module_load_include('inc', 'ting_fulltext', '/includes/ting_fulltext.pages');
 
-    $xml = ting_fulltext_object_load($object_id);
-    $full_text = ting_fulltext_parse($xml);
-    // We dont need to display the title again.
-    unset($full_text['title']);
+  $full_text = ting_fulltext_parse($object);
+  // We dont need to display the title again.
+  unset($full_text['title']);
 
-    $results = array(
-      '#theme' => 'ting_fulltext',
-      '#fields' => $full_text,
-    );
-    $output = drupal_render($results);
+  $results = array(
+    '#theme' => 'ting_fulltext',
+    '#fields' => $full_text,
+  );
+  $output = drupal_render($results);
 
-    return drupal_json_output($output);
-  }
-  catch (Exception $e) {
-    watchdog_exception('ting_fulltext', $e);
-    drupal_add_http_header('Status', '500 Internal Server Error');
-    drupal_exit();
-  }
+  return drupal_json_output($output);
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5445

#### Description

This is a part off the Seo project. It moves the text for lektørudtalelser into the object page for Seo purposes. It is done via ajax for performance reasons.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/73946470/170044198-786ad8f4-972d-450c-a3b9-d64ee4d96731.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
