### PR TITLE
Changed function names to php 7

### DIFF
--- a/modules/ting_oembed/ting_oembed.module
+++ b/modules/ting_oembed/ting_oembed.module
@@ -106,17 +106,17 @@ function ting_oembed_oembed_response_alter(&$response) {
       $iframe->setAttribute('data-consent-src', $src);
       $iframe->setAttribute('data-category-consent', "cookie_cat_statistic");
 
-      $consent = $dom->createNode('div');
+      $consent = $dom->createElement('div');
       $consent->setAttribute('class', 'consent-placeholder');
-      $concent->setAttribute('data-category', "cookie_cat_statistic");
+      $consent->setAttribute('data-category', "cookie_cat_statistic");
 
-      $concent->append($dom->createNode('p', t("This video is not accessible as you haven't accepted marketing-cookies")));
-      $a = $dom->createNode('a', t('Click here to change your consent'));
+      $consent->appendChild($dom->createElement('p', t("This video is not accessible as you haven't accepted marketing-cookies")));
+      $a = $dom->createElement('a', t('Click here to change your consent'));
       $a->setAttribute('class', 'js-cookie-popup-trigger');
       $a->setAttribute('href', '#');
-      $concent->append($a);
+      $consent->appendChild($a);
 
-      $iframe->parentNode->prepend($concent);
+      $iframe->parentNode->insertBefore($consent);
     }
     $response['html'] = $dom->saveHTML();
   }


### PR DESCRIPTION
#### Link to issue

https://platform.dandigbib.org/issues/5448#note-42

#### Description

Method calls to Domdocument used php 8 naming so they failed. Converted to php 7 naming.

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My complies with [our coding guidelines](../docs/code_guidelines.md).
- [ ] My code passes our static analysis suite. If not then I have added a comment explaining why this change should be exempt from the code standards and process.
- [ ] My code passes our continuous integration process. If not then I have added a comment explaining why this change should be exempt from the code standards and process.

#### Additional comments or questions

If you have any further comments or questions for the reviewer them please add them here.
