### PR TITLE
4935: Dont validate materials which the library does not have

### DIFF
--- a/modules/ting_reference/ting_reference.module
+++ b/modules/ting_reference/ting_reference.module
@@ -570,8 +570,8 @@ function ting_reference_object_id_validate($element, &$form_state, $form) {
     }
   }
 
-  // Don't bother validating empty fields.
-  if (!empty($ting_object_id)) {
+  // Don't bother validating empty fields or materials imported from the BPI service which the library does not have.
+  if (!empty($ting_object_id) && !(substr( $ting_object_id, 0, 20) === "Invalid material id:")) {
     // If the colon was URL-encoded, decode it - and trim whitespace from
     // both ends of the input string.
     $ting_object_id = trim(str_replace('%3A', ':', $ting_object_id));


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/4935#note-46

#### Description

Handles the issue that nodes with materials imported from BPI which the library does not have cant be saved. That happens because the validation function does not allow it. The solution is another check so the function does not validate materials which are not in the libraries holdings.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
