### PR TITLE
Revert "5490: Make table definition css more specific"

### DIFF
--- a/themes/ddbasic/sass/base/table.scss
+++ b/themes/ddbasic/sass/base/table.scss
@@ -19,9 +19,7 @@
 //
 // Styleguide 1.3
 
-// The cookieinformation service puts a css definition of table elements in so we need
-// to be more specific here. Therefore the body tag in front of table.
-body table {
+table {
   width: 100%;
   border-collapse: collapse;
   thead {


### PR DESCRIPTION
Reverts ding2/ding2#1908

These Changes to CSS are no longer relevant as the original problem in the Infomedia CSS has been fixed.