### PR TITLE
5354: cast parameters to string

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -125,7 +125,7 @@
           linkId: 'Slet valgte reservering',
           customClickParameter: {}
         };
-        eventData.customClickParameter[DING_WEBTREKK_PARAMETER_DELETE_RESERVATION_SELECTED] = numberSelected;
+        eventData.customClickParameter[DING_WEBTREKK_PARAMETER_DELETE_RESERVATION_SELECTED] = numberSelected.toString();
         pushEvent('click', eventData);
       }
 

--- a/modules/ding_webtrekk/ding_webtrekk.module
+++ b/modules/ding_webtrekk/ding_webtrekk.module
@@ -400,7 +400,7 @@ function _ding_webtrekk_delete_alle_reservations_event(&$form, &$form_state) {
   ding_webtrekk_attach_event(
     $form['actions_container']['actions_top']['delete_all']['#attributes'],
     'Slet alle reserveringer',
-    [DING_WEBTREKK_PARAMETER_DELETE_RESERVATION_ALL => $count_reservations]
+    [DING_WEBTREKK_PARAMETER_DELETE_RESERVATION_ALL => (string) $count_reservations]
   );
 
   // The delete selected is handled in js.


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5354#note-17

#### Description

Mapp parameters need to be a string in order to be sent.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
