### PR TITLE
5448: Add cookie banner placeholders on videos

### DIFF
--- a/modules/ding_content/ding_content.info
+++ b/modules/ding_content/ding_content.info
@@ -3,6 +3,7 @@ description = Create panels panes for Ding!
 core = 7.x
 package = Ding!
 project = ding_content
+scripts[] = js/ding_content.cookie_consent.js
 dependencies[] = clone
 dependencies[] = ctools
 dependencies[] = ctools_custom_content

--- a/modules/ding_content/js/ding_content.cookie_consent.js
+++ b/modules/ding_content/js/ding_content.cookie_consent.js
@@ -1,0 +1,15 @@
+/**
+ * @file
+ * Behaviour for triggering the cookie popup.
+ */
+(function ($) {
+  Drupal.behaviors.dingContentCookieConsent = {
+    attach: function (context, settings) {
+      $('.js-cookie-popup-trigger').once('cookie-popup-trigger-processed', function () {
+        $(this).click(function() {
+          CookieConsent.renew();
+        });
+      });
+    }
+  }
+}(jQuery));

--- a/modules/ding_content/templates/media-vimeo-video--cookieinformation.tpl.php
+++ b/modules/ding_content/templates/media-vimeo-video--cookieinformation.tpl.php
@@ -20,5 +20,9 @@
  */
 ?>
 <div class="<?php print $classes; ?> media-vimeo-<?php print $id; ?>">
+  <div class="consent-placeholder" data-category="cookie_cat_statistic">
+    <p><?php print t("This video is not accessible as you haven't accepted marketing-cookies"); ?></p>
+    <a href="#" class="js-cookie-popup-trigger"><?php print t('Click here to change your consent'); ?></a>
+  </div>
   <iframe class="media-vimeo-player" data-category-consent="cookie_cat_statistic" <?php print $api_id_attribute; ?>width="<?php print $width; ?>" height="<?php print $height; ?>" title="<?php print $title; ?>" src="" data-consent-src="<?php print $url; ?>" frameborder="0" allowfullscreen><?php print $alternative_content; ?></iframe>
 </div>

--- a/modules/ding_content/templates/media-youtube-video--cookieinformation.tpl.php
+++ b/modules/ding_content/templates/media-youtube-video--cookieinformation.tpl.php
@@ -20,5 +20,9 @@
  */
 ?>
 <div class="<?php print $classes; ?> media-youtube-<?php print $id; ?>">
+  <div class="consent-placeholder" data-category="cookie_cat_statistic">
+    <p><?php print t("This video is not accessible as you haven't accepted marketing-cookies"); ?></p>
+    <a href="#" class="js-cookie-popup-trigger"><?php print t('Click here to change your consent'); ?></a>
+  </div>
   <iframe class="media-youtube-player" data-category-consent="cookie_cat_statistic" <?php print $api_id_attribute; ?>width="<?php print $width; ?>" height="<?php print $height; ?>" title="<?php print $title; ?>" src="" data-consent-src="<?php print $url; ?>" name="<?php print $title; ?>" frameborder="0" allowfullscreen><?php print $alternative_content; ?></iframe>
 </div>

--- a/modules/ting_oembed/ting_oembed.module
+++ b/modules/ting_oembed/ting_oembed.module
@@ -105,6 +105,18 @@ function ting_oembed_oembed_response_alter(&$response) {
       $iframe->setAttribute('src', '');
       $iframe->setAttribute('data-consent-src', $src);
       $iframe->setAttribute('data-category-consent', "cookie_cat_statistic");
+
+      $consent = $dom->createNode('div');
+      $consent->setAttribute('class', 'consent-placeholder');
+      $concent->setAttribute('data-category', "cookie_cat_statistic");
+
+      $concent->append($dom->createNode('p', t("This video is not accessible as you haven't accepted marketing-cookies")));
+      $a = $dom->createNode('a', t('Click here to change your consent'));
+      $a->setAttribute('class', 'js-cookie-popup-trigger');
+      $a->setAttribute('href', '#');
+      $concent->append($a);
+
+      $iframe->parentNode->prepend($concent);
     }
     $response['html'] = $dom->saveHTML();
   }

--- a/themes/ddbasic/sass/components/class.scss
+++ b/themes/ddbasic/sass/components/class.scss
@@ -734,6 +734,7 @@ ul.tabs.primary {
   width: 100%;
   padding-top: 56.3%;
 
+  .consent-placeholder,
   iframe {
     position: absolute;
     top: 0;


### PR DESCRIPTION
Tell the user they have to accept cookies to view the video,

#### Link to issue

https://platform.dandigbib.org/issues/5448

#### Description

Add cookie banner placeholders on videos that tell the user they have to accept cookies to view the video.

#### Screenshot of the result

![image](https://user-images.githubusercontent.com/229422/188371740-707b533c-bae2-4cb0-8950-c1881d1457de.png)

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
