### PR TITLE
5448: Patch cookie informations module to downgrade PHP requirements

### DIFF
--- a/patches/cookieinformation-downgrade-php-requirements.patch
+++ b/patches/cookieinformation-downgrade-php-requirements.patch
@@ -1,0 +1,35 @@
+diff --git a/cookieinformation.info b/cookieinformation.info
+index fdbfb49..601305b 100644
+--- a/cookieinformation.info
++++ b/cookieinformation.info
+@@ -2,7 +2,6 @@ name = Cookie Information
+ description = Integrating cookie consent popup from Cookieinformation.com.
+ core = 7.x
+ configure = admin/config/system/cookieinformation
+-php = 7.1
+ 
+ ; Information added by Drupal.org packaging script on 2020-06-08
+ version = "7.x-1.0"
+diff --git a/cookieinformation.module b/cookieinformation.module
+index 80408dc..15081e0 100644
+--- a/cookieinformation.module
++++ b/cookieinformation.module
+@@ -8,7 +8,7 @@
+ /**
+  *  Implements hook_help().
+  */
+-function cookieinformation_help(string $path, array $arg) {
++function cookieinformation_help($path, array $arg) {
+   if ($path !== 'admin/help#cookieinformation') {
+     return;
+   }
+@@ -16,8 +16,7 @@ function cookieinformation_help(string $path, array $arg) {
+     '@cookieinformation_website' => 'https://cookieinformation.com',
+     '@project_page' => 'https://drupal.org/project/cookieinformation',
+   ];
+-  $output = '';
+-  $output .= '<h3>' . t('About') . '</h3>';
++  $output = '<h3>' . t('About') . '</h3>';
+   $output .= '<p>' . t('The Cookie Information module provides a simple way of adding the Cookie Information consent popup to any Drupal site with an active Cookie Information subscription. See the <a href="@cookieinformation_website">Cookie Information website</a> for general information about Cookie Information. For more module help, see the <a href="@project_page">module project page</a>.', $links) . '</p>';
+   return $output;
+ }

--- a/project.make
+++ b/project.make
@@ -39,6 +39,7 @@ projects[conditional_styles][version] = "2.2"
 
 projects[cookieinformation][subdir] = "contrib"
 projects[cookieinformation][version] = "1.0"
+projects[cookieinformation][patch][] = "patches/cookieinformation-downgrade-php-requirements.patch"
 
 projects[cs_adaptive_image][subdir] = "contrib"
 projects[cs_adaptive_image][version] = "1.0"


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5448

#### Description

Downgrade the requirement for PHP 7.1

#### Screenshot of the result

No screenshot

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

No comment