### PR TITLE
3750 log in page hook

### DIFF
--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -333,7 +333,7 @@ function ding_adgangsplatformen_login() {
  */
 function ding_adgangsplatformen_login_provider_user() {
   // We save the current page as destination.
-  $options = ['query' => ['destination' => request_uri()]];
+  $options = ['query' => drupal_get_destination()];
   // The classes in the oauth2-client don't get loaded unless we go to the login page.
   drupal_goto(DING_ADGANGSPLATFORMEN_LOGIN_URL, $options);
 }

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -335,8 +335,9 @@ function ding_adgangsplatformen_login() {
  *   If required libraries are not loaded.
  */
 function ding_adgangsplatformen_login_provider_user() {
-  // We save the current page including query parameters before sending the user to the login page.
-  ding_user_set_destination(request_uri());
+  // We save the current page including query parameters as destination parameters. That gets saved in the
+  // ding_adgangsplatformen_generate_login_url method.
+  $_REQUEST['destination'] = request_uri();
   ding_adgangsplatformen_login();
 }
 

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -331,8 +331,6 @@ function ding_adgangsplatformen_login() {
  *
  * Saves the current path and sends the user to the login page.
  *
- * @throws Exception
- *   If required libraries are not loaded.
  */
 function ding_adgangsplatformen_login_provider_user() {
   // We save the current page as destination.

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -335,10 +335,10 @@ function ding_adgangsplatformen_login() {
  *   If required libraries are not loaded.
  */
 function ding_adgangsplatformen_login_provider_user() {
-  // We save the current page including query parameters as destination parameters. That gets saved in the
-  // ding_adgangsplatformen_generate_login_url method.
-  $_REQUEST['destination'] = request_uri();
-  ding_adgangsplatformen_login();
+  // We save the current page as destination.
+  $options = ['query' => ['destination' => request_uri()]];
+  // The classes in the oauth2-client don't get loaded unless we go to the login page.
+  drupal_goto(DING_ADGANGSPLATFORMEN_LOGIN_URL, $options);
 }
 
 /**

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -327,10 +327,9 @@ function ding_adgangsplatformen_login() {
 }
 
 /**
- * Implements hooK_login_provider_user.
+ * Implements hook_login_provider_user().
  *
  * Saves the current path and sends the user to the login page.
- *
  */
 function ding_adgangsplatformen_login_provider_user() {
   // We save the current page as destination.

--- a/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
+++ b/modules/ding_adgangsplatformen/ding_adgangsplatformen.module
@@ -327,6 +327,20 @@ function ding_adgangsplatformen_login() {
 }
 
 /**
+ * Implements hooK_login_provider_user.
+ *
+ * Saves the current path and sends the user to the login page.
+ *
+ * @throws Exception
+ *   If required libraries are not loaded.
+ */
+function ding_adgangsplatformen_login_provider_user() {
+  // We save the current page including query parameters before sending the user to the login page.
+  ding_user_set_destination(request_uri());
+  ding_adgangsplatformen_login();
+}
+
+/**
  * Logout the user from adgangsplatformen.
  *
  * @param bool $regen_session

--- a/modules/ding_user_frontend/ding_user_frontend.module
+++ b/modules/ding_user_frontend/ding_user_frontend.module
@@ -307,7 +307,8 @@ function ding_user_frontend_url_inbound_alter(&$path, $original_path, $path_lang
       if (isset($matches[1])) {
         $path .= '/' . $matches[1];
       }
-    } else {
+    }
+    else {
       // Send the user to a login page if there is a module that implements the login_provider_user hook.
       module_invoke_all('login_provider_user');
     }

--- a/modules/ding_user_frontend/ding_user_frontend.module
+++ b/modules/ding_user_frontend/ding_user_frontend.module
@@ -307,6 +307,9 @@ function ding_user_frontend_url_inbound_alter(&$path, $original_path, $path_lang
       if (isset($matches[1])) {
         $path .= '/' . $matches[1];
       }
+    } else {
+      // Send the user to a login page if there is a module that implements the login_provider_user hook.
+      module_invoke_all('login_provider_user');
     }
   }
 }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/3750

#### Description

When user arent logged in on user status pages. Eg. /user/me/loans they are sent automatically to a login page. In order not to create dependency this is done with a hook. There is a reguirement that page parameters are preserved in the process. See PR: https://github.com/ding2/ding2/pull/1855 for discussion.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
