### PR TITLE
Remove float on webform elements

### DIFF
--- a/themes/ddbasic/sass/components/webform.scss
+++ b/themes/ddbasic/sass/components/webform.scss
@@ -5,7 +5,6 @@
 
 .webform-client-form {
   .webform-component {
-    float: left;
     width: 100%;
     margin-bottom: 30px;
     label {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5244

#### Description

Remove float on webform components. Somethings clearly missing in order to layout-by-float, and default block layout looks okay.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/177723388-00d08738-1430-4ead-8e81-08b3fd01de06.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
