### PR TITLE
5282: Changed height to work on horisontal phones

### DIFF
--- a/themes/ddbasic/sass/components/header.scss
+++ b/themes/ddbasic/sass/components/header.scss
@@ -433,7 +433,7 @@
       max-height: 100%;
       background-color: transparent;
       box-shadow: none;
-      height: 70vh;
+      height: 63vh;
       .mobile-menu-is-open & {
         @include transform(translateY(0%));
       }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5282

#### Description

Scrolling of a big menu was not working on mobilephone when they where horisontal. Needed a little tweak of the height. There is a bigger problem with the combination of using fixed position and high zindex in the menu which causes problems with scrolling. But thats outside the scope of this issue.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
