### PR TITLE
5465: Easy double charge bug

### DIFF
--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -705,6 +705,23 @@ function _ding_debt_easy_process_payment($payment_id, array $local_record, $amou
     }
   }
   else {
+    // Check order status at the provider.
+    /** @var \DingProviderDebt[] $fees */
+    $fees = ding_provider_invoke('debt', 'list', NULL, TRUE, $local_record['patron_id'], TRUE);
+    foreach ($local_record['provider_ids'] as $id) {
+      // The order contains one or more ids marked as payed at the provider.
+      // (This can happen if a user is presented with a stale list of debts
+      // and the user tries to pay the same id once more. Stale list can arise
+      // when user prematurely closes the browser window before
+      // _ding_debt_easy_callback() has been run.
+      if (isset($fees[$id])) {
+        watchdog_exception('ding_debt_easy', $exception, 'The order contains one or more ids already payed for. (Order ID: %order_id)', [
+          '%order_id' => $local_record['order_id'],
+        ]);
+        _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_FAILED);
+        break;
+      }
+    }
     watchdog('ding_debt_easy', 'There is a communication problem with the provider (Order ID: %order_id)', [
       '%order_id' => $local_record['order_id'],
     ]);

--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -721,7 +721,7 @@ function _ding_debt_easy_process_payment($payment_id, array $local_record, $amou
       }
     }
     if ($payed) {
-      watchdog_exception('ding_debt_easy', $exception, 'The order contains one or more ids already payed for. (Order ID: %order_id)', [
+      watchdog('ding_debt_easy', 'The order contains one or more ids already payed for. (Order ID: %order_id)', [
         '%order_id' => $local_record['order_id'],
       ]);
       _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_FAILED);

--- a/modules/ding_debt_easy/ding_debt_easy.module
+++ b/modules/ding_debt_easy/ding_debt_easy.module
@@ -709,26 +709,33 @@ function _ding_debt_easy_process_payment($payment_id, array $local_record, $amou
     /** @var \DingProviderDebt[] $fees */
     $fees = ding_provider_invoke('debt', 'list', NULL, TRUE, $local_record['patron_id'], TRUE);
     foreach ($local_record['provider_ids'] as $id) {
-      // The order contains one or more ids marked as payed at the provider.
-      // (This can happen if a user is presented with a stale list of debts
-      // and the user tries to pay the same id once more. Stale list can arise
-      // when user prematurely closes the browser window before
+      // Check if the order contains one or more ids marked as payed at the
+      // provider. (This can happen if a user is presented with a stale list
+      // of debts and the user tries to pay the same id once more. Stale list
+      // can arise when user prematurely closes the browser window before
       // _ding_debt_easy_callback() has been run.
-      if (isset($fees[$id])) {
-        watchdog_exception('ding_debt_easy', $exception, 'The order contains one or more ids already payed for. (Order ID: %order_id)', [
-          '%order_id' => $local_record['order_id'],
-        ]);
-        _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_FAILED);
+      $payed = FALSE;
+      if (isset($fees[$id]) && $fees[$id]->paid_date) {
+        $payed = TRUE;
         break;
       }
     }
-    watchdog('ding_debt_easy', 'There is a communication problem with the provider (Order ID: %order_id)', [
-      '%order_id' => $local_record['order_id'],
-    ]);
+    if ($payed) {
+      watchdog_exception('ding_debt_easy', $exception, 'The order contains one or more ids already payed for. (Order ID: %order_id)', [
+        '%order_id' => $local_record['order_id'],
+      ]);
+      _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_FAILED);
+    }
+    else {
+      watchdog('ding_debt_easy', 'There is a communication problem with the provider (Order ID: %order_id)', [
+        '%order_id' => $local_record['order_id'],
+      ]);
 
-    // As the amount has not been marked as paid at the provider. The local
-    // order will be set to pending for retry via cron.
-    _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_PENDING);
+      // As the amount has not been marked as paid at the provider. The local
+      // order will be set to pending for retry via cron.
+      _ding_debt_easy_update_status_local($local_record['order_id'], DING_DEBT_EASY_STATUS_PENDING);
+
+    }
   }
 }
 


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5465

#### Description
In rare cases the same debt id is charged twice. This is what happens:
Some users close the browser window during payment process before  _ding_debt_easy_callback() has finished.
Thereby their debt list in DDB CMS isn't updated and it contains already paid debts. Some users access the stale list and try to pay the same debt ids once more. That causes a negative response from FBS-provider, and the payment is transferred to the error handling system, where it is charged.

We need a check if the negative response from FBS is caused by the fee already being payed.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
