### PR TITLE
5448: Handles removing cookies from sub domains

### DIFF
--- a/modules/ding_webtrekk/ding_webtrekk.js
+++ b/modules/ding_webtrekk/ding_webtrekk.js
@@ -242,9 +242,16 @@
       const noCookieTracking = function (name) {
         var cookiesToDelete = Drupal.settings.dingWebtrekk.cookiesToRemove;
         cookiesToDelete.forEach(cookie => {
+          var hostname = window.location.hostname;
+          while (hostname !== '') {
           // The version of jquery.cookie which comes with this version of Drupal does not have
           // removeCookie function so we use this method instead.
-          $.cookie(cookie, null, { path: '/', domain: window.location.hostname });
+            $.cookie(cookie, null, { path: '/', domain: hostname });
+
+            var index = hostname.indexOf('.');
+            // We can be on a sub-domain, so keep checking the main domain as well.
+            hostname = (index === -1) ? '' : hostname.substring(index + 1);
+          }
         });
       }
       // This code fires multiple times. But we need to make sure that the cookies are removed after they are


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5448#note-30

#### Description

There is problem that cookies don't get removed on pages with a subdomain. The cookie is registered to the root domain but windows.location.hostname returns the full hostname.  This solution is based on code from the eu cookie complience modules and iteratets over all the domains and attempts to remove the cookies.

Note this can't be properly tested. In order to test this we need a domain which includes a subdomain which is registred with KPI index as a domain to test Mapp on. My local dev domain is bur contains only a root domain. Upgrade-fbs can be used..

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
