### PR TITLE
Core: Order update hooks to avoid conflicts

### DIFF
--- a/ding2.install
+++ b/ding2.install
@@ -126,6 +126,11 @@ function ding2_update_dependencies() {
     // provider is present.
     'ting' => 7014,
   );
+  // Update hook which accesses the cache.
+  $dependencies['ding2'][7102] = array(
+    // The update hook that modifies user tables related to entity cache.
+    'user' => 7020,
+  );
 
   return $dependencies;
 }


### PR DESCRIPTION
#### Description

During rollout of release 7.x-6.6.0-beta5 we are seeing warnings due to missing columns in the user table when accessed by the entity cache. This is happening when running update hook  ding2_update_7102 where importing translations also clears the cache.

To avoid this we mark ding2_update_7102 as being dependent on user_update_7020 - the update hook responsible for adding the  additional columns.

#### Checklist

- [x] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [x] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [x] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.