### PR TITLE
5490: Make table definition css more specific

### DIFF
--- a/themes/ddbasic/sass/base/table.scss
+++ b/themes/ddbasic/sass/base/table.scss
@@ -19,7 +19,9 @@
 //
 // Styleguide 1.3
 
-table {
+// The cookieinformation service puts a css definition of table elements in so we need
+// to be more specific here. Therefore the body tag in front of table.
+body table {
   width: 100%;
   border-collapse: collapse;
   thead {


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5490

#### Description

The cookieinformation service puts a bit of css into the page which includes a general styling of tables. In order to make our own css styling work it needed to be a bit more specifik.  

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/73946470/186159829-9d865fb4-04ba-4d1c-98ac-56356dabf646.png)


#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
